### PR TITLE
There was a bug in the HTTPClientConfig.Builder that was causing a probl...

### DIFF
--- a/src/main/java/com/basho/riak/client/raw/http/HTTPClientConfig.java
+++ b/src/main/java/com/basho/riak/client/raw/http/HTTPClientConfig.java
@@ -199,7 +199,6 @@ public class HTTPClientConfig implements Configuration {
          * @return a {@link HTTPClientConfig}
          */
         public HTTPClientConfig build() {
-           
             String builderUrl = url;
             if (builderUrl == null) {
                 StringBuilder sb = new StringBuilder(scheme).append("://").append(host).append(":").append(port);
@@ -236,16 +235,13 @@ public class HTTPClientConfig implements Configuration {
             // In order to allow you to change the host or port through the 
             // the builder when we're starting from an existing config, 
             // we need to parse them out (and not copy the existing url).
-            if (copyConfig.url != null)
-            {
+            if (copyConfig.url != null) {
                 Pattern p = Pattern.compile("//(.*):(\\d+)/");
                 Matcher m = p.matcher(copyConfig.url);
-                if (m.find())
-                {
+                if (m.find()) {
                     b.host = m.group(1);
                     b.port = Integer.parseInt(m.group(2));
                 }
-                
             }
             
             return b;


### PR DESCRIPTION
There was a bug in the HTTPClientConfig.Builder that was causing a problem with creating a HTTPClusterClient

If you supplied an existing HTTPClientConfig to the builder it would copy the URL - at that point calling the withHost() or withPort() methods would not produce a change because having already set the URL took precedence. 

A second problem was that even if you hadn't set the URL, calling build() did set it. This causes a problem if you were attempting to use the builder to construct multiple HTTPClients with different hosts and/or ports (as was the case with HTTPClusterClient) - you end up with all the HTTPClients having the same URL

I corrected this by parsing out the host and port from the URL if you passed in an existing config to the builder while at the same time not copying the URL. I also changed build() to not set the URL internally but rather construct it every time if the URL hasn't already been explicitly set (to preserve the existing precedence rules)

The HTTPClusterClient.addHosts() methods now work correctly. 
