### PR TITLE
Added read/write timeout to PB client

### DIFF
--- a/src/main/java/com/basho/riak/client/raw/pbc/PBClientConfig.java
+++ b/src/main/java/com/basho/riak/client/raw/pbc/PBClientConfig.java
@@ -31,6 +31,7 @@ public class PBClientConfig implements Configuration {
     private final int initialPoolSize;
     private final long idleConnectionTTLMillis;
     private final long connectionWaitTimeoutMillis;
+    private final int requestTimeoutMillis;
 
     /**
      * Creates a new {@link PBClientConfig} instance. Use the {@link Builder}
@@ -54,9 +55,12 @@ public class PBClientConfig implements Configuration {
      * @param connectionWaitTimeoutMillis
      *            How many milliseconds to block trying to obtain a connection
      *            from the pool before failing
+     * @param requestTimeoutMillis 
+     *            How many milliseconds to block/wait trying to read/write from/to
+     *            a connection (This is the SO_TIMEOUT parameter on the Socket)
      */
     private PBClientConfig(int socketBufferSizeKb, String host, int port, int poolSize, int initialPoolSize,
-            long idleConnectionTTLMillis, long connectionWaitTimeoutMillis) {
+            long idleConnectionTTLMillis, long connectionWaitTimeoutMillis, int requestTimeoutMillis) {
         this.socketBufferSizeKb = socketBufferSizeKb;
         this.host = host;
         this.port = port;
@@ -64,6 +68,7 @@ public class PBClientConfig implements Configuration {
         this.initialPoolSize = initialPoolSize;
         this.idleConnectionTTLMillis = idleConnectionTTLMillis;
         this.connectionWaitTimeoutMillis = connectionWaitTimeoutMillis;
+        this.requestTimeoutMillis = requestTimeoutMillis;
     }
 
     /**
@@ -127,6 +132,15 @@ public class PBClientConfig implements Configuration {
     public long getConnectionWaitTimeoutMillis() {
         return connectionWaitTimeoutMillis;
     }
+    
+    /**
+     * @return the how long to wait/block (in milliseconds) when reading/writing 
+     *         from/to a connection. Note that the default 0 is no timeout
+     */
+    
+    public int getRequestTimeoutMillis() {
+        return requestTimeoutMillis;
+    }
 
     /**
      * Builder for the {@link PBClientConfig} Has the following default values:
@@ -165,6 +179,10 @@ public class PBClientConfig implements Configuration {
      * <td>1000 (if a connection cannot be acquired within this time and
      * exception is thrown)</td>
      * </tr>
+     * <tr>
+     * <td>requestTimeoutMillis</td>
+     * <td>0 (no timeout)</td>
+     * </tr>
      * </table>
      * 
      * @author russell
@@ -177,10 +195,12 @@ public class PBClientConfig implements Configuration {
         private int initialPoolSize = 0;
         private long idleConnectionTTLMillis = 1000;
         private long connectionWaitTimeoutMillis = 1000;
+        private int requestTimeoutMillis = 0;
 
         public PBClientConfig build() {
             return new PBClientConfig(socketBufferSizeKb, host, port, poolSize, initialPoolSize,
-                                      idleConnectionTTLMillis, connectionWaitTimeoutMillis);
+                                      idleConnectionTTLMillis, connectionWaitTimeoutMillis, 
+                                      requestTimeoutMillis );
         }
 
         /**
@@ -201,6 +221,7 @@ public class PBClientConfig implements Configuration {
             b.initialPoolSize = copyConfig.initialPoolSize;
             b.idleConnectionTTLMillis = copyConfig.idleConnectionTTLMillis;
             b.connectionWaitTimeoutMillis = copyConfig.connectionWaitTimeoutMillis;
+            b.requestTimeoutMillis = copyConfig.requestTimeoutMillis;
             return b;
         }
 
@@ -238,5 +259,11 @@ public class PBClientConfig implements Configuration {
             this.connectionWaitTimeoutMillis = connectionTimeoutMillis;
             return this;
         }
+        
+        public Builder withRequestTimeoutMillis(int requestTimeoutMillis) {
+            this.requestTimeoutMillis = requestTimeoutMillis;
+            return this;
+        }
+        
     }
 }

--- a/src/main/java/com/basho/riak/client/raw/pbc/PBClusterClient.java
+++ b/src/main/java/com/basho/riak/client/raw/pbc/PBClusterClient.java
@@ -88,13 +88,15 @@ public class PBClusterClient extends ClusterClient<PBClientConfig> {
             pool = new RiakConnectionPool(node.getInitialPoolSize(), node.getPoolSize(),
                                           InetAddress.getByName(node.getHost()), node.getPort(),
                                           node.getConnectionWaitTimeoutMillis(), node.getSocketBufferSizeKb(),
-                                          node.getIdleConnectionTTLMillis());
+                                          node.getIdleConnectionTTLMillis(),
+                                          node.getRequestTimeoutMillis());
         } else {
             pool = new RiakConnectionPool(node.getInitialPoolSize(), new PoolSemaphore(clusterSemaphore,
                                                                                        node.getPoolSize()),
                                           InetAddress.getByName(node.getHost()), node.getPort(),
                                           node.getConnectionWaitTimeoutMillis(), node.getSocketBufferSizeKb(),
-                                          node.getIdleConnectionTTLMillis());
+                                          node.getIdleConnectionTTLMillis(),
+                                          node.getRequestTimeoutMillis());
         }
         return pool;
     }

--- a/src/main/java/com/basho/riak/client/raw/pbc/PBRiakClientFactory.java
+++ b/src/main/java/com/basho/riak/client/raw/pbc/PBRiakClientFactory.java
@@ -67,7 +67,8 @@ public class PBRiakClientFactory implements RiakClientFactory {
                                                                hostAddress, conf.getPort(),
                                                                conf.getConnectionWaitTimeoutMillis(),
                                                                conf.getSocketBufferSizeKb(),
-                                                               conf.getIdleConnectionTTLMillis());
+                                                               conf.getIdleConnectionTTLMillis(),
+                                                               conf.getRequestTimeoutMillis());
 
         pool.start();
         return new PBClientAdapter(new RiakClient(pool));

--- a/src/main/java/com/basho/riak/pbc/RiakClient.java
+++ b/src/main/java/com/basho/riak/pbc/RiakClient.java
@@ -86,12 +86,12 @@ public class RiakClient implements RiakMessageCodes {
 	}
 
 	public RiakClient(InetAddress addr, int port) throws IOException {
-		this.pool = new RiakConnectionPool(0, RiakConnectionPool.LIMITLESS, addr, port, 1000, BUFFER_SIZE_KB, 1000);
+		this.pool = new RiakConnectionPool(0, RiakConnectionPool.LIMITLESS, addr, port, 1000, BUFFER_SIZE_KB, 1000,0);
 		this.pool.start();
 	}
 
 	public RiakClient(String host, int port, int bufferSizeKb)  throws IOException {
-	    this.pool = new RiakConnectionPool(0, RiakConnectionPool.LIMITLESS, InetAddress.getByName(host), port, 1000, bufferSizeKb, 1000);
+	    this.pool = new RiakConnectionPool(0, RiakConnectionPool.LIMITLESS, InetAddress.getByName(host), port, 1000, bufferSizeKb, 1000,0);
 	    this.pool.start();
 	}
 

--- a/src/main/java/com/basho/riak/pbc/RiakConnectionPool.java
+++ b/src/main/java/com/basho/riak/pbc/RiakConnectionPool.java
@@ -138,6 +138,7 @@ public class RiakConnectionPool {
     private final int bufferSizeKb;
     private final int initialSize;
     private final long idleConnectionTTLNanos;
+    private final int requestTimeoutMillis;
     private final ScheduledExecutorService idleReaper;
     private final ScheduledExecutorService shutdownExecutor;
     // what state the pool is in (see enum State)
@@ -165,13 +166,17 @@ public class RiakConnectionPool {
      * @param idleConnectionTTLMillis
      *            How long for an idle connection to exist before it is reaped,
      *            0 mean forever
+     * @param requestTimeoutMillis 
+     *            The SO_TIMEOUT flag on the socket; read/write timeout
+     *            0 means forever
      * @throws IOException
      *             If the initial connection creation throws an IOException
      */
     public RiakConnectionPool(int initialSize, int maxSize, InetAddress host, int port,
-            long connectionWaitTimeoutMillis, int bufferSizeKb, long idleConnectionTTLMillis) throws IOException {
+            long connectionWaitTimeoutMillis, int bufferSizeKb, long idleConnectionTTLMillis,
+            int requestTimeoutMillis) throws IOException {
         this(initialSize, getSemaphore(maxSize), host, port, connectionWaitTimeoutMillis, bufferSizeKb,
-             idleConnectionTTLMillis);
+             idleConnectionTTLMillis, requestTimeoutMillis);
 
         if (initialSize > maxSize && (maxSize > 0)) {
             state = State.SHUTTING_DOWN;
@@ -200,11 +205,15 @@ public class RiakConnectionPool {
      * @param idleConnectionTTLMillis
      *            How long for an idle connection to exist before it is reaped,
      *            0 mean forever
+     * @param requestTimeoutMillis 
+     *            The SO_TIMEOUT flag on the socket; read/write timeout
+     *            0 means forever
      * @throws IOException
      *             If the initial connection creation throws an IOException
      */
     public RiakConnectionPool(int initialSize, Semaphore poolSemaphore, InetAddress host, int port,
-            long connectionWaitTimeoutMillis, int bufferSizeKb, long idleConnectionTTLMillis) throws IOException {
+            long connectionWaitTimeoutMillis, int bufferSizeKb, long idleConnectionTTLMillis,
+            int requestTimeoutMillis) throws IOException {
         this.permits = poolSemaphore;
         this.available = new ConcurrentLinkedQueue<RiakConnection>();
         this.inUse = new ConcurrentLinkedQueue<RiakConnection>();
@@ -212,6 +221,7 @@ public class RiakConnectionPool {
         this.host = host;
         this.port = port;
         this.connectionWaitTimeoutNanos = TimeUnit.NANOSECONDS.convert(connectionWaitTimeoutMillis, TimeUnit.MILLISECONDS);
+        this.requestTimeoutMillis = requestTimeoutMillis;
         this.initialSize = initialSize;
         this.idleConnectionTTLNanos = TimeUnit.NANOSECONDS.convert(idleConnectionTTLMillis, TimeUnit.MILLISECONDS);
         this.idleReaper = Executors.newScheduledThreadPool(1);
@@ -282,7 +292,10 @@ public class RiakConnectionPool {
     private void warmUp() throws IOException {
         if (permits.tryAcquire(initialSize)) {
             for (int i = 0; i < this.initialSize; i++) {
-                available.add(new RiakConnection(this.host, this.port, this.bufferSizeKb, this));
+                available.add(new RiakConnection(this.host, this.port, 
+                    this.bufferSizeKb, this, 
+                    TimeUnit.MILLISECONDS.convert(connectionWaitTimeoutNanos, TimeUnit.NANOSECONDS), 
+                    requestTimeoutMillis));
             }
         } else {
             throw new RuntimeException("Unable to create initial connections");
@@ -375,7 +388,7 @@ public class RiakConnectionPool {
         try {
             if (permits.tryAcquire(connectionWaitTimeoutNanos, TimeUnit.NANOSECONDS)) {
                 try {
-                    return new RiakConnection(host, port, bufferSizeKb, this, TimeUnit.MILLISECONDS.convert(connectionWaitTimeoutNanos, TimeUnit.NANOSECONDS));
+                    return new RiakConnection(host, port, bufferSizeKb, this, TimeUnit.MILLISECONDS.convert(connectionWaitTimeoutNanos, TimeUnit.NANOSECONDS), requestTimeoutMillis);
                 } catch(SocketTimeoutException e) {
                     throw new AcquireConnectionTimeoutException("timeout from socket connection " + e.getMessage());
                 } catch (IOException e) {

--- a/src/test/java/com/basho/riak/pbc/itest/ITestRiakConnectionPool.java
+++ b/src/test/java/com/basho/riak/pbc/itest/ITestRiakConnectionPool.java
@@ -59,7 +59,7 @@ public class ITestRiakConnectionPool {
         final InetAddress host = InetAddress.getByName(HOST);
         byte[] clientId = new byte[] { 13, 45, 99, 2 };
         // create a pool
-        final RiakConnectionPool pool = new RiakConnectionPool(0, 1, host, PORT, 1000, 16, 5000);
+        final RiakConnectionPool pool = new RiakConnectionPool(0, 1, host, PORT, 1000, 16, 5000, 0);
         pool.start();
         // get a connection
         PublicRiakConnection wrapper = new PublicRiakConnection(pool.getConnection(clientId));
@@ -80,7 +80,7 @@ public class ITestRiakConnectionPool {
         final InetAddress host = InetAddress.getByName(HOST);
         byte[] clientId = new byte[] { 13, 45, 99, 2 };
         // create a pool
-        final RiakConnectionPool pool = new RiakConnectionPool(1, 1, host, PORT, 1000, 16, 5000);
+        final RiakConnectionPool pool = new RiakConnectionPool(1, 1, host, PORT, 1000, 16, 5000, 0);
         pool.start();
         // get a connection
         PublicRiakConnection wrapper = new PublicRiakConnection(pool.getConnection(clientId));
@@ -108,7 +108,7 @@ public class ITestRiakConnectionPool {
         byte[] clientId = new byte[] { 13, 45, 99, 2 };
         final int reapTime = 500;
         // create a pool
-        final RiakConnectionPool pool = new RiakConnectionPool(1, 1, host, PORT, 1000, 16, reapTime);
+        final RiakConnectionPool pool = new RiakConnectionPool(1, 1, host, PORT, 1000, 16, reapTime, 0);
         pool.start();
         // get a connection
         PublicRiakConnection wrapper = new PublicRiakConnection(pool.getConnection(clientId));
@@ -157,7 +157,7 @@ public class ITestRiakConnectionPool {
     private void doConcurrentAcquire(int numTasks, int maxConnections) throws Exception {
         final InetAddress host = InetAddress.getByName(HOST);
         // create a pool
-        final RiakConnectionPool pool = new RiakConnectionPool(0, maxConnections, host, PORT, 1000, 16, 0);
+        final RiakConnectionPool pool = new RiakConnectionPool(0, maxConnections, host, PORT, 1000, 16, 0, 0);
         pool.start();
 
         Collection<Future<PublicRiakConnection>> results = Executors.newFixedThreadPool(numTasks).invokeAll(makeTasks(numTasks,
@@ -210,7 +210,7 @@ public class ITestRiakConnectionPool {
 
     @Test public void shutDownWorksAfterError() throws Exception {
         final InetAddress host = InetAddress.getByName(HOST);
-        final RiakConnectionPool pool = new RiakConnectionPool(0, 10, host, PORT, 1000, 16, 5000);
+        final RiakConnectionPool pool = new RiakConnectionPool(0, 10, host, PORT, 1000, 16, 5000, 0);
         pool.start();
 
         assertEquals("RUNNING", pool.getPoolState());
@@ -238,7 +238,7 @@ public class ITestRiakConnectionPool {
 
     @Test public void shutdownWorksAfterSuccessfulMapReduce() throws Exception {
         final InetAddress host = InetAddress.getByName(HOST);
-        final RiakConnectionPool pool = new RiakConnectionPool(0, 10, host, PORT, 1000, 16, 5000);
+        final RiakConnectionPool pool = new RiakConnectionPool(0, 10, host, PORT, 1000, 16, 5000, 0);
         pool.start();
         assertEquals("RUNNING", pool.getPoolState());
         RiakClient delegate = new RiakClient(pool);


### PR DESCRIPTION
Builder has new option withRequestTimeout(iint milliseconds)
This is passed down into the original PB client and its connection
pool.
read/write timeout will now occur and throw exception up the stack

closes #138 issue
