### PR TITLE
Bump jackson to 1.9.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,12 +75,12 @@
 		<dependency>
 			<groupId>org.codehaus.jackson</groupId>
 			<artifactId>jackson-core-asl</artifactId>
-			<version>1.7.5</version>
+			<version>1.9.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.codehaus.jackson</groupId>
 			<artifactId>jackson-mapper-asl</artifactId>
-			<version>1.7.5</version>
+			<version>1.9.2</version>
 		</dependency>
 		<!-- Testing -->
 		<dependency>


### PR DESCRIPTION
While working on a Clojure library for Riak I ran into a dependency that needed the latest stable release of jackson, but now it's at conflict with riak-java-client's dependencies.

I'll admit to not knowing a lot about JVM dependencies/libraries/versioning... but all tests seem to pass. Thoughts?
