### PR TITLE
Make RiakConnection's timer daemon and named

### DIFF
--- a/src/main/java/com/basho/riak/pbc/RiakConnection.java
+++ b/src/main/java/com/basho/riak/pbc/RiakConnection.java
@@ -108,7 +108,7 @@ class RiakConnection {
 		}
 	}
 
-	static Timer timer = new Timer();
+	static Timer TIMER = new Timer("riak-client-timeout-thread", true);
 	TimerTask idle_timeout;
 	
 	public void beginIdle() {
@@ -120,7 +120,7 @@ class RiakConnection {
 			}
 		};
 		
-		timer.schedule(idle_timeout, 1000);
+		TIMER.schedule(idle_timeout, 1000);
 	}
 
 	synchronized void timer_fired(TimerTask fired_timer) {

--- a/src/main/java/com/basho/riak/pbc/RiakStreamClient.java
+++ b/src/main/java/com/basho/riak/pbc/RiakStreamClient.java
@@ -43,7 +43,7 @@ abstract class RiakStreamClient<T> implements Iterable<T> {
 		ReaperTask (Object holder, RiakConnection conn) {
 			this.conn = conn;
 			this.ref = new WeakReference<Object>(holder);
-			RiakConnection.timer.scheduleAtFixedRate(this, 1000, 1000);
+			RiakConnection.TIMER.scheduleAtFixedRate(this, 1000, 1000);
 		}
 		
 		@Override


### PR DESCRIPTION
Also, rename it to fit into Java idioms.

This will allow application to exit when their main thread stops.

Fixes [Bug 1085](https://issues.basho.com/show_bug.cgi?id=1085).
