### PR TITLE
Fix store to return siblings if returnbody is true

### DIFF
--- a/src/main/java/com/basho/riak/client/RiakClient.java
+++ b/src/main/java/com/basho/riak/client/RiakClient.java
@@ -235,8 +235,21 @@ public class RiakClient {
             meta.setQueryParam(Constants.QP_RETURN_BODY, "true");
         }
 
+        setAcceptHeader(meta);
         HttpResponse r = helper.store(object, meta);
-        return new StoreResponse(r);
+        return new StoreResponse(new FetchResponse(r, this));
+    }
+
+    /**
+     * @param meta
+     */
+    private void setAcceptHeader(RequestMeta meta) {
+        String accept = meta.getHeader(Constants.HDR_ACCEPT);
+        if (accept == null) {
+            meta.setHeader(Constants.HDR_ACCEPT, Constants.CTYPE_ANY + ", " + Constants.CTYPE_MULTIPART_MIXED);
+        } else {
+            meta.setHeader(Constants.HDR_ACCEPT, accept + ", " + Constants.CTYPE_MULTIPART_MIXED);
+        }
     }
 
     public StoreResponse store(RiakObject object) {
@@ -338,13 +351,7 @@ public class RiakClient {
             meta = new RequestMeta();
         }
 
-        String accept = meta.getHeader(Constants.HDR_ACCEPT);
-        if (accept == null) {
-            meta.setHeader(Constants.HDR_ACCEPT, Constants.CTYPE_ANY + ", " + Constants.CTYPE_MULTIPART_MIXED);
-        } else {
-            meta.setHeader(Constants.HDR_ACCEPT, accept + ", " + Constants.CTYPE_MULTIPART_MIXED);
-        }
-
+        setAcceptHeader(meta);
         HttpResponse r = helper.fetch(bucket, key, meta, streamResponse);
 
         try {

--- a/src/main/java/com/basho/riak/client/response/FetchResponse.java
+++ b/src/main/java/com/basho/riak/client/response/FetchResponse.java
@@ -31,7 +31,7 @@ import com.basho.riak.client.util.StreamedMultipart;
  * to interpret fetch and fetchMeta responses from Riak's HTTP interface which
  * returns object metadata in HTTP headers and value in the body.
  */
-public class FetchResponse extends HttpResponseDecorator implements HttpResponse {
+public class FetchResponse extends HttpResponseDecorator implements WithBodyResponse {
 
     private RiakObject object = null;
     private Collection<RiakObject> siblings = new ArrayList<RiakObject>();
@@ -71,8 +71,9 @@ public class FetchResponse extends HttpResponseDecorator implements HttpResponse
         if (r.getStatusCode() == 300) {
             String contentType = headers.get(Constants.HDR_CONTENT_TYPE);
 
-            if (contentType == null || !(contentType.trim().toLowerCase().startsWith(Constants.CTYPE_MULTIPART_MIXED)))
+            if (contentType == null || !(contentType.trim().toLowerCase().startsWith(Constants.CTYPE_MULTIPART_MIXED))) {
                 throw new RiakResponseRuntimeException(r, "multipart/mixed content expected when object has siblings");
+            }
 
             if (r.isStreamed()) {
                 try {

--- a/src/main/java/com/basho/riak/client/response/StoreResponse.java
+++ b/src/main/java/com/basho/riak/client/response/StoreResponse.java
@@ -13,8 +13,10 @@
  */
 package com.basho.riak.client.response;
 
+import java.util.Collection;
 import java.util.Map;
 
+import com.basho.riak.client.RiakObject;
 import com.basho.riak.client.util.Constants;
 
 /**
@@ -22,8 +24,9 @@ import com.basho.riak.client.util.Constants;
  * interpret store responses from Riak which returns updated object metadata in
  * HTTP headers.
  */
-public class StoreResponse extends HttpResponseDecorator implements HttpResponse {
+public class StoreResponse extends HttpResponseDecorator implements WithBodyResponse {
 
+    private final FetchResponse fetchResponse;
     private String vclock = null;
     private String lastmod = null;
     private String vtag = null;
@@ -31,11 +34,13 @@ public class StoreResponse extends HttpResponseDecorator implements HttpResponse
     /**
      * On a 2xx response, parses the HTTP headers into updated object metadata.
      */
-    public StoreResponse(HttpResponse r) {
-        super(r);
+    public StoreResponse(FetchResponse fetchResponse) {
+        super(fetchResponse);
 
-        if (r != null && r.isSuccess()) {
-            Map<String, String> headers = r.getHttpHeaders();
+        this.fetchResponse = fetchResponse;
+
+        if (fetchResponse != null && fetchResponse.isSuccess()) {
+            Map<String, String> headers = fetchResponse.getHttpHeaders();
             vclock = headers.get(Constants.HDR_VCLOCK);
             lastmod = headers.get(Constants.HDR_LAST_MODIFIED);
             vtag = headers.get(Constants.HDR_ETAG);
@@ -57,5 +62,37 @@ public class StoreResponse extends HttpResponseDecorator implements HttpResponse
     /** The object's updated etag or null if Riak didn't return one. */
     public String getVtag() {
         return vtag;
+    }
+
+    /**
+     * @return
+     * @see com.basho.riak.client.response.FetchResponse#hasObject()
+     */
+    public boolean hasObject() {
+        return fetchResponse.hasObject();
+    }
+
+    /**
+     * @return
+     * @see com.basho.riak.client.response.FetchResponse#getObject()
+     */
+    public RiakObject getObject() {
+        return fetchResponse.getObject();
+    }
+
+    /**
+     * @return
+     * @see com.basho.riak.client.response.FetchResponse#hasSiblings()
+     */
+    public boolean hasSiblings() {
+        return fetchResponse.hasSiblings();
+    }
+
+    /**
+     * @return
+     * @see com.basho.riak.client.response.FetchResponse#getSiblings()
+     */
+    public Collection<RiakObject> getSiblings() {
+        return fetchResponse.getSiblings();
     }
 }

--- a/src/main/java/com/basho/riak/client/response/WithBodyResponse.java
+++ b/src/main/java/com/basho/riak/client/response/WithBodyResponse.java
@@ -1,0 +1,36 @@
+/*
+ * This file is provided to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.basho.riak.client.response;
+
+import java.util.Collection;
+
+import com.basho.riak.client.RiakObject;
+
+/**
+ * A unified interface for responses that may return one, or more RiakObjects
+ * 
+ * @see {@link FetchResponse}, {@link StoreResponse}
+ * @author russell
+ * 
+ */
+public interface WithBodyResponse extends HttpResponse {
+
+    public boolean hasObject();
+
+    public RiakObject getObject();
+
+    public boolean hasSiblings();
+
+    public Collection<RiakObject> getSiblings();
+}

--- a/src/test/java/com/basho/riak/client/TestRiakClient.java
+++ b/src/test/java/com/basho/riak/client/TestRiakClient.java
@@ -214,6 +214,18 @@ public class TestRiakClient {
         assertTrue(meta.getHeader("accept").contains("multipart/mixed"));
     }
 
+    @Test public void store_adds_accept_header_for_multipart_content() {
+        final RequestMeta meta = new RequestMeta();
+        RiakObject o = new RiakObject(bucket, key);
+        impl.store(o, meta);
+        assertTrue(meta.getHeader("accept").contains("multipart/mixed"));
+
+        meta.setHeader("accept", "text/plain");
+        impl.fetch(bucket, key, meta, false);
+        assertTrue(meta.getHeader("accept").contains("text/plain"));
+        assertTrue(meta.getHeader("accept").contains("multipart/mixed"));
+    }
+
     @Test public void fetch_meta_asks_fetchresponse_to_associate_new_objects_with_client() {
         when(mockHelper.fetchMeta(anyString(), anyString(), any(RequestMeta.class))).thenReturn(mockHttpResponse);
         when(mockHttpResponse.isSuccess()).thenReturn(true);

--- a/src/test/java/com/basho/riak/client/itest/ITestBasic.java
+++ b/src/test/java/com/basho/riak/client/itest/ITestBasic.java
@@ -24,9 +24,14 @@ import com.basho.riak.client.RiakBucketInfo;
 import com.basho.riak.client.RiakClient;
 import com.basho.riak.client.RiakLink;
 import com.basho.riak.client.RiakObject;
+import com.basho.riak.client.plain.PlainClient;
+import com.basho.riak.client.plain.RiakIOException;
+import com.basho.riak.client.plain.RiakResponseException;
+import com.basho.riak.client.request.RequestMeta;
 import com.basho.riak.client.response.BucketResponse;
 import com.basho.riak.client.response.FetchResponse;
 import com.basho.riak.client.response.StoreResponse;
+import com.basho.riak.client.util.Constants;
 
 /**
  * Basic exercises such as store, fetch, and modify objects for the Riak client.
@@ -132,5 +137,69 @@ public class ITestBasic {
         assertSuccess(c.delete(BUCKET, KEY1));
         assertSuccess(c.delete(BUCKET, KEY2));
         assertSuccess(c.delete(BUCKET, KEY3));
+    }
+
+    @Test public void fetchNonExistant() {
+        final RiakClient c = new RiakClient(RIAK_URL);
+        final String BUCKET = UUID.randomUUID().toString();
+        final String KEY = UUID.randomUUID().toString();
+
+        FetchResponse fetchresp = c.fetch(BUCKET, KEY);
+        assertEquals(404, fetchresp.getStatusCode());
+        assertNull(fetchresp.getObject());
+    }
+
+    @Test public void fetchNonExistant_plainClient() throws RiakIOException, RiakResponseException {
+        final RiakClient c = new RiakClient(RIAK_URL);
+        PlainClient client = new PlainClient(c);
+        final String BUCKET = UUID.randomUUID().toString();
+        final String KEY = UUID.randomUUID().toString();
+
+        RiakObject o = client.fetch(BUCKET, KEY);
+        assertNull(o);
+    }
+
+    @Test public void storeWithReturnBody() {
+        final RiakClient c = new RiakClient(RIAK_URL);
+        final String bucket = UUID.randomUUID().toString();
+        final String key = UUID.randomUUID().toString();
+        final byte[] value = "value".getBytes();
+
+        RiakObject o = new RiakObject(bucket, key, value);
+        StoreResponse storeresp = c.store(o, WRITE_3_REPLICAS());
+        assertSuccess(storeresp);
+
+        assertTrue(storeresp.hasObject());
+        assertArrayEquals(value, storeresp.getObject().getValueAsBytes());
+        assertFalse(storeresp.hasSiblings());
+        assertEquals(0, storeresp.getSiblings().size());
+    }
+
+    @Test public void storeWithReturnBodyAndSiblings() throws InterruptedException {
+        final RiakClient c = new RiakClient(RIAK_URL);
+
+        final String bucket = UUID.randomUUID().toString();
+        final String key = UUID.randomUUID().toString();
+        final byte[] value = "value".getBytes();
+        final byte[] newValue = "new_value".getBytes();
+
+        RiakBucketInfo bucketInfo = new RiakBucketInfo();
+        bucketInfo.setAllowMult(true);
+
+        c.setBucketSchema(bucket, bucketInfo);
+        RiakObject o = new RiakObject(bucket, key, value);
+
+        final RequestMeta rm = WRITE_3_REPLICAS().setHeader(Constants.QP_RETURN_BODY, "true");
+
+        StoreResponse storeresp = c.store(o, rm);
+        assertSuccess(storeresp);
+
+        o = new RiakObject(bucket, key, newValue);
+        storeresp = c.store(o, rm);
+
+        assertSuccess(storeresp);
+        assertTrue(storeresp.hasObject());
+        assertTrue(storeresp.hasSiblings());
+        assertEquals(2, storeresp.getSiblings().size());
     }
 }

--- a/src/test/java/com/basho/riak/client/response/TestStoreResponse.java
+++ b/src/test/java/com/basho/riak/client/response/TestStoreResponse.java
@@ -29,19 +29,35 @@ public class TestStoreResponse {
     }
     
     @Test public void parses_meta_headers() {
-        final HttpResponse mockHttpResponse = mock(HttpResponse.class);
+        final FetchResponse mockFetchResponse = mock(FetchResponse.class);
         final Map<String, String> HTTP_HEADERS = new HashMap<String, String>();
         HTTP_HEADERS.put("X-Riak-Vclock".toLowerCase(), "a85hYGBgzGDKBVIsDPKZOzKYEhnzWBlaJyw9wpcFAA==");
         HTTP_HEADERS.put("Last-Modified".toLowerCase(), "Tue, 22 Dec 2009 18:48:37 GMT");
         HTTP_HEADERS.put("ETag".toLowerCase(), "4d5y9wqQK2Do0RK5ezwCJD");
 
-        when(mockHttpResponse.getHttpHeaders()).thenReturn(HTTP_HEADERS);
-        when(mockHttpResponse.isSuccess()).thenReturn(true);
+        when(mockFetchResponse.getHttpHeaders()).thenReturn(HTTP_HEADERS);
+        when(mockFetchResponse.isSuccess()).thenReturn(true);
 
-        StoreResponse impl = new StoreResponse(mockHttpResponse);
+        StoreResponse impl = new StoreResponse(mockFetchResponse);
 
         assertEquals("a85hYGBgzGDKBVIsDPKZOzKYEhnzWBlaJyw9wpcFAA==", impl.getVclock());
         assertEquals("Tue, 22 Dec 2009 18:48:37 GMT", impl.getLastmod());
         assertEquals("4d5y9wqQK2Do0RK5ezwCJD", impl.getVtag());
+    }
+
+    @Test public void delegates_multiimpl_to_bodyresponse() {
+        final FetchResponse mockFetchResponse = mock(FetchResponse.class);
+        StoreResponse impl = new StoreResponse(mockFetchResponse);
+
+        impl.hasObject();
+        impl.getObject();
+        impl.hasSiblings();
+        impl.getSiblings();
+
+        verify(mockFetchResponse, times(1)).hasObject();
+        verify(mockFetchResponse, times(1)).getObject();
+        verify(mockFetchResponse, times(1)).hasSiblings();
+        verify(mockFetchResponse, times(1)).getSiblings();
+
     }
 }


### PR DESCRIPTION
HTTP RiakClient's store method could not return siblings due to 

```
Limitations of StoreResponse
Missing Accept header if returnbody was true
```

Fix the accept header on store and enable StoreResponse to contain siblings
