### PR TITLE
Add Riak Java client to travis-ci.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: java
 notifications:
+  # Email notifications are disabled to not annoy anybody.
+  # See http://about.travis-ci.org/docs/user/build-configuration/ to learn more
+  # about configuring notification recipients and more.
   email: false


### PR DESCRIPTION
We are preparing to ship Java, Scala and Groovy support on [travis-ci.org](http://travis-ci.org), so per discussion with @seancribbs, I've added .travis.yml for Riak Java client (Sean [has been using travis for Ripple](http://travis-ci.org/#!/seancribbs/ripple) for a while now). It has email notifications disabled to be on the safe side. Please feel free to [list notifications recipients or add IRC notifications](http://about.travis-ci.org/docs/user/build-configuration/) via .travis.yml.

_Before_ you merge this pull request, you'll need to [enable GitHub hook](http://about.travis-ci.org/docs/user/how-to-setup-and-trigger-the-hook-manually/), then merge and it will trigger initial build.

To see what it looks like, see [my fork on travis](http://travis-ci.org/#!/michaelklishin/riak-java-client). If you need an introduction to Travis, please take a look at [our documentation site](http://about.travis-ci.org/) and [Getting Started guide](http://about.travis-ci.org/docs/user/getting-started/).

We are in #travis on freenode.net if you have any questions. Thank you.
