### PR TITLE
Ensure map/reduce function argument is encoded and sent to server

### DIFF
--- a/src/main/java/com/basho/riak/client/query/MapReduce.java
+++ b/src/main/java/com/basho/riak/client/query/MapReduce.java
@@ -153,7 +153,11 @@ public abstract class MapReduce implements RiakOperation<MapReduceResult> {
                 switch (phase.getType()) {
                 case MAP:
                 case REDUCE:
-                    FunctionToJson.newWriter(((MapPhase) phase).getPhaseFunction(), jg).write();
+                    MapPhase mapPhase = (MapPhase)phase;
+                    FunctionToJson.newWriter(mapPhase.getPhaseFunction(), jg).write();
+                    if(mapPhase.getArg() != null) {
+                        jg.writeStringField("arg", mapPhase.getArg().toString());
+                    }
                     break;
                 case LINK:
                     jg.writeStringField("bucket", ((LinkPhase) phase).getBucket());

--- a/src/test/java/com/basho/riak/client/itest/ITestMapReduce.java
+++ b/src/test/java/com/basho/riak/client/itest/ITestMapReduce.java
@@ -280,6 +280,20 @@ public abstract class ITestMapReduce {
         }
     }
 
+    @Test public void doErlangMapReduce_notFound() throws RiakException {
+        MapReduceResult result = client.mapReduce()
+        .addInput(BUCKET_NAME, UUID.randomUUID().toString())
+        .addInput(BUCKET_NAME, UUID.randomUUID().toString())
+        .addInput(BUCKET_NAME, "java_1")
+        .addMapPhase(new NamedErlangFunction("riak_kv_mapreduce","map_object_value"), "filter_notfound")
+        .execute();
+
+        assertNotNull(result);
+        List<Integer> items = new LinkedList<Integer>(result.getResult(Integer.class));
+        assertEquals(1, items.size());
+        assertEquals(new Integer(1), items.get(0));
+    }
+
     /**
      * A JS function that will cause a m/r timeout
      * @return String of js sleep function


### PR DESCRIPTION
The optional argument to m/r fun was not being encoded to JSON and passed on to Riak. This pr fixes that.
