### PR TITLE
public fields without getters annotated with Riak annotations are now excluded from JSON serialization

### DIFF
--- a/src/main/java/com/basho/riak/client/convert/RiakBeanSerializerModifier.java
+++ b/src/main/java/com/basho/riak/client/convert/RiakBeanSerializerModifier.java
@@ -13,6 +13,7 @@
  */
 package com.basho.riak.client.convert;
 
+import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Field;
 import java.util.LinkedList;
 import java.util.List;
@@ -81,9 +82,10 @@ public class RiakBeanSerializerModifier extends BeanSerializerModifier {
         RiakLinks links = null;
         AnnotatedMember member = beanPropertyWriter.getMember();
         if (member instanceof AnnotatedField) {
-            key = beanPropertyWriter.getAnnotation(RiakKey.class);
-            usermeta = beanPropertyWriter.getAnnotation(RiakUsermeta.class);
-            links = beanPropertyWriter.getAnnotation(RiakLinks.class);
+            AnnotatedElement element = member.getAnnotated();
+            key = element.getAnnotation(RiakKey.class);
+            usermeta = element.getAnnotation(RiakUsermeta.class);
+            links = element.getAnnotation(RiakLinks.class);
         } else {
             @SuppressWarnings("rawtypes") Class clazz = member.getDeclaringClass();
             Field field;

--- a/src/test/java/com/basho/riak/client/convert/RiakBeanSerializerModifierTest.java
+++ b/src/test/java/com/basho/riak/client/convert/RiakBeanSerializerModifierTest.java
@@ -41,6 +41,16 @@ public class RiakBeanSerializerModifierTest {
         assertEquals(2, map.size());
         assertTrue(map.containsKey("someField"));
         assertTrue(map.containsKey("someOtherField"));
+        
+        RiakAnnotatedClassWithPublicFields racwpf = new RiakAnnotatedClassWithPublicFields();
+
+        json = mapper.writeValueAsString(racwpf);
+
+        map = mapper.readValue(json, Map.class);
+
+        assertEquals(2, map.size());
+        assertTrue(map.containsKey("someField"));
+        assertTrue(map.containsKey("someOtherField"));
     }
 
     @SuppressWarnings("unused") private static final class RiakAnnotatedClass {
@@ -74,6 +84,15 @@ public class RiakBeanSerializerModifierTest {
         public String getMetaValueField() {
             return metaValueField;
         }
+    }
+
+    @SuppressWarnings("unused") private static final class RiakAnnotatedClassWithPublicFields {
+        @RiakKey public String keyField = "key";
+        @RiakUsermeta(key = "metaKey1") public String metaValueField = "ONE";
+        @RiakUsermeta public Map<String, String> usermeta = new HashMap<String, String>();
+
+        public String someField = "TWO";
+        public String someOtherField = "THREE";
     }
 
 }


### PR DESCRIPTION
Jackson prefers getters for serialization. Our code acted correctly when that was the case and the getter was for a Riak annotated field. 

In the absence of a getter, we had a bug where we were not looking for our annotations in the right place (in the Jackson API). This PR fixes that and will now properly exclude our fields. A test is included. 
