### PR TITLE
Make raw HTTP client expose riak config

### DIFF
--- a/src/main/java/com/basho/riak/client/raw/http/HTTPClientAdapter.java
+++ b/src/main/java/com/basho/riak/client/raw/http/HTTPClientAdapter.java
@@ -21,6 +21,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import com.basho.riak.client.http.RiakConfig;
 import org.apache.http.HttpStatus;
 
 import com.basho.riak.client.IRiakObject;
@@ -487,5 +488,11 @@ public class HTTPClientAdapter implements RawClient {
             }
         }
     }
-    
+
+    /* (non-Javadoc)
+     * @see com.basho.riak.client.http.RiakClient#getConfig()
+     */
+    public RiakConfig getConfig() {
+      return client.getConfig();
+    }
 }


### PR DESCRIPTION
Clients that sit on top of the Riak Java client (such as [Welle](http://clojureriak.info)) and provide
additional features, for example, Solr API support, may need to access HTTP endpoint.

In Welle, to support Solr API we currently have to subclass the raw HTTP client and use 
our own client class that does nothing else but exposes the config.

It would be nice if the Java client just provided access to it.
