### PR TITLE
Fix broken from(Config) method in PB client config builder

### DIFF
--- a/src/main/java/com/basho/riak/client/raw/config/ClusterConfig.java
+++ b/src/main/java/com/basho/riak/client/raw/config/ClusterConfig.java
@@ -80,4 +80,27 @@ public abstract class ClusterConfig<T extends Configuration> implements Configur
     public synchronized List<T> getClients() {
         return Collections.unmodifiableList(nodes);
     }
+
+    /**
+     * Convenience method for creating a cluster of hosts with a common, default
+     * config except for host
+     * 
+     * @param hosts
+     *            var arg String array of hosts
+     * @return the {@link ClusterConfig} with a node for each host in
+     *         <code>hosts</code>
+     */
+    protected abstract ClusterConfig<T> addHosts(String... hosts);
+
+    /**
+     * Convenience method for creating a cluster of hosts with a common
+     * config except for host
+     * 
+     * @param config T the common base config
+     * @param hosts
+     *            var arg String array of hosts
+     * @return the {@link ClusterConfig} with a node for each host in
+     *         <code>hosts</code>
+     */
+    protected abstract ClusterConfig<T> addHosts(T config, String... hosts);
 }

--- a/src/main/java/com/basho/riak/client/raw/http/HTTPClusterConfig.java
+++ b/src/main/java/com/basho/riak/client/raw/http/HTTPClusterConfig.java
@@ -14,6 +14,7 @@
 package com.basho.riak.client.raw.http;
 
 import com.basho.riak.client.raw.config.ClusterConfig;
+import com.basho.riak.client.raw.http.HTTPClientConfig.Builder;
 
 /**
  * Concrete child of {@link ClusterConfig} that provides the generic type
@@ -30,4 +31,31 @@ public class HTTPClusterConfig extends ClusterConfig<HTTPClientConfig> {
         super(totalMaximumConnections);
     }
 
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * com.basho.riak.client.raw.config.ClusterConfig#forHosts(java.lang.String
+     * [])
+     */
+    @Override public ClusterConfig<HTTPClientConfig> addHosts(String... hosts) {
+        return addHosts(HTTPClientConfig.defaults(), hosts);
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * com.basho.riak.client.raw.config.ClusterConfig#forHosts(com.basho.riak
+     * .client.raw.config.Configuration, java.lang.String[])
+     */
+    @Override public ClusterConfig<HTTPClientConfig> addHosts(HTTPClientConfig config, String... hosts) {
+        Builder b = HTTPClientConfig.Builder.from(config);
+
+        for (String host : hosts) {
+            addClient(b.withHost(host).build());
+        }
+
+        return this;
+    }
 }

--- a/src/main/java/com/basho/riak/client/raw/pbc/PBClientConfig.java
+++ b/src/main/java/com/basho/riak/client/raw/pbc/PBClientConfig.java
@@ -201,7 +201,7 @@ public class PBClientConfig implements Configuration {
             b.initialPoolSize = copyConfig.initialPoolSize;
             b.idleConnectionTTLMillis = copyConfig.idleConnectionTTLMillis;
             b.connectionWaitTimeoutMillis = copyConfig.connectionWaitTimeoutMillis;
-            return new PBClientConfig.Builder();
+            return b;
         }
 
         public Builder withSocketBufferSizeKb(int socketBufferSizeKb) {

--- a/src/main/java/com/basho/riak/client/raw/pbc/PBClusterConfig.java
+++ b/src/main/java/com/basho/riak/client/raw/pbc/PBClusterConfig.java
@@ -14,6 +14,7 @@
 package com.basho.riak.client.raw.pbc;
 
 import com.basho.riak.client.raw.config.ClusterConfig;
+import com.basho.riak.client.raw.pbc.PBClientConfig.Builder;
 
 /**
  * {@link ClusterConfig} implementation that provides {@link PBClientConfig} as
@@ -29,6 +30,26 @@ public class PBClusterConfig extends ClusterConfig<PBClientConfig> {
      */
     public PBClusterConfig(int totalMaximumConnections) {
         super(totalMaximumConnections);
+    }
+
+    /* (non-Javadoc)
+     * @see com.basho.riak.client.raw.config.ClusterConfig#forHosts(java.lang.String[])
+     */
+    @Override public ClusterConfig<PBClientConfig> addHosts(String... hosts) {
+        return addHosts(PBClientConfig.defaults(), hosts);
+    }
+
+    /* (non-Javadoc)
+     * @see com.basho.riak.client.raw.config.ClusterConfig#forHosts(com.basho.riak.client.raw.config.Configuration, java.lang.String[])
+     */
+    @Override public ClusterConfig<PBClientConfig> addHosts(PBClientConfig config, String... hosts) {
+        Builder b = PBClientConfig.Builder.from(config);
+
+        for(String host : hosts) {
+            addClient(b.withHost(host).build());
+        }
+
+        return this;
     }
 
 }

