### PR TITLE
Client will now support multiple links to the same object over HTTP

### DIFF
--- a/src/main/java/com/basho/riak/client/http/util/ClientUtils.java
+++ b/src/main/java/com/basho/riak/client/http/util/ClientUtils.java
@@ -391,13 +391,15 @@ public class ClientUtils {
      */
     public static List<RiakLink> parseLinkHeader(String header) {
         List<RiakLink> links = new ArrayList<RiakLink>();
-        Map<String, Map<String, String>> parsedLinks = LinkHeader.parse(header);
-        for (Entry<String, Map<String, String>> e: parsedLinks.entrySet()) {
+        Map<String, List<Map<String, String>>> parsedLinks = LinkHeader.parse(header);
+        for (Entry<String, List<Map<String, String>>> e: parsedLinks.entrySet()) {
         	String url = e.getKey();
-        	RiakLink link = parseOneLink(url, e.getValue());
-        	if (link != null) {
-        		links.add(link);
-        	}
+            for (Map<String,String> params : e.getValue()) {
+                RiakLink link = parseOneLink(url, params);
+                if (link != null) {
+                    links.add(link);
+                }
+            }
         }
         return links;
     }

--- a/src/main/java/com/basho/riak/client/http/util/LinkHeader.java
+++ b/src/main/java/com/basho/riak/client/http/util/LinkHeader.java
@@ -16,6 +16,7 @@ package com.basho.riak.client.http.util;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -58,11 +59,13 @@ public class LinkHeader {
      *            e.g. {@literal </path/to/resource1>; param="value",
      *            </path/to/resource2>}
      * 
-     * @return A map of links to their parameters. Parameters are a map of
-     *         parameter name to value.
+     * @return A map of links to their parameters. Parameters are a list of maps of
+     *         parameter name to value. (A URI can appear multiple times in the 
+     *         Link header, each Map in the List represents a set of parameters)
      */
-    public static Map<String, Map<String, String>> parse(String header) {
-        Map<String, Map<String, String>> out = new LinkedHashMap<String, Map<String, String>>();
+    public static Map<String, List<Map<String, String>>> parse(String header) {
+        Map<String, List<Map<String, String>>> out = 
+            new LinkedHashMap<String, List<Map<String, String>>>();
 
         if (header == null || header.length() == 0)
             return out;
@@ -85,7 +88,16 @@ public class LinkHeader {
                     }
                 }
             }
-            out.put(url, parsedLink);
+            
+            List<Map<String, String>> existing = out.get(url);
+            
+            if (existing == null) {
+                existing = new LinkedList<Map<String,String>>();
+                out.put(url, existing);
+            }
+                
+            existing.add(parsedLink);
+            
         }
 
         return out;

--- a/src/test/java/com/basho/riak/client/http/util/TestLinkHeader.java
+++ b/src/test/java/com/basho/riak/client/http/util/TestLinkHeader.java
@@ -20,12 +20,13 @@ import java.util.Map;
 import org.junit.Test;
 
 import com.basho.riak.client.http.util.LinkHeader;
+import java.util.List;
 
 public class TestLinkHeader {
 
     @Test public void parses_null_and_empty_headers() {
         String header = null;
-        Map<String, Map<String, String>> links = LinkHeader.parse(header);
+        Map<String, List<Map<String, String>>> links = LinkHeader.parse(header);
         assertEquals(0, links.size());
 
         header = "";
@@ -39,7 +40,7 @@ public class TestLinkHeader {
 
     @Test public void ignores_malformed_header_components() {
         final String header = "</res>, ;>>abc, </res2>";
-        Map<String, Map<String, String>> links = LinkHeader.parse(header);
+        Map<String, List<Map<String, String>>> links = LinkHeader.parse(header);
         assertEquals(2, links.size());
         assertNotNull(links.get("/res"));
         assertNotNull(links.get("/res2"));
@@ -47,55 +48,55 @@ public class TestLinkHeader {
 
     @Test public void ignores_empty_elements() {
         final String header = ",</res>; param=value, ,, </res2>,";
-        Map<String, Map<String, String>> links = LinkHeader.parse(header);
+        Map<String, List<Map<String, String>>> links = LinkHeader.parse(header);
         
         assertEquals(2, links.size());
         
         assertNotNull(links.get("/res"));
-        assertEquals(1, links.get("/res").keySet().size());
-        assertEquals("value", links.get("/res").get("param"));
+        assertEquals(1, links.get("/res").get(0).keySet().size());
+        assertEquals("value", links.get("/res").get(0).get("param"));
 
         assertNotNull(links.get("/res2"));
-        assertEquals(0, links.get("/res2").keySet().size());
+        assertEquals(0, links.get("/res2").get(0).keySet().size());
     }
 
     @Test public void parses_one_link_with_one_parameter() {
         final String header = "</res>; param=value";
-        Map<String, Map<String, String>> links = LinkHeader.parse(header);
+        Map<String, List<Map<String, String>>> links = LinkHeader.parse(header);
         assertEquals(1, links.size());
         assertNotNull(links.get("/res"));
-        assertEquals("value", links.get("/res").get("param"));
+        assertEquals("value", links.get("/res").get(0).get("param"));
     }
 
     @Test public void parses_multiple_links() {
         final String header = "</res>; param=value, </res2>; param2=value2, </another/res>; param3=value3";
-        Map<String, Map<String, String>> links = LinkHeader.parse(header);
+        Map<String, List<Map<String, String>>> links = LinkHeader.parse(header);
         assertEquals(3, links.size());
         assertNotNull(links.get("/res"));
         assertNotNull(links.get("/res2"));
         assertNotNull(links.get("/another/res"));
-        assertEquals("value", links.get("/res").get("param"));
-        assertEquals("value2", links.get("/res2").get("param2"));
-        assertEquals("value3", links.get("/another/res").get("param3"));
+        assertEquals("value", links.get("/res").get(0).get("param"));
+        assertEquals("value2", links.get("/res2").get(0).get("param2"));
+        assertEquals("value3", links.get("/another/res").get(0).get("param3"));
     }
 
     @Test public void handles_varying_whitespace() {
         final String header = "</res>;param=value;param2=value2,</res2>;   param3=value3;  param4=value4,    </another/res>";
-        Map<String, Map<String, String>> links = LinkHeader.parse(header);
+        Map<String, List<Map<String, String>>> links = LinkHeader.parse(header);
         assertEquals(3, links.size());
         assertNotNull(links.get("/res"));
         assertNotNull(links.get("/res2"));
         assertNotNull(links.get("/another/res"));
-        assertEquals("value", links.get("/res").get("param"));
-        assertEquals("value2", links.get("/res").get("param2"));
-        assertEquals("value3", links.get("/res2").get("param3"));
-        assertEquals("value4", links.get("/res2").get("param4"));
-        assertEquals(0, links.get("/another/res").keySet().size());
+        assertEquals("value", links.get("/res").get(0).get("param"));
+        assertEquals("value2", links.get("/res").get(0).get("param2"));
+        assertEquals("value3", links.get("/res2").get(0).get("param3"));
+        assertEquals("value4", links.get("/res2").get(0).get("param4"));
+        assertEquals(0, links.get("/another/res").get(0).keySet().size());
     }
     
     @Test public void handles_malformed_links() {
         String header = "; param=value";
-        Map<String, Map<String, String>> links = LinkHeader.parse(header);
+        Map<String, List<Map<String, String>>> links = LinkHeader.parse(header);
         assertEquals(0, links.size());
         
         header = "<>/res>; param=value";
@@ -109,39 +110,39 @@ public class TestLinkHeader {
 
     @Test public void parses_link_with_no_parameters() {  
         String header = "</res>";
-        Map<String, Map<String, String>> links = LinkHeader.parse(header);
+        Map<String, List<Map<String, String>>> links = LinkHeader.parse(header);
         assertEquals(1, links.size());
-        assertEquals(0, links.get("/res").keySet().size());
+        assertEquals(0, links.get("/res").get(0).keySet().size());
     }
 
     @Test public void parses_link_with_multiple_parameters() {  
         String header = "</res>; param1=value1; param2=value2; param3=value3";
-        Map<String, Map<String, String>> links = LinkHeader.parse(header);
+        Map<String, List<Map<String, String>>> links = LinkHeader.parse(header);
         assertEquals(1, links.size());
-        assertEquals(3, links.get("/res").keySet().size());
-        assertEquals("value1", links.get("/res").get("param1"));
-        assertEquals("value2", links.get("/res").get("param2"));
-        assertEquals("value3", links.get("/res").get("param3"));
+        assertEquals(3, links.get("/res").get(0).keySet().size());
+        assertEquals("value1", links.get("/res").get(0).get("param1"));
+        assertEquals("value2", links.get("/res").get(0).get("param2"));
+        assertEquals("value3", links.get("/res").get(0).get("param3"));
     }
 
     @Test public void parses_link_with_quoted_parameter() {
         String header = "</res>; param1=\"\\\"\\value1\\\"\"";   // backslash escaped quote and 'v' in quoted string
-        Map<String, Map<String, String>> links = LinkHeader.parse(header);
+        Map<String, List<Map<String, String>>> links = LinkHeader.parse(header);
         assertEquals(1, links.size());
-        assertEquals("\"value1\"", links.get("/res").get("param1"));
+        assertEquals("\"value1\"", links.get("/res").get(0).get("param1"));
     }
 
     @Test public void maps_valueless_parameter_to_null() {
         final String header = "</res>; param";
-        Map<String, Map<String, String>> links = LinkHeader.parse(header);
+        Map<String, List<Map<String, String>>> links = LinkHeader.parse(header);
         
-        assertTrue(links.get("/res").keySet().contains("param"));
-        assertEquals(null, links.get("/res").get("param"));
+        assertTrue(links.get("/res").get(0).keySet().contains("param"));
+        assertEquals(null, links.get("/res").get(0).get("param"));
     }
 
     @Test public void ignores_links_with_malformed_parameters() {
         String header = "</res>; param=, </res2>";
-        Map<String, Map<String, String>> links = LinkHeader.parse(header);
+        Map<String, List<Map<String, String>>> links = LinkHeader.parse(header);
         assertEquals(1, links.size());
         assertNotNull(links.get("/res2"));
 
@@ -154,5 +155,18 @@ public class TestLinkHeader {
         links = LinkHeader.parse(header);
         assertEquals(1, links.size());
         assertNotNull(links.get("/res2"));
-}
+    }
+    
+    @Test public void parse_multiple_links_to_same_object() {
+        String header = "</res>; param=foo, </res>; param=bar";
+        Map<String, List<Map<String, String>>> links = LinkHeader.parse(header);
+        assertEquals(1, links.size());
+        List<Map<String,String>> paramMaps = links.get("/res");
+        assertEquals(2, paramMaps.size());
+        Map<String,String> map1 = paramMaps.get(0);
+        assertEquals(map1.get("param"), "foo");
+        
+        
+    }
+    
 }


### PR DESCRIPTION
The original HTTP client was using a Map with the URI as the key when
parsing the HTTP Link: header. If you had multiple links to the same URI
all but the last would be discarded.

Fixes issue #164
