### PR TITLE
Added getter to expose the Jackson ObjectMapper in JSONConverter

### DIFF
--- a/src/main/java/com/basho/riak/client/convert/JSONConverter.java
+++ b/src/main/java/com/basho/riak/client/convert/JSONConverter.java
@@ -159,4 +159,13 @@ public class JSONConverter<T> implements Converter<T> {
             throw new ConversionException(e);
         }
     }
+    
+    /**
+     * Returns the {@link ObjectMapper} being used.
+     * This is a convenience method to allow changing its behavior.
+     * @return The Jackson ObjectMapper
+     */
+    public ObjectMapper getObjectMapper() {
+        return objectMapper;
+    }
 }


### PR DESCRIPTION
Small change per a customer request. 

Allows you to get the Jackson ObjectMapper from the JSONConverter