--- a/src/test/java/com/basho/riak/client/raw/config/ClusterConfigTest.java
+++ b/src/test/java/com/basho/riak/client/raw/config/ClusterConfigTest.java
@@ -1,0 +1,104 @@
+/*
+ * This file is provided to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.basho.riak.client.raw.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.basho.riak.client.raw.pbc.PBClientConfig;
+import com.basho.riak.client.raw.pbc.PBClusterConfig;
+
+/**
+ * @author russell
+ * 
+ */
+public class ClusterConfigTest {
+
+    private static final String[] HOSTS = new String[] { "localhost", "remotehost1", "remotehost2" };
+
+    private PBClusterConfig clusterConfig;
+
+    /**
+     * @throws java.lang.Exception
+     */
+    @Before public void setUp() throws Exception {
+        clusterConfig = new PBClusterConfig(500);
+    }
+
+    /**
+     * Test method for
+     * {@link com.basho.riak.client.raw.config.ClusterConfig#addHosts(java.lang.String[])}
+     * .
+     */
+    @Test public void forHosts() {
+        PBClientConfig config = PBClientConfig.defaults();
+
+        clusterConfig.addHosts(HOSTS);
+
+        List<PBClientConfig> clientConfigs = clusterConfig.getClients();
+        assertEquals("Expected 3 client configs", 3, clientConfigs.size());
+
+        List<String> clientHosts = new ArrayList<String>();
+
+        for (PBClientConfig pbc : clusterConfig.getClients()) {
+            clientHosts.add(pbc.getHost());
+            configsEqual(config, pbc);
+        }
+
+        assertTrue("Expected an entry per host", clientHosts.containsAll(Arrays.asList(HOSTS)));
+    }
+
+    /**
+     * Test method for
+     * {@link com.basho.riak.client.raw.config.ClusterConfig#addHosts(com.basho.riak.client.raw.config.Configuration, java.lang.String[])}
+     * .
+     */
+    @Test public void forHostsWithConfig() {
+        PBClientConfig config = new PBClientConfig.Builder()
+                   .withConnectionTimeoutMillis(50000)
+                   .withPoolSize(10)
+                   .withPort(999)
+               .build();
+
+        clusterConfig.addHosts(config, HOSTS);
+
+        List<PBClientConfig> clientConfigs = clusterConfig.getClients();
+        assertEquals("Expected 3 client configs", 3, clientConfigs.size());
+
+        List<String> clientHosts = new ArrayList<String>();
+
+        for (PBClientConfig pbc : clusterConfig.getClients()) {
+            clientHosts.add(pbc.getHost());
+            configsEqual(config, pbc);
+        }
+
+        assertTrue("Expected an entry per host", clientHosts.containsAll(Arrays.asList(HOSTS)));
+    }
+
+    private void configsEqual(PBClientConfig config, PBClientConfig config2) {
+        assertEquals(config.getConnectionWaitTimeoutMillis(), config2.getConnectionWaitTimeoutMillis());
+        assertEquals(config.getIdleConnectionTTLMillis(), config2.getIdleConnectionTTLMillis());
+        assertEquals(config.getInitialPoolSize(), config2.getInitialPoolSize());
+        assertEquals(config.getPoolSize(), config2.getPoolSize());
+        assertEquals(config.getPort(), config2.getPort());
+        assertEquals(config.getSocketBufferSizeKb(), config2.getSocketBufferSizeKb());
+    }
+}


### PR DESCRIPTION
Add tests for same.
Add convenience method to ClusterConfig for using 1 config across
many hosts.
