### PR TITLE
Riak-Search Integration

### DIFF
--- a/src/main/java/com/basho/riak/client/RiakClient.java
+++ b/src/main/java/com/basho/riak/client/RiakClient.java
@@ -512,9 +512,22 @@ public class RiakClient {
      * @param objects
      *            A set of objects represented as a map of { bucket : [ list of
      *            keys in bucket ] }
+     * @return A {@link MapReduceBuilder} to build the map reduce job
      */
     public MapReduceBuilder mapReduceOverObjects(Map<String, Set<String>> objects) {
         return new MapReduceBuilder(this).setRiakObjects(objects);
+    }
+    
+    /**
+     * Same as {@link RiakClient#mapReduceOverBucket(String)}, except over a 
+     * riak-search query instead of a bucket.
+     * 
+     * @param bucket The bucket to perform the riak-search over
+     * @param search The query that riak-search will execute
+     * @return A {@link MapReduceBuilder} to build the map reduce job
+     */
+    public MapReduceBuilder mapReduceOverSearch(String bucket, String search) {
+    	return new MapReduceBuilder(this).setBucket(bucket).setSearch(search);
     }
 
     /**

--- a/src/main/java/com/basho/riak/pbc/mapreduce/MapReduceBuilder.java
+++ b/src/main/java/com/basho/riak/pbc/mapreduce/MapReduceBuilder.java
@@ -45,6 +45,7 @@ public class MapReduceBuilder {
     }
 
     private String bucket = null;
+    private String search = null;
     private Map<String, Set<String>> objects = new LinkedHashMap<String, Set<String>>();
     private List<MapReducePhase> phases = new LinkedList<MapReducePhase>();
     private int timeout = -1;
@@ -92,6 +93,25 @@ public class MapReduceBuilder {
         bucket = newBucket;
         return this;
     }
+    
+    /**
+     * Gets the search query the map/reduce job will process
+     */
+    public String getSearch() {
+    	return search;
+    }
+    
+    /**
+     * Sets the name of the Riak bucket that will be searched and the query that will be executed
+     * 
+     * @throws IllegalStateException - If objects or bucket has already been added
+     */
+    public MapReduceBuilder setSearch(String search) {
+    	if (objects.size() > 0)
+    		throw new IllegalStateException("Cannot map/reduce over objects and search");
+    	this.search = search;
+    	return this;
+    }
 
     /**
      * Adds a Riak object (bucket name/key pair) to the map/reduce job as inputs
@@ -100,6 +120,8 @@ public class MapReduceBuilder {
      *             - If a bucket name has already been set on the job
      */
     public void addRiakObject(String bucket, String key) {
+        if (search != null)
+            throw new IllegalStateException("Cannot map/reduce over objects and search");
         if (this.bucket != null)
             throw new IllegalStateException("Cannot map/reduce over buckets and objects");
         Set<String> keys = objects.get(bucket);
@@ -138,6 +160,8 @@ public class MapReduceBuilder {
      *             - If a bucket name has already been set on the job
      */
     public MapReduceBuilder setRiakObjects(Map<String, Set<String>> objects) {
+        if (search != null)
+            throw new IllegalStateException("Cannot map/reduce over objects and search");
         if (bucket != null)
             throw new IllegalStateException("Cannot map/reduce over buckets and objects");
 
@@ -151,6 +175,8 @@ public class MapReduceBuilder {
     }
 
     public MapReduceBuilder setRiakObjects(Collection<RiakObject> objects) {
+        if (search != null)
+            throw new IllegalStateException("Cannot map/reduce over objects and search");
         if (bucket != null)
             throw new IllegalStateException("Cannot map/reduce over buckets and objects");
 
@@ -366,7 +392,20 @@ public class MapReduceBuilder {
     }
     
     private void buildInputs(JSONObject job) {
-        if (bucket != null) {
+    	if (search != null) {
+            try {
+                JSONObject jobInputs = new JSONObject();
+                jobInputs.put("module", "riak_search");
+                jobInputs.put("function", "mapred_search");
+                JSONArray jobArgs = new JSONArray();
+                jobArgs.put(bucket);
+                jobArgs.put(search);
+                jobInputs.put("arg", jobArgs);
+                job.put("inputs", jobInputs);
+            } catch (JSONException e) {
+                throw new RuntimeException("Can always assemble a query");
+            }
+    	} else if (bucket != null) {
             try {
                 job.put("inputs", bucket);
             } catch (JSONException e) {

--- a/src/test/java/com/basho/riak/client/itest/ITestMapReduce.java
+++ b/src/test/java/com/basho/riak/client/itest/ITestMapReduce.java
@@ -24,94 +24,140 @@ import java.util.List;
 import org.apache.commons.httpclient.HttpException;
 import org.json.JSONArray;
 import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.basho.riak.client.RiakBucketInfo;
 import com.basho.riak.client.RiakClient;
 import com.basho.riak.client.RiakLink;
 import com.basho.riak.client.RiakObject;
 import com.basho.riak.client.mapreduce.ErlangFunction;
 import com.basho.riak.client.mapreduce.JavascriptFunction;
 import com.basho.riak.client.request.MapReduceBuilder;
+import com.basho.riak.client.response.BucketResponse;
 import com.basho.riak.client.response.MapReduceResponse;
 
 /**
- * Exercises map/reduce features of the Riak client.
- * Assumes Riak is reachable at {@link com.basho.riak.client.Hosts#RIAK_URL }.
+ * Exercises map/reduce features of the Riak client. Assumes Riak is reachable at {@link com.basho.riak.client.Hosts#RIAK_URL }.
+ * 
  * @see com.basho.riak.client.Hosts#RIAK_URL
  */
 public class ITestMapReduce {
-
-    public static String BUCKET_NAME = "mr_test_java";
-    public static int TEST_ITEMS = 200;
-    
-    @BeforeClass
-    public static void setup() {
-       RiakClient c = new RiakClient(RIAK_URL);
-       for(int i = 0; i < TEST_ITEMS; i++) {
-          RiakObject object = new RiakObject(BUCKET_NAME, "java_" + Integer.toString(i));
-          object.setContentType("text/plain");
-          object.setValue(Integer.toString(i));
-          if (i < TEST_ITEMS - 1) {
-             RiakLink link = new RiakLink(BUCKET_NAME, "java_" + Integer.toString(i + 1), "test");
-             List<RiakLink> links = new ArrayList<RiakLink>(1);
-             links.add(link);
-             object.setLinks(links);
-          }
-          c.store(object);
-       }       
-       
-    }
-    
-    @AfterClass
-    public static void teardown() {
-       RiakClient c = new RiakClient(RIAK_URL);
-       for(int i = 0; i < TEST_ITEMS; i++) {
-          c.delete(BUCKET_NAME, "java_" + Integer.toString(i));          
-       }              
-    }
-    
-    @Test public void doLinkMapReduce() throws HttpException, IOException, JSONException {
-       RiakClient c = new RiakClient(RIAK_URL);
-       MapReduceResponse response = c.mapReduceOverBucket(BUCKET_NAME)
-           .link(BUCKET_NAME, "test", false)
-           .map(JavascriptFunction.named("Riak.mapValuesJson"), false)
-           .reduce(new ErlangFunction("riak_kv_mapreduce", "reduce_sort"), true)
-           .submit();
-       assertTrue(response.isSuccess());
-       JSONArray results = response.getResults();
-       assertEquals(TEST_ITEMS - 1, results.length());
-    }
-    
-    @Test public void doErlangMapReduce() throws HttpException, IOException, JSONException {
-       RiakClient c = new RiakClient(RIAK_URL);
-       MapReduceBuilder builder = new MapReduceBuilder(c);
-       builder.setBucket(BUCKET_NAME);
-       builder.map(new ErlangFunction("riak_kv_mapreduce", "map_object_value"), false);
-       builder.reduce(new ErlangFunction("riak_kv_mapreduce", "reduce_string_to_integer"), false);
-       builder.reduce(new ErlangFunction("riak_kv_mapreduce", "reduce_sort"), true);
-       MapReduceResponse response = builder.submit();
-       assertTrue(response.isSuccess());
-       JSONArray results = response.getResults();
-       assertEquals(TEST_ITEMS, results.length());
-       assertEquals(0, results.getInt(0));
-       assertEquals(73, results.getInt(73));
-       assertEquals(197, results.getInt(197));       
-    }
-    
-    @Test public void doJavascriptMapReduce() throws HttpException, IOException, JSONException {
-       RiakClient c = new RiakClient(RIAK_URL);
-       MapReduceBuilder builder = new MapReduceBuilder(c);
-       builder.setBucket(BUCKET_NAME);
-       builder.map(JavascriptFunction.named("Riak.mapValuesJson"), false);
-       builder.reduce(JavascriptFunction.named("Riak.reduceNumericSort"), true);
-       MapReduceResponse response = builder.submit();
-       assertTrue(response.isSuccess());
-       JSONArray results = response.getResults();
-       assertEquals(TEST_ITEMS, results.length());
-       assertEquals(0, results.getInt(0));
-       assertEquals(73, results.getInt(73));
-       assertEquals(197, results.getInt(197));       
-    }
+	public static enum Digit { ZERO, ONE, TWO, THREE, FOUR, FIVE, SIX, SEVEN, EIGHT, NINE };
+	
+	public static String	BUCKET_NAME	       = "mr_test_java";
+	public static String	SEARCH_BUCKET_NAME	= "mr_stest_java";
+	public static int	 TEST_ITEMS	           = 200;
+	
+	@BeforeClass
+	public static void setup() {
+		RiakClient c = new RiakClient(RIAK_URL);
+		
+		indexBucket(c, SEARCH_BUCKET_NAME);
+		
+		for (int i = 0; i < TEST_ITEMS; i++) {
+			RiakObject object = new RiakObject(BUCKET_NAME, "java_" + Integer.toString(i));
+			object.setContentType("text/plain");
+			object.setValue(Integer.toString(i));
+			if (i < TEST_ITEMS - 1) {
+				RiakLink link = new RiakLink(BUCKET_NAME, "java_" + Integer.toString(i + 1), "test");
+				List<RiakLink> links = new ArrayList<RiakLink>(1);
+				links.add(link);
+				object.setLinks(links);
+			}
+			c.store(object);
+			
+			RiakObject searchObject = new RiakObject(SEARCH_BUCKET_NAME, "java_" + Integer.toString(i));
+			searchObject.setContentType("application/json");
+			searchObject.setValue("{\"foo\":\"" + Digit.values()[i % 10].toString().toLowerCase() + "\"}");
+			c.store(searchObject);
+		}
+	}
+	
+	private static void indexBucket(RiakClient c, String bucket) {
+		try {
+			BucketResponse response = c.getBucketSchema(SEARCH_BUCKET_NAME);
+			RiakBucketInfo info = response.getBucketInfo();
+			JSONObject schema = info.getSchema();
+			
+			JSONArray precommit = (JSONArray) schema.get("precommit");
+			for (int i = 0; i < precommit.length(); i++) {
+				JSONObject handler = (JSONObject) precommit.get(i);
+				if (handler.has("mod") && handler.get("mod").equals("riak_search_kv_hook")) return;
+			}
+			precommit.put(new JSONObject() {
+				{
+					put("mod", "riak_search_kv_hook");
+					put("fun", "precommit");
+				}
+			});
+			
+			c.setBucketSchema(SEARCH_BUCKET_NAME, info);
+		} catch (JSONException e) {
+			throw new RuntimeException("Should always be able to create JSONObject");
+		}
+	}
+	
+	@AfterClass
+	public static void teardown() {
+		RiakClient c = new RiakClient(RIAK_URL);
+		for (int i = 0; i < TEST_ITEMS; i++) {
+			c.delete(BUCKET_NAME, "java_" + Integer.toString(i));
+			c.delete(SEARCH_BUCKET_NAME, "java_" + Integer.toString(i));
+		}
+	}
+	
+	@Test
+	public void doSearchMapOnly() throws HttpException, IOException, JSONException {
+		RiakClient c = new RiakClient(RIAK_URL);
+		MapReduceResponse response = c.mapReduceOverSearch(SEARCH_BUCKET_NAME, "foo:zero").map(JavascriptFunction.anon("function(v) { return [v]; }"), true).submit();
+		assertTrue(response.isSuccess());
+		JSONArray results = response.getResults();
+		assertEquals(TEST_ITEMS / 10, results.length());
+	}
+	
+	@Test
+	public void doLinkMapReduce() throws HttpException, IOException, JSONException {
+		RiakClient c = new RiakClient(RIAK_URL);
+		MapReduceResponse response = c.mapReduceOverBucket(BUCKET_NAME).link(BUCKET_NAME, "test", false)
+		        .map(JavascriptFunction.named("Riak.mapValuesJson"), false).reduce(new ErlangFunction("riak_kv_mapreduce", "reduce_sort"), true).submit();
+		assertTrue(response.isSuccess());
+		JSONArray results = response.getResults();
+		assertEquals(TEST_ITEMS - 1, results.length());
+	}
+	
+	@Test
+	public void doErlangMapReduce() throws HttpException, IOException, JSONException {
+		RiakClient c = new RiakClient(RIAK_URL);
+		MapReduceBuilder builder = new MapReduceBuilder(c);
+		builder.setBucket(BUCKET_NAME);
+		builder.map(new ErlangFunction("riak_kv_mapreduce", "map_object_value"), false);
+		builder.reduce(new ErlangFunction("riak_kv_mapreduce", "reduce_string_to_integer"), false);
+		builder.reduce(new ErlangFunction("riak_kv_mapreduce", "reduce_sort"), true);
+		MapReduceResponse response = builder.submit();
+		assertTrue(response.isSuccess());
+		JSONArray results = response.getResults();
+		assertEquals(TEST_ITEMS, results.length());
+		assertEquals(0, results.getInt(0));
+		assertEquals(73, results.getInt(73));
+		assertEquals(197, results.getInt(197));
+	}
+	
+	@Test
+	public void doJavascriptMapReduce() throws HttpException, IOException, JSONException {
+		RiakClient c = new RiakClient(RIAK_URL);
+		MapReduceBuilder builder = new MapReduceBuilder(c);
+		builder.setBucket(BUCKET_NAME);
+		builder.map(JavascriptFunction.named("Riak.mapValuesJson"), false);
+		builder.reduce(JavascriptFunction.named("Riak.reduceNumericSort"), true);
+		MapReduceResponse response = builder.submit();
+		assertTrue(response.isSuccess());
+		JSONArray results = response.getResults();
+		assertEquals(TEST_ITEMS, results.length());
+		assertEquals(0, results.getInt(0));
+		assertEquals(73, results.getInt(73));
+		assertEquals(197, results.getInt(197));
+	}
 }

--- a/src/test/java/com/basho/riak/client/mapreduce/TestMapReduceBuilder.java
+++ b/src/test/java/com/basho/riak/client/mapreduce/TestMapReduceBuilder.java
@@ -64,6 +64,12 @@ public class TestMapReduceBuilder {
       assertEquals(builder.getBucket(), "foo");
    }
    
+   @Test public void canStoreSearch() {
+	  MapReduceBuilder builder = new MapReduceBuilder();
+	  builder.setSearch("foo:bar");
+	  assertEquals(builder.getSearch(), "foo:bar");
+   }
+   
    @Test public void canStoreObjects() {
       MapReduceBuilder builder = new MapReduceBuilder();
       builder.addRiakObject("foo", "bar");
@@ -121,6 +127,35 @@ public class TestMapReduceBuilder {
       builder.addRiakObject("foo", "bar");
    }
    
+   @Test(expected=IllegalStateException.class)
+   public void cannotUseObjectsAndSearch() {
+	   MapReduceBuilder builder = new MapReduceBuilder();
+	   builder.addRiakObject("foo", "bar");
+	   builder.setSearch("foo:bar");
+   }
+   
+   @Test(expected=IllegalStateException.class)
+   public void cannotUseFiltersAndSearch() {
+	   MapReduceBuilder builder = new MapReduceBuilder();
+	   builder.keyFilter(new MatchFilter("foo"));
+	   builder.setSearch("foo:bar");
+   }
+   
+   @Test(expected=IllegalStateException.class)
+   public void cannotUseSearchAndFilters() {
+	   MapReduceBuilder builder = new MapReduceBuilder();
+	   builder.setSearch("foo:bar");
+	   builder.keyFilter(new MatchFilter("foo"));
+   }
+   
+   @Test public void canUseBucketAndSearch() {
+	   MapReduceBuilder builder = new MapReduceBuilder();
+	   builder.setBucket("foo");
+	   builder.setSearch("foo:bar");
+	   assertEquals(builder.getBucket(), "foo");
+	   assertEquals(builder.getSearch(), "foo:bar");
+   }
+   
    @Test public void canBuildJSMapOnlyJobWithBucket() throws JSONException {
       MapReduceBuilder builder = new MapReduceBuilder();
       builder.setBucket("wubba");
@@ -165,6 +200,63 @@ public class TestMapReduceBuilder {
       builder.reduce(new ErlangFunction("baz", "quux"), true);
       
       JSONObject expected = new JSONObject("{\"inputs\":\"wubba\",\"query\":[{\"map\":{\"module\":\"foo\"," +
+                                           "\"language\":\"erlang\",\"keep\":false,\"function\":\"bar\"}}," +
+                                           "{\"reduce\":{\"module\":\"baz\",\"language\":\"erlang\",\"keep\":true,\"function\":\"quux\"}}]}");
+
+      assertTrue("Generated JSON not as expected", JSONEquals.equals(expected, builder.toJSON()));
+   }
+   
+   @Test public void canBuildJSMapOnlyJobWithSearch() throws JSONException {
+	  MapReduceBuilder builder = new MapReduceBuilder();
+	  builder.setBucket("gumby");
+	  builder.setSearch("horse:pokey");
+	  builder.map(JavascriptFunction.named("Riak.mapValuesJson"), true);
+	  
+	  JSONObject expected = new JSONObject("{\"inputs\":{\"module\":\"riak_search\",\"function\":\"mapred_search\"," +
+                                           "\"arg\":[\"gumby\",\"horse:pokey\"]},\"query\":[{\"map\":{\"name\":\"Riak.mapValuesJson\"," +
+                                           "\"language\":\"javascript\",\"keep\":true}}]}");
+	  
+	  assertTrue("Generated JSON not as expected", JSONEquals.equals(expected, builder.toJSON()));
+   }
+   
+   @Test public void canBuildJSMapReduceJobWithSearch() throws JSONException {
+      MapReduceBuilder builder = new MapReduceBuilder();
+	  builder.setBucket("gumby");
+	  builder.setSearch("horse:pokey");
+      builder.map(JavascriptFunction.anon("function(v) { return [v]; }"), false);
+      builder.reduce(JavascriptFunction.named("Riak.reduceMin"), true);
+      
+      JSONObject expected = new JSONObject("{\"inputs\":{\"module\":\"riak_search\",\"function\":\"mapred_search\"," +
+                                           "\"arg\":[\"gumby\",\"horse:pokey\"]},\"query\":[{\"map\":{\"source\":" +
+                                           "\"function(v) { return [v]; }\",\"language\":\"javascript\",\"keep\":false}}," + 
+                                           "{\"reduce\":{\"name\":\"Riak.reduceMin\",\"language\":\"javascript\",\"keep\":true}}]}");
+      
+      assertTrue("Generated JSON not as expected", JSONEquals.equals(expected, builder.toJSON()));
+   }
+
+   
+   @Test public void canBuildErlangMapOnlyJobWithSearch() throws JSONException {
+      MapReduceBuilder builder = new MapReduceBuilder();
+	  builder.setBucket("gumby");
+	  builder.setSearch("horse:pokey");
+      builder.map(new ErlangFunction("foo", "bar"), true);
+      
+      JSONObject expected = new JSONObject("{\"inputs\":{\"module\":\"riak_search\",\"function\":\"mapred_search\"," +
+                                           "\"arg\":[\"gumby\",\"horse:pokey\"]},\"query\":[{\"map\":{\"module\":\"foo\"," +
+                                           "\"language\":\"erlang\",\"keep\":true,\"function\":\"bar\"}}]}");
+      
+      assertTrue("Generated JSON not as expected", JSONEquals.equals(expected, builder.toJSON()));
+   }
+   
+   @Test public void canBuildErlangMapReduceJobWithSearch() throws JSONException {
+      MapReduceBuilder builder = new MapReduceBuilder();
+	  builder.setBucket("gumby");
+	  builder.setSearch("horse:pokey");
+      builder.map(new ErlangFunction("foo", "bar"), false);
+      builder.reduce(new ErlangFunction("baz", "quux"), true);
+      
+      JSONObject expected = new JSONObject("{\"inputs\":{\"module\":\"riak_search\",\"function\":\"mapred_search\"," +
+                                           "\"arg\":[\"gumby\",\"horse:pokey\"]},\"query\":[{\"map\":{\"module\":\"foo\"," +
                                            "\"language\":\"erlang\",\"keep\":false,\"function\":\"bar\"}}," +
                                            "{\"reduce\":{\"module\":\"baz\",\"language\":\"erlang\",\"keep\":true,\"function\":\"quux\"}}]}");
 

--- a/src/test/java/com/basho/riak/pbc/itest/ITestMapReduce.java
+++ b/src/test/java/com/basho/riak/pbc/itest/ITestMapReduce.java
@@ -14,7 +14,6 @@
 package com.basho.riak.pbc.itest;
 
 import static com.basho.riak.client.Hosts.RIAK_HOST;
-import static com.basho.riak.client.Hosts.RIAK_PORT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -26,8 +25,10 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
+import com.basho.riak.client.itest.ITestMapReduce.Digit;
 import com.basho.riak.pbc.MapReduceResponseSource;
 import com.basho.riak.pbc.RiakClient;
 import com.basho.riak.pbc.RiakObject;
@@ -46,6 +47,7 @@ public class ITestMapReduce {
     private static final String KEY_PREFIX = "pbc_java_";
     private static final String TAG = "test";
     public static String BUCKET = "pbc_mr_test_java";
+	public static String	SEARCH_BUCKET_NAME	= "pbc_mr_stest_java";
     public static int TEST_ITEMS = 200;
 
     @BeforeClass public static void setup() throws Exception {
@@ -58,6 +60,10 @@ public class ITestMapReduce {
                 object.addLink(TAG, BUCKET, KEY_PREFIX + Integer.toString(i + 1));
             }
             c.store(object);
+            
+			RiakObject searchObject = new RiakObject(SEARCH_BUCKET_NAME, "java_" + Integer.toString(i), "{\"foo\":\"" + Digit.values()[i % 10].toString().toLowerCase() + "\"}");
+			searchObject.setContentType("application/json");
+			c.store(searchObject);
         }
     }
 
@@ -66,8 +72,37 @@ public class ITestMapReduce {
 
         for (int i = 0; i < TEST_ITEMS; i++) {
             c.delete(BUCKET, KEY_PREFIX + Integer.toString(i));
+			c.delete(SEARCH_BUCKET_NAME, "java_" + Integer.toString(i));
         }
     }
+    
+	/**
+	 * This test is fully functional but requires that the target bucket have search
+	 * installed.  As the PBC client currently cannot access/change bucket schemas, there
+	 * appears no way to accomplish this programatically without using the HTTP interface.
+	 * 
+	 * So for now I have this disabled - but the test will execute properly on
+	 * an indexed bucket so if at some point the above limitation is addressed then this 
+	 * test can be re-enabled.  For an example of this fully functional, see 
+	 * {@link com.basho.riak.client.itest.ITestMapReduce}.
+	 */
+    @Ignore
+	@Test
+	public void doSearchMapOnly() throws HttpException, IOException, JSONException {
+		RiakClient c = new RiakClient(RIAK_HOST);
+        MapReduceBuilder mrb = new MapReduceBuilder(c)
+    		.setBucket(SEARCH_BUCKET_NAME)
+    		.setSearch("foo:zero")
+    		.map(JavascriptFunction.anon("function(v) { return [v]; }"), true);
+        MapReduceResponseSource response = mrb.submit();
+        assertTrue(response.hasNext());
+        int i = 0;
+		JSONArray results;
+		while (response.hasNext() && (results = response.next().getJSON()) != null) {
+			i += results.length();
+		}
+		assertEquals(TEST_ITEMS / 10, i);
+	}
 
     @Test public void doLinkMapReduce() throws HttpException, IOException, JSONException {
        final RiakClient c = new RiakClient(RIAK_HOST);

--- a/src/test/java/com/basho/riak/pbc/mapreduce/TestMapReduceBuilder.java
+++ b/src/test/java/com/basho/riak/pbc/mapreduce/TestMapReduceBuilder.java
@@ -38,6 +38,12 @@ public class TestMapReduceBuilder {
       builder.setBucket("foo");
       assertEquals(builder.getBucket(), "foo");
    }
+   
+   @Test public void canStoreSearch() {
+	  MapReduceBuilder builder = new MapReduceBuilder();
+	  builder.setSearch("foo:bar");
+	  assertEquals(builder.getSearch(), "foo:bar");
+   }
 
    @Test public void canStoreObjects() {
       MapReduceBuilder builder = new MapReduceBuilder();
@@ -104,6 +110,21 @@ public class TestMapReduceBuilder {
                                                                       new RiakObject("foo", "baz", "v")});
       builder.setRiakObjects(riakObjects);
    }
+   
+   @Test(expected=IllegalStateException.class)
+   public void cannotUseObjectsAndSearch() {
+	   MapReduceBuilder builder = new MapReduceBuilder();
+	   builder.addRiakObject("foo", "bar");
+	   builder.setSearch("foo:bar");
+   }
+   
+   @Test public void canUseBucketAndSearch() {
+	   MapReduceBuilder builder = new MapReduceBuilder();
+	   builder.setBucket("foo");
+	   builder.setSearch("foo:bar");
+	   assertEquals(builder.getBucket(), "foo");
+	   assertEquals(builder.getSearch(), "foo:bar");
+   }
 
    @Test public void canBuildJSMapOnlyJobWithBucket() throws JSONException {
       MapReduceBuilder builder = new MapReduceBuilder();
@@ -149,6 +170,63 @@ public class TestMapReduceBuilder {
       builder.reduce(new ErlangFunction("baz", "quux"), true);
 
       JSONObject expected = new JSONObject("{\"inputs\":\"wubba\",\"query\":[{\"map\":{\"module\":\"foo\"," +
+                                           "\"language\":\"erlang\",\"keep\":false,\"function\":\"bar\"}}," +
+                                           "{\"reduce\":{\"module\":\"baz\",\"language\":\"erlang\",\"keep\":true,\"function\":\"quux\"}}]}");
+
+      assertTrue("Generated JSON not as expected", JSONEquals.equals(expected, builder.toJSON()));
+   }
+   
+   @Test public void canBuildJSMapOnlyJobWithSearch() throws JSONException {
+	  MapReduceBuilder builder = new MapReduceBuilder();
+	  builder.setBucket("gumby");
+	  builder.setSearch("horse:pokey");
+	  builder.map(JavascriptFunction.named("Riak.mapValuesJson"), true);
+	  
+	  JSONObject expected = new JSONObject("{\"inputs\":{\"module\":\"riak_search\",\"function\":\"mapred_search\"," +
+                                           "\"arg\":[\"gumby\",\"horse:pokey\"]},\"query\":[{\"map\":{\"name\":\"Riak.mapValuesJson\"," +
+                                           "\"language\":\"javascript\",\"keep\":true}}]}");
+	  
+	  assertTrue("Generated JSON not as expected", JSONEquals.equals(expected, builder.toJSON()));
+   }
+   
+   @Test public void canBuildJSMapReduceJobWithSearch() throws JSONException {
+      MapReduceBuilder builder = new MapReduceBuilder();
+	  builder.setBucket("gumby");
+	  builder.setSearch("horse:pokey");
+      builder.map(JavascriptFunction.anon("function(v) { return [v]; }"), false);
+      builder.reduce(JavascriptFunction.named("Riak.reduceMin"), true);
+      
+      JSONObject expected = new JSONObject("{\"inputs\":{\"module\":\"riak_search\",\"function\":\"mapred_search\"," +
+                                           "\"arg\":[\"gumby\",\"horse:pokey\"]},\"query\":[{\"map\":{\"source\":" +
+                                           "\"function(v) { return [v]; }\",\"language\":\"javascript\",\"keep\":false}}," + 
+                                           "{\"reduce\":{\"name\":\"Riak.reduceMin\",\"language\":\"javascript\",\"keep\":true}}]}");
+      
+      assertTrue("Generated JSON not as expected", JSONEquals.equals(expected, builder.toJSON()));
+   }
+
+   
+   @Test public void canBuildErlangMapOnlyJobWithSearch() throws JSONException {
+      MapReduceBuilder builder = new MapReduceBuilder();
+	  builder.setBucket("gumby");
+	  builder.setSearch("horse:pokey");
+      builder.map(new ErlangFunction("foo", "bar"), true);
+      
+      JSONObject expected = new JSONObject("{\"inputs\":{\"module\":\"riak_search\",\"function\":\"mapred_search\"," +
+                                           "\"arg\":[\"gumby\",\"horse:pokey\"]},\"query\":[{\"map\":{\"module\":\"foo\"," +
+                                           "\"language\":\"erlang\",\"keep\":true,\"function\":\"bar\"}}]}");
+      
+      assertTrue("Generated JSON not as expected", JSONEquals.equals(expected, builder.toJSON()));
+   }
+   
+   @Test public void canBuildErlangMapReduceJobWithSearch() throws JSONException {
+      MapReduceBuilder builder = new MapReduceBuilder();
+	  builder.setBucket("gumby");
+	  builder.setSearch("horse:pokey");
+      builder.map(new ErlangFunction("foo", "bar"), false);
+      builder.reduce(new ErlangFunction("baz", "quux"), true);
+      
+      JSONObject expected = new JSONObject("{\"inputs\":{\"module\":\"riak_search\",\"function\":\"mapred_search\"," +
+                                           "\"arg\":[\"gumby\",\"horse:pokey\"]},\"query\":[{\"map\":{\"module\":\"foo\"," +
                                            "\"language\":\"erlang\",\"keep\":false,\"function\":\"bar\"}}," +
                                            "{\"reduce\":{\"module\":\"baz\",\"language\":\"erlang\",\"keep\":true,\"function\":\"quux\"}}]}");
 


### PR DESCRIPTION
I needed to be able to use a Riak-Search query as an input to a map/reduce job.  This is supported by Riak, but had not yet been integrated into the Java version of the client.  So I went ahead and bit the bullet :)

For both the HTTP and PBC clients, I have added support to MapReduceBuilder to allow for a "setSearch" method.  This works collaboratively with "setBucket", but is mutually exclusive with objects or filters (much as objects and bucket were previously mutually exclusive).

I then added functionality to the HTTP RiakClient equivalent to the existing "mapReduceOverBucket" and "mapReduceOverObjects" - "mapReduceOverSearch" that takes a bucket and query string.

Finally I added unit tests for all of this functionality mirroring the unit test functionality that existed for other M/R functions.  One of the unit tests - the itest for PBC search - is currently set to be ignored because PBC does not appear able to modify a bucket schema to add the necessary post-commit hooks for search (but the test is there and does work if you manually "install" search on the bucket).

Thanks!

Casey
