### PR TITLE
Date speedup

### DIFF
--- a/src/main/java/com/basho/riak/client/RiakObject.java
+++ b/src/main/java/com/basho/riak/client/RiakObject.java
@@ -29,8 +29,6 @@ import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.entity.AbstractHttpEntity;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.InputStreamEntity;
-import org.apache.http.impl.cookie.DateParseException;
-import org.apache.http.impl.cookie.DateUtils;
 
 import com.basho.riak.client.http.util.ClientUtils;
 import com.basho.riak.client.request.RequestMeta;
@@ -573,11 +571,7 @@ public class RiakObject {
      * object. Returns null if header is null, malformed, or cannot be parsed.
      */
     public Date getLastmodAsDate() {
-        try {
-            return DateUtils.parseDate(lastmod);
-        } catch (DateParseException e) {
-            return null;
-        }
+        return ClientUtils.parseDate(lastmod);
     }
 
     /**

--- a/src/main/java/com/basho/riak/client/http/RiakObject.java
+++ b/src/main/java/com/basho/riak/client/http/RiakObject.java
@@ -30,10 +30,7 @@ import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.entity.AbstractHttpEntity;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.InputStreamEntity;
-import org.apache.http.impl.cookie.DateParseException;
-import org.apache.http.impl.cookie.DateUtils;
 
-import com.basho.riak.client.http.RiakClient;
 import com.basho.riak.client.http.request.RequestMeta;
 import com.basho.riak.client.http.request.RiakWalkSpec;
 import com.basho.riak.client.http.response.FetchResponse;
@@ -609,11 +606,7 @@ public class RiakObject {
      * @see com.basho.riak.client.HttpRiakObject#getLastmodAsDate()
      */
     public Date getLastmodAsDate() {
-        try {
-            return DateUtils.parseDate(lastmod);
-        } catch (DateParseException e) {
-            return null;
-        }
+        return ClientUtils.parseDate(lastmod);
     }
 
     /* (non-Javadoc)

--- a/src/main/java/com/basho/riak/client/http/util/ClientUtils.java
+++ b/src/main/java/com/basho/riak/client/http/util/ClientUtils.java
@@ -21,6 +21,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -36,6 +37,8 @@ import org.apache.http.client.params.AllClientPNames;
 import org.apache.http.conn.ClientConnectionManager;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.impl.conn.tsccm.ThreadSafeClientConnManager;
+import org.apache.http.impl.cookie.DateParseException;
+import org.apache.http.impl.cookie.DateUtils;
 import org.apache.http.params.HttpParams;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -57,6 +60,9 @@ import com.basho.riak.client.util.CharsetUtils;
 public class ClientUtils {
 
     private static final String COMMA = ",";
+    private static final String[] DATE_FORMATS = new String[] {
+            DateUtils.PATTERN_RFC1123, DateUtils.PATTERN_RFC1036, DateUtils.PATTERN_ASCTIME };
+
     // Matches the scheme, host and port of a URL
     private static String URL_PATH_MASK = "^(?:[A-Za-z0-9+-\\.]+://)?[^/]*";
     private static Random rng = new Random();
@@ -577,6 +583,14 @@ public class ClientUtils {
             return tmp.toByteArray();
         } catch (IOException e) {
             throw new RiakIORuntimeException(e);
+        }
+    }
+
+    public static Date parseDate(String date) {
+        try {
+            return DateUtils.parseDate(date, DATE_FORMATS);
+        } catch (DateParseException e) {
+            return null;
         }
     }
 }

--- a/src/main/java/com/basho/riak/client/raw/pbc/ConversionUtil.java
+++ b/src/main/java/com/basho/riak/client/raw/pbc/ConversionUtil.java
@@ -29,8 +29,7 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
-import org.apache.http.impl.cookie.DateParseException;
-import org.apache.http.impl.cookie.DateUtils;
+import com.basho.riak.client.http.util.ClientUtils;
 
 import com.basho.riak.client.IRiakObject;
 import com.basho.riak.client.RiakLink;
@@ -430,12 +429,9 @@ public final class ConversionUtil {
             b.withContentType(contentType);
             b.withVtag((String) meta.get("X-Riak-VTag"));
 
-            try {
-                Date lastModDate = DateUtils.parseDate((String) meta.get("X-Riak-Last-Modified"));
+            Date lastModDate = ClientUtils.parseDate((String) meta.get("X-Riak-Last-Modified"));
+            if (lastModDate != null)
                 b.withLastModified(lastModDate.getTime());
-            } catch (DateParseException e) {
-                // NO-OP
-            }
 
             List<List<String>> links = (List<List<String>>) meta.get("Links");
             for (List<String> link : links) {


### PR DESCRIPTION
Apache httpclient 4.1.x uses { RFC1036, RFC1123, ASCTIME }, and uses java.text.SimpleDateFormat#parse(String), which raises an exception on failure. Since the Riak server uses RFC1123, this ordering is faster -- we avoid the creation of a ParseException during the failed RFC1036 parse.

See https://issues.apache.org/jira/browse/HTTPCLIENT-1227 for details.
