### PR TITLE
Post-commit hooks are added to the pre-commit hook list ...

### DIFF
--- a/src/main/java/com/basho/riak/client/builders/BucketPropertiesBuilder.java
+++ b/src/main/java/com/basho/riak/client/builders/BucketPropertiesBuilder.java
@@ -128,7 +128,7 @@ public final class BucketPropertiesBuilder {
         if (this.postcommitHooks == null) {
             this.postcommitHooks = new ArrayList<NamedErlangFunction>();
         }
-        this.precommitHooks.add(postcommitHook);
+        this.postcommitHooks.add(postcommitHook);
         return this;
     }
 


### PR DESCRIPTION
This change fixes a bug in the Java client where all commit hooks are added to the pre-commit list; anything incoming in the post-commit list goes to the pre-commit hook list instead.

Bob Baker (sharecare.com)
