### PR TITLE
Parse multipart/mixed response entities as byte arrays, not strings.

### DIFF
--- a/src/main/java/com/basho/riak/client/response/FetchResponse.java
+++ b/src/main/java/com/basho/riak/client/response/FetchResponse.java
@@ -83,7 +83,7 @@ public class FetchResponse extends HttpResponseDecorator implements WithBodyResp
                     throw new RiakIORuntimeException("Error finding initial boundary", e);
                 }
             } else {
-                siblings = ClientUtils.parseMultipart(riak, r.getBucket(), r.getKey(), headers, r.getBodyAsString());
+                siblings = ClientUtils.parseMultipart(riak, r.getBucket(), r.getKey(), headers, r.getBody());
             }
 
             object = siblings.iterator().next();

--- a/src/main/java/com/basho/riak/client/response/WalkResponse.java
+++ b/src/main/java/com/basho/riak/client/response/WalkResponse.java
@@ -81,7 +81,7 @@ public class WalkResponse extends HttpResponseDecorator implements HttpResponse 
         String bucket = r.getBucket();
         String key = r.getKey();
         List<List<RiakObject>> parsedSteps = new ArrayList<List<RiakObject>>();
-        List<Multipart.Part> parts = Multipart.parse(r.getHttpHeaders(), r.getBodyAsString());
+        List<Multipart.Part> parts = Multipart.parse(r.getHttpHeaders(), r.getBody());
 
         if (parts != null) {
             for (Multipart.Part part : parts) {
@@ -92,7 +92,7 @@ public class WalkResponse extends HttpResponseDecorator implements HttpResponse 
                     !(contentType.trim().toLowerCase().startsWith(Constants.CTYPE_MULTIPART_MIXED)))
                     throw new RiakResponseRuntimeException(r, "multipart/mixed subparts expected in link walk results");
 
-                parsedSteps.add(ClientUtils.parseMultipart(riak, bucket, key, partHeaders, part.getBodyAsString()));
+                parsedSteps.add(ClientUtils.parseMultipart(riak, bucket, key, partHeaders, part.getBody()));
             }
         }
 

