### PR TITLE
The WriteBucket constructor that takes an existing Bucket as a parameter...

### DIFF
--- a/src/main/java/com/basho/riak/client/bucket/WriteBucket.java
+++ b/src/main/java/com/basho/riak/client/bucket/WriteBucket.java
@@ -87,6 +87,10 @@ public class WriteBucket implements RiakOperation<Bucket> {
         this.retrier = retrier;
         this.precommitHooks = bucket.getPrecommitHooks();
         this.postcommitHooks = bucket.getPostcommitHooks();
+        
+        // replace the default builder with one using the properties from the 
+        // bucket that was passed in.
+        builder = BucketPropertiesBuilder.from(bucket);
     }
 
     /**


### PR DESCRIPTION
I noticed the WriteBucket constructor that takes an existing Bucket as a parameter wasn't copying over the BucketProperties from that Bucket. This fixes that. 
