### PR TITLE
Add shutdown method to pb connection pool

### DIFF
--- a/src/main/java/com/basho/riak/client/raw/pbc/PBClusterClient.java
+++ b/src/main/java/com/basho/riak/client/raw/pbc/PBClusterClient.java
@@ -66,6 +66,7 @@ public class PBClusterClient extends ClusterClient<PBClientConfig> {
 
         for (PBClientConfig node : clusterConfig.getClients()) {
             final RiakConnectionPool hostPool = makePool(clusterSemaphore, node);
+            hostPool.start();
             clients.add(new PBClientAdapter(new RiakClient(hostPool)));
         }
         return clients.toArray(new RawClient[clients.size()]);

--- a/src/main/java/com/basho/riak/client/raw/pbc/PBRiakClientFactory.java
+++ b/src/main/java/com/basho/riak/client/raw/pbc/PBRiakClientFactory.java
@@ -69,6 +69,7 @@ public class PBRiakClientFactory implements RiakClientFactory {
                                                                conf.getSocketBufferSizeKb(),
                                                                conf.getIdleConnectionTTLMillis());
 
+        pool.start();
         return new PBClientAdapter(new RiakClient(pool));
     }
 }

--- a/src/main/java/com/basho/riak/pbc/RiakConnection.java
+++ b/src/main/java/com/basho/riak/pbc/RiakConnection.java
@@ -45,7 +45,7 @@ class RiakConnection {
 	 // Guarded by the intrinsic lock 'this'
 	 private byte[] clientId;
 
-    private long idleStart;
+    private volatile long idleStart;
 
 	public RiakConnection(InetAddress addr, int port, int bufferSizeKb, final RiakConnectionPool pool) throws IOException {
         this.pool = pool;
@@ -139,7 +139,7 @@ class RiakConnection {
 	    this.idleStart = System.nanoTime();
 	}
 	
-	public synchronized long getIdleStartTimeNanos() {
+	public long getIdleStartTimeNanos() {
        return this.idleStart;
     }
 	

--- a/src/test/java/com/basho/riak/pbc/itest/ITestRiakConnectionPool.java
+++ b/src/test/java/com/basho/riak/pbc/itest/ITestRiakConnectionPool.java
@@ -51,6 +51,7 @@ public class ITestRiakConnectionPool {
         byte[] clientId = new byte[] { 13, 45, 99, 2 };
         // create a pool
         final RiakConnectionPool pool = new RiakConnectionPool(0, 1, host, PORT, 1000, 16, 5000);
+        pool.start();
         // get a connection
         PublicRiakConnection wrapper = new PublicRiakConnection(pool.getConnection(clientId));
         // release it (but retain it, bwah ha ha)
@@ -59,6 +60,7 @@ public class ITestRiakConnectionPool {
         assertEquals(wrapper.getConn(), pool.getConnection(clientId));
 
         pool.releaseConnection(wrapper.getConn());
+        pool.shutdown();
     }
 
     /**
@@ -70,6 +72,7 @@ public class ITestRiakConnectionPool {
         byte[] clientId = new byte[] { 13, 45, 99, 2 };
         // create a pool
         final RiakConnectionPool pool = new RiakConnectionPool(1, 1, host, PORT, 1000, 16, 5000);
+        pool.start();
         // get a connection
         PublicRiakConnection wrapper = new PublicRiakConnection(pool.getConnection(clientId));
 
@@ -84,6 +87,7 @@ public class ITestRiakConnectionPool {
         PublicRiakConnection wrapper2 = new PublicRiakConnection(pool.getConnection(clientId));
         assertEquals(wrapper.getConn(), wrapper2.getConn());
         pool.releaseConnection(wrapper2.getConn());
+        pool.shutdown();
     }
 
     /**
@@ -109,6 +113,7 @@ public class ITestRiakConnectionPool {
         PublicRiakConnection wrapper2 = new PublicRiakConnection(pool.getConnection(clientId));
 
         assertNotSame(wrapper2.getConn(), wrapper.getConn());
+        pool.shutdown();
     }
 
     @Test public void conncurrentAcquire_toFewConnections() throws Exception {
@@ -151,6 +156,7 @@ public class ITestRiakConnectionPool {
         assertEquals("Wrong number of connections acquired", Math.min(numTasks, maxConnections), successCount);
         assertEquals("Wrong number of failed connection acquisitions", Math.max(0, numTasks - maxConnections),
                      failureCount);
+        pool.shutdown();
     }
 
     /**


### PR DESCRIPTION
Fix factories/tests that did not start up the pool before using
Fix tests to shutdown pool when finished
