### PR TITLE
Adjusted the annotation processing

### DIFF
--- a/src/test/java/com/basho/riak/client/convert/RiakBeanSerializerModifierTest.java
+++ b/src/test/java/com/basho/riak/client/convert/RiakBeanSerializerModifierTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.codehaus.jackson.annotate.JsonProperty;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.Test;
 
@@ -51,6 +52,20 @@ public class RiakBeanSerializerModifierTest {
         assertEquals(2, map.size());
         assertTrue(map.containsKey("someField"));
         assertTrue(map.containsKey("someOtherField"));
+		
+        // Test the combination of a Riak annotation and the Jackson @JsonProperty
+        RiakAnnotatedClassWithJsonProp racwjp = new RiakAnnotatedClassWithJsonProp();
+        json = mapper.writeValueAsString(racwjp);
+
+        map = mapper.readValue(json, Map.class);
+
+        assertEquals(4, map.size());
+        assertTrue(map.containsKey("keyField"));
+        assertTrue(map.containsKey("metaValueField"));
+        assertTrue(map.containsKey("someField"));
+        assertTrue(map.containsKey("someOtherField"));
+		
+		
     }
 
     @SuppressWarnings("unused") private static final class RiakAnnotatedClass {
@@ -95,4 +110,20 @@ public class RiakBeanSerializerModifierTest {
         public String someOtherField = "THREE";
     }
 
+	@SuppressWarnings("unused") private static final class RiakAnnotatedClassWithJsonProp {
+        @JsonProperty
+		@RiakKey private String keyField = "key";
+        @JsonProperty
+		@RiakUsermeta(key = "metaKey1") public String metaValueField = "ONE";
+        @RiakUsermeta public Map<String, String> usermeta = new HashMap<String, String>();
+
+        public String someField = "TWO";
+        public String someOtherField = "THREE";
+
+        public String getKeyField() {
+            return keyField;
+        }
+
+    }
+	
 }


### PR DESCRIPTION
Adjusted the annotation processing to allow a @RiakKey to be included in the JSON serialization if it is also annotated with the Jackson @JsonProperty. Test case is included
