### PR TITLE
add shutdown to RiakClient 

### DIFF
--- a/src/main/java/com/basho/riak/pbc/RiakClient.java
+++ b/src/main/java/com/basho/riak/pbc/RiakClient.java
@@ -116,6 +116,7 @@ public class RiakClient implements RiakMessageCodes {
                 connection.close();
             }
         } finally {
+            // not canceled Timer prevents JVM shutdown.
             RiakConnection.timer.cancel();
         }
     }


### PR DESCRIPTION
shutdown method close current connection and cancel Timer.
because not canceled Timer prevents JVM shutdown.
