### PR TITLE
T46 lazy bucket properties

### DIFF
--- a/src/main/java/com/basho/riak/client/bucket/FetchBucket.java
+++ b/src/main/java/com/basho/riak/client/bucket/FetchBucket.java
@@ -105,6 +105,7 @@ public class FetchBucket implements RiakOperation<Bucket> {
      * called then they are never retrieved.
      * </p>
      * @return this 
+     * @since 1.0.4
      */
     public FetchBucket lazyLoadBucketProperties() {
         this.lazyLoadProperties = true;

--- a/src/main/java/com/basho/riak/client/bucket/LazyBucketProperties.java
+++ b/src/main/java/com/basho/riak/client/bucket/LazyBucketProperties.java
@@ -32,6 +32,7 @@ import com.basho.riak.client.raw.RawClient;
  *
  * 
  * @author roach
+ * @since 1.0.4
  */
 public class LazyBucketProperties implements BucketProperties {
 

--- a/src/main/java/com/basho/riak/client/bucket/WriteBucket.java
+++ b/src/main/java/com/basho/riak/client/bucket/WriteBucket.java
@@ -551,6 +551,7 @@ public class WriteBucket implements RiakOperation<Bucket> {
      * called then they are never retrieved.
      * </p>
      * @return this 
+     * @since 1.0.4
      */
     public WriteBucket lazyLoadBucketProperties() {
         this.lazyLoadProperties = true;

--- a/src/test/java/com/basho/riak/client/AllTests.java
+++ b/src/test/java/com/basho/riak/client/AllTests.java
@@ -29,6 +29,7 @@ import org.junit.runner.notification.RunListener;
 import org.junit.runners.Suite;
 
 import com.basho.riak.client.bucket.Bucket;
+import com.basho.riak.client.bucket.LazyBucketPropertiesTest;
 import com.basho.riak.client.bucket.WriteBucketTest;
 import com.basho.riak.client.cap.ClobberMutationTest;
 import com.basho.riak.client.cap.QuoraTest;
@@ -192,6 +193,7 @@ import com.basho.riak.pbc.itest.ITestRiakConnectionPool;
     UnmodifiableIteratorTest.class,
     UsermetaConverterTest.class,
     WriteBucketTest.class,
+    LazyBucketPropertiesTest.class,
     com.basho.riak.client.itest.ITestMapReduceHTTP.class,
     com.basho.riak.client.itest.ITestMapReducePB.class})
 public class AllTests {


### PR DESCRIPTION
Allows the deferral of the buck properties fetch from Riak until (if) it's required.
