### PR TITLE
Add RW param to delete operations for HTTP client

### DIFF
--- a/src/main/java/com/basho/riak/client/request/RequestMeta.java
+++ b/src/main/java/com/basho/riak/client/request/RequestMeta.java
@@ -72,6 +72,22 @@ public class RequestMeta {
     }
 
     /**
+     * Use the given rw parameter for delete operations
+     *
+     * @param rw
+     *            rw- parameter for delete: the number of
+     *            successful read/write response required for a successful overall
+     *            response
+     * @return A {@link RequestMeta} object with the appropriate query
+     *         parameters
+     */
+    public static RequestMeta deleteParams(int rw) {
+        RequestMeta meta = new RequestMeta();
+        meta.setQueryParam(Constants.QP_RW, Integer.toString(rw));
+        return meta;
+    }
+
+    /**
      * Add the specified HTTP header
      * 
      * @param key

--- a/src/main/java/com/basho/riak/client/util/Constants.java
+++ b/src/main/java/com/basho/riak/client/util/Constants.java
@@ -78,6 +78,7 @@ public interface Constants {
     public static String QP_R = "r";
     public static String QP_W = "w";
     public static String QP_DW = "dw";
+    public static String QP_RW = "rw";
     public static String QP_KEYS = "keys";
 
     // HTTP method names

--- a/src/test/java/com/basho/riak/client/request/TestRequestMeta.java
+++ b/src/test/java/com/basho/riak/client/request/TestRequestMeta.java
@@ -41,6 +41,12 @@ public class TestRequestMeta {
         assertEquals(Integer.toString(DW), impl.getQueryParam("dw"));
     }
 
+    @Test public void deleteParams_sets_rw_query_parameter() {
+        final int RW = 10;
+        RequestMeta impl = RequestMeta.deleteParams(RW);
+        assertEquals(Integer.toString(RW), impl.getQueryParam("rw"));
+    }
+
     @Test public void headers_are_returned_by_get_headers() {
         final String HEADER_KEY = "key";
         final String HEADER_VALUE = "value";


### PR DESCRIPTION
https://issues.basho.com/show_bug.cgi?id=1070

RW param is not passed on DELETE.