--- a/src/main/java/com/basho/riak/client/util/ClientUtils.java
+++ b/src/main/java/com/basho/riak/client/util/ClientUtils.java
@@ -401,7 +401,7 @@ public class ClientUtils {
      * @return List of {@link RiakObject}s represented by the multipart document
      */
     public static List<RiakObject> parseMultipart(RiakClient riak, String bucket, String key,
-                                                  Map<String, String> docHeaders, String docBody) {
+                                                  Map<String, String> docHeaders, byte[] docBody) {
 
         String vclock = null;
 

--- a/src/test/java/com/basho/riak/client/util/TestClientUtils.java
+++ b/src/test/java/com/basho/riak/client/util/TestClientUtils.java
@@ -276,7 +276,7 @@ public class TestClientUtils {
         headers.put("content-type", "multipart/mixed; boundary=boundary");
         String body = "\r\n--boundary\r\n" + "\r\n" + "--boundary--";
 
-        List<RiakObject> objects = ClientUtils.parseMultipart(mockRiakClient, "b", "k", headers, body);
+        List<RiakObject> objects = ClientUtils.parseMultipart(mockRiakClient, "b", "k", headers, body.getBytes());
         assertEquals(1, objects.size());
         assertSame(mockRiakClient, objects.get(0).getRiakClient());
         assertEquals("b", objects.get(0).getBucket());
@@ -291,7 +291,7 @@ public class TestClientUtils {
                       + "Link: </riak/b/l>; riaktag=t\r\n" + "ETag: vtag\r\n" + "X-Riak-Meta-Test: value\r\n" + "\r\n"
                       + "--boundary--";
 
-        List<RiakObject> objects = ClientUtils.parseMultipart(mockRiakClient, "b", "k", headers, body);
+        List<RiakObject> objects = ClientUtils.parseMultipart(mockRiakClient, "b", "k", headers, body.getBytes());
 
         assertEquals(1, objects.get(0).numLinks());
         assertTrue(objects.get(0).hasLink(new RiakLink("b", "l", "t")));
@@ -310,7 +310,7 @@ public class TestClientUtils {
         headers.put("content-type", "multipart/mixed; boundary=boundary");
         String body = "\r\n--boundary\r\n" + "\r\n" + "foo\r\n" + "--boundary--";
 
-        List<RiakObject> objects = ClientUtils.parseMultipart(mockRiakClient, "b", "k", headers, body);
+        List<RiakObject> objects = ClientUtils.parseMultipart(mockRiakClient, "b", "k", headers, body.getBytes());
         assertEquals("foo", objects.get(0).getValue());
     }
 

--- a/src/test/java/com/basho/riak/client/util/TestMultipart.java
+++ b/src/test/java/com/basho/riak/client/util/TestMultipart.java
@@ -13,13 +13,15 @@
  */
 package com.basho.riak.client.util;
 
-import static org.junit.Assert.*;
+import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class TestMultipart {
 
@@ -27,7 +29,7 @@ public class TestMultipart {
         Map<String, String> headers = new HashMap<String, String>();
         headers.put("content-type", "text/plain");
         String body = "abc";
-        assertNull(Multipart.parse(headers, body));
+        assertNull(Multipart.parse(headers, body.getBytes()));
     }
 
     @Test public void null_result_if_not_content_type_missing_boundary_parameter() {
@@ -35,7 +37,7 @@ public class TestMultipart {
         headers.put("content-type", "multipart/mixed");
         String body = "\r\n--boundary\r\n" + "Content-Type: text/plain\r\n" + "\r\n" + "subpart\r\n" + "--boundary--";
 
-        assertNull(Multipart.parse(headers, body));
+        assertNull(Multipart.parse(headers, body.getBytes()));
     }
 
     @Test public void parses_multipart_with_1_empty_part() {
@@ -43,7 +45,7 @@ public class TestMultipart {
         headers.put("content-type", "multipart/mixed; boundary=boundary");
         String body = "\r\n--boundary\r\n" + "\r\n" + "--boundary--";
 
-        List<Multipart.Part> parts = Multipart.parse(headers, body);
+        List<Multipart.Part> parts = Multipart.parse(headers, body.getBytes());
         assertEquals(1, parts.size());
         assertEquals(0, parts.get(0).getHeaders().size());
         assertEquals("", parts.get(0).getBodyAsString());
@@ -54,11 +56,38 @@ public class TestMultipart {
         headers.put("content-type", "multipart/mixed; boundary=boundary");
         String body = "\r\n--boundary\r\n" + "Content-Type: text/plain\r\n" + "\r\n" + "subpart\r\n" + "--boundary--";
 
-        List<Multipart.Part> parts = Multipart.parse(headers, body);
+        List<Multipart.Part> parts = Multipart.parse(headers, body.getBytes());
         assertEquals(1, parts.size());
         assertEquals(1, parts.get(0).getHeaders().size());
         assertEquals("text/plain", parts.get(0).getHeaders().get(Constants.HDR_CONTENT_TYPE));
         assertEquals("subpart", parts.get(0).getBodyAsString());
+    }
+
+    @Test public void parses_multipart_with_invalid_utf8_binary_part() {
+        Map<String, String> headers = new HashMap<String, String>();
+        headers.put("content-type", "multipart/mixed; boundary=boundary");
+
+        /* 00000000  0d 0a 2d 2d 62 6f 75 6e  64 61 72 79 0d 0a 43 6f |..--boundary..Co|
+         * 00000010  6e 74 65 6e 74 2d 54 79  70 65 3a 20 74 65 78 74 |ntent-Type: text|
+         * 00000020  2f 70 6c 61 69 6e 0d 0a  0d 0a f0 28 8c 28 0d 0a |/plain.....(.(..|
+         * 00000030  2d 2d 62 6f 75 6e 64 61  72 79 2d 2d             |--boundary--|
+         * 0000003c
+        */
+        byte[] body = new byte[]{
+                13, 10, 45, 45, 98, 111, 117, 110, 100, 97, 114, 121, 13, 10, 67, 111,
+                110, 116, 101, 110, 116, 45, 84, 121, 112, 101, 58, 32, 116, 101, 120,
+                116, 47, 112, 108, 97, 105, 110, 13, 10, 13, 10,
+                -16, 40, -116, 40, // <- invalid UTF8 sequence, valid binary data
+                13, 10, 45, 45, 98, 111, 117, 110, 100, 97, 114, 121, 45, 45
+        };
+
+        byte[] invalidUtf8 = new byte[]{-16, 40, -116, 40};
+
+        List<Multipart.Part> parts = Multipart.parse(headers, body);
+        assertEquals(1, parts.size());
+        assertEquals(1, parts.get(0).getHeaders().size());
+        assertEquals("text/plain", parts.get(0).getHeaders().get(Constants.HDR_CONTENT_TYPE));
+        assertArrayEquals(invalidUtf8, parts.get(0).getBody());
     }
 
     @Test public void parses_multipart_with_multiple_parts() {
@@ -67,7 +96,7 @@ public class TestMultipart {
         String body = "\r\n--boundary\r\n" + "Content-Type: text/plain\r\n" + "\r\n" + "part1\r\n" + "--boundary\r\n" + "\r\n"
                       + "part2\r\n" + "--boundary--";
 
-        List<Multipart.Part> parts = Multipart.parse(headers, body);
+        List<Multipart.Part> parts = Multipart.parse(headers, body.getBytes());
         assertEquals(2, parts.size());
         assertEquals("part1", parts.get(0).getBodyAsString());
         assertEquals("part2", parts.get(1).getBodyAsString());
@@ -81,10 +110,10 @@ public class TestMultipart {
                       + "subpart1\r\n" + "--5hgaasMxj1NIcoxJBpWd4j9IuaW\r\n" + "Content-Type: application/octet-stream\r\n"
                       + "\r\n" + "subpart2\r\n" + "--5hgaasMxj1NIcoxJBpWd4j9IuaW--\r\n" + "\r\n" + "--boundary--\r\n";
 
-        List<Multipart.Part> parts = Multipart.parse(headers, body);
+        List<Multipart.Part> parts = Multipart.parse(headers, body.getBytes());
         assertEquals(1, parts.size());
 
-        List<Multipart.Part> subparts = Multipart.parse(parts.get(0).getHeaders(), parts.get(0).getBodyAsString());
+        List<Multipart.Part> subparts = Multipart.parse(parts.get(0).getHeaders(), parts.get(0).getBody());
         assertEquals(2, subparts.size());
         assertEquals("subpart1", subparts.get(0).getBodyAsString());
         assertEquals("subpart2", subparts.get(1).getBodyAsString());
@@ -98,7 +127,7 @@ public class TestMultipart {
                       "Location: /riak/test/key\r\n" + "Content-Type: application/octet-stream\r\n" + "\r\n" + PART_BODY +
                       "\r\n--boundary--";
 
-        List<Multipart.Part> parts = Multipart.parse(headers, body);
+        List<Multipart.Part> parts = Multipart.parse(headers, body.getBytes());
         assertEquals(3, parts.get(0).getHeaders().size());
         assertEquals("a85hYGBgzGDKBVIsLOLmazKYEhnzWBkmzFt4hC8LAA==",
                      parts.get(0).getHeaders().get(Constants.HDR_VCLOCK));
@@ -116,7 +145,7 @@ public class TestMultipart {
                                                                                   // \x"
         String body = "\r\n--\\x\"\r\n" + "\r\n" + "part\r\n" + "--\\x\"--";
 
-        List<Multipart.Part> parts = Multipart.parse(headers, body);
+        List<Multipart.Part> parts = Multipart.parse(headers, body.getBytes());
         assertEquals(1, parts.size());
         assertEquals(0, parts.get(0).getHeaders().size());
         assertEquals("part", parts.get(0).getBodyAsString());


### PR DESCRIPTION
This should fix all character set/encoding bugs associated with binary sibling values.

Specifically, my current problem: [Bug 677](https://issues.basho.com/show_bug.cgi?id=677)/[1084](https://issues.basho.com/show_bug.cgi?id=1084).

This also includes a test for my specific problem, including an example of invalid UTF-8.
