### PR TITLE
Removed r=2 default for fetch requests

### DIFF
--- a/src/main/java/com/basho/riak/client/http/util/ClientHelper.java
+++ b/src/main/java/com/basho/riak/client/http/util/ClientHelper.java
@@ -199,9 +199,7 @@ public class ClientHelper {
         if (meta == null) {
             meta = new RequestMeta();
         }
-        if (meta.getQueryParam(Constants.QP_R) == null) {
-            meta.setQueryParam(Constants.QP_R, Constants.DEFAULT_R.toString());
-        }
+        
         HttpHead head = new HttpHead(ClientUtils.makeURI(config, bucket, key));
         return executeMethod(bucket, key, head, meta);
     }
@@ -227,9 +225,7 @@ public class ClientHelper {
         if (meta == null) {
             meta = new RequestMeta();
         }
-        if (meta.getQueryParam(Constants.QP_R) == null) {
-            meta.setQueryParam(Constants.QP_R, Constants.DEFAULT_R.toString());
-        }
+        
         HttpGet get = new HttpGet(ClientUtils.makeURI(config, bucket, key));
         return executeMethod(bucket, key, get, meta, streamResponse);
     }
@@ -245,9 +241,7 @@ public class ClientHelper {
         if (meta == null) {
             meta = new RequestMeta();
         }
-        if (meta.getQueryParam(Constants.QP_R) == null) {
-            meta.setQueryParam(Constants.QP_R, Constants.DEFAULT_R.toString());
-        }
+
         HttpGet get = new HttpGet(ClientUtils.makeURI(config, bucket, key));
         try {
             org.apache.http.HttpResponse response = httpClient.execute(get);

--- a/src/main/java/com/basho/riak/client/http/util/Constants.java
+++ b/src/main/java/com/basho/riak/client/http/util/Constants.java
@@ -88,11 +88,6 @@ public interface Constants {
     public static String CTYPE_TEXT = "text/plain";
     public static String CTYPE_TEXT_UTF8 = "text/plain; charset=UTF-8";
 
-    // Default r, w, and dw values to use when not specified
-    public static Integer DEFAULT_R = 2;
-    public static Integer DEFAULT_W = null;
-    public static Integer DEFAULT_DW = null;
-    
     // Values for the "keys" query parameter
     public static String NO_KEYS = "false";
     public static String INCLUDE_KEYS = "true";

--- a/src/test/java/com/basho/riak/client/http/util/TestClientHelper.java
+++ b/src/test/java/com/basho/riak/client/http/util/TestClientHelper.java
@@ -203,12 +203,6 @@ public class TestClientHelper {
         verify(mockHttpClient).execute(any(HttpHead.class));
     }
 
-    @Test public void fetchMeta_adds_default_R_value() throws IOException {
-        stubResponse(true);
-        impl.fetchMeta(bucket, key, meta);
-        assertEquals(Integer.toString(Constants.DEFAULT_R), meta.getQueryParam(Constants.QP_R));
-    }
-
     @Test public void fetch_GETs_object_URL() throws IOException {
         when(mockHttpClient.execute(any(HttpRequestBase.class))).thenAnswer(pathVerifier("/" + bucket + "/" + key));
         stubResponse(false);
@@ -216,23 +210,11 @@ public class TestClientHelper {
         verify(mockHttpClient).execute(any(HttpGet.class));
     }
     
-    @Test public void fetch_adds_default_R_value() throws IOException {
-        stubResponse(true);
-        impl.fetch(bucket, key, meta);
-        assertEquals(Integer.toString(Constants.DEFAULT_R), meta.getQueryParam(Constants.QP_R));
-    }
-    
     @Test public void stream_GETs_object_URL() throws IOException {
         when(mockHttpClient.execute(any(HttpRequestBase.class))).thenAnswer(pathVerifier("/" + bucket + "/" + key));
         stubResponse(false);
         impl.stream(bucket, key, mock(StreamHandler.class), meta);
         verify(mockHttpClient).execute(any(HttpGet.class));
-    }
-
-    @Test public void stream_adds_default_R_value() throws IOException {
-        stubResponse(true);
-        impl.stream(bucket, key, mock(StreamHandler.class), meta);
-        assertEquals(Integer.toString(Constants.DEFAULT_R), meta.getQueryParam(Constants.QP_R));
     }
     
     @Test public void delete_DELETEs_object_URL() throws IOException {


### PR DESCRIPTION
The original HTTP client would supply r=2 as a default when r
was not explicitly set for any fetch request. This has now been
removed and the bucket defaults will be used.

Fixes #167
