### PR TITLE
Allow null keys when storing objects with protobuf client (complete patch with test).

### DIFF
--- a/src/main/java/com/basho/riak/client/DefaultRiakObject.java
+++ b/src/main/java/com/basho/riak/client/DefaultRiakObject.java
@@ -88,10 +88,6 @@ public class DefaultRiakObject implements IRiakObject {
             throw new IllegalArgumentException("Bucket cannot be null");
         }
 
-        if (key == null) {
-            throw new IllegalArgumentException("Key cannot be null");
-        }
-
         this.bucket = bucket;
         this.key = key;
         this.vclock = vclock;

--- a/src/main/java/com/basho/riak/client/bucket/DefaultBucket.java
+++ b/src/main/java/com/basho/riak/client/bucket/DefaultBucket.java
@@ -450,14 +450,9 @@ public class DefaultBucket implements Bucket {
      */
     public <T> StoreObject<T> store(final T o) {
         @SuppressWarnings("unchecked") Class<T> clazz = (Class<T>) o.getClass();
-        final String key = getKey(o);
-        if (key == null) {
-            throw new NoKeySpecifedException(o);
-        }
-
         Converter<T> converter = getDefaultConverter(clazz);
 
-        return new StoreObject<T>(client, name, key, retrier)
+        return new StoreObject<T>(client, name, getKey(o), retrier)
             .withConverter(converter)
                 .withMutator(new ClobberMutation<T>(o))
                   .withResolver(new DefaultResolver<T>());

--- a/src/main/java/com/basho/riak/client/operations/StoreObject.java
+++ b/src/main/java/com/basho/riak/client/operations/StoreObject.java
@@ -26,7 +26,6 @@ import com.basho.riak.client.cap.*;
 import com.basho.riak.client.convert.ConversionException;
 import com.basho.riak.client.convert.Converter;
 import com.basho.riak.client.convert.VClockUtil;
-import com.basho.riak.client.raw.MatchFoundException;
 import com.basho.riak.client.raw.RawClient;
 import com.basho.riak.client.raw.RiakResponse;
 import com.basho.riak.client.raw.StoreMeta;
@@ -73,7 +72,7 @@ public class StoreObject<T> implements RiakOperation<T> {
      * @param bucket
      *            location of data to store
      * @param key
-     *            location of data to store
+     *            location of data to store (if null, Riak will generate one)
      * @param retrier
      *            the Retrier to use for this operation
      */
@@ -81,6 +80,9 @@ public class StoreObject<T> implements RiakOperation<T> {
         this.client = client;
         this.retrier = retrier;
         fetchObject = new FetchObject<T>(client, bucket, key, retrier);
+        if (key == null) {
+            doNotFetch = true;
+        }
     }
 
     /**

--- a/src/main/java/com/basho/riak/client/raw/pbc/PBClientAdapter.java
+++ b/src/main/java/com/basho/riak/client/raw/pbc/PBClientAdapter.java
@@ -172,9 +172,9 @@ public class PBClientAdapter implements RawClient {
      * , com.basho.riak.client.raw.StoreMeta)
      */
     public RiakResponse store(IRiakObject riakObject, StoreMeta storeMeta) throws IOException {
-        if (riakObject == null || riakObject.getKey() == null || riakObject.getBucket() == null) {
+        if (riakObject == null || riakObject.getBucket() == null) {
             throw new IllegalArgumentException(
-                                               "object cannot be null, object's key cannot be null, object's bucket cannot be null");
+                                               "object cannot be null, object's bucket cannot be null");
         }
 
         try {

--- a/src/main/java/com/basho/riak/pbc/RiakClient.java
+++ b/src/main/java/com/basho/riak/pbc/RiakClient.java
@@ -395,8 +395,11 @@ public class RiakClient implements RiakMessageCodes {
 			throws IOException {
 
 		RiakKvPB.RpbPutReq.Builder builder = RiakKvPB.RpbPutReq.newBuilder().setBucket(
-				value.getBucketBS()).setKey(value.getKeyBS()).setContent(
+				value.getBucketBS()).setContent(
 				value.buildContent());
+		if (value.getKeyBS() != null) {
+			builder.setKey(value.getKeyBS());
+		}
 
 		if (value.getVclock() != null) {
 			builder.setVclock(value.getVclock());
@@ -420,9 +423,12 @@ public class RiakClient implements RiakMessageCodes {
 			RiakObject[] res = new RiakObject[resp.getContentCount()];
 			ByteString vclock = resp.getVclock();
 
+			// The key parameter will be set only if the server generated a
+			// key for the object so we check and set it accordingly.
 			for (int i = 0; i < res.length; i++) {
-				res[i] = new RiakObject(vclock, value.getBucketBS(), value
-						.getKeyBS(), resp.getContent(i));
+				res[i] = new RiakObject(vclock, value.getBucketBS(),
+						resp.hasKey() ? resp.getKey() : value.getKeyBS(),
+						resp.getContent(i));
 			}
 
 			return res;

--- a/src/main/java/com/basho/riak/pbc/RiakObject.java
+++ b/src/main/java/com/basho/riak/pbc/RiakObject.java
@@ -154,7 +154,7 @@ public class RiakObject {
 	}
 	
 	public String getKey() {
-		return key.toStringUtf8();
+		return key == null ? null : key.toStringUtf8();
 	}
 	
 	public ByteString getVclock() {

--- a/src/test/java/com/basho/riak/pbc/itest/ITestDataLoad.java
+++ b/src/test/java/com/basho/riak/pbc/itest/ITestDataLoad.java
@@ -18,6 +18,7 @@ import static com.basho.riak.client.http.Hosts.RIAK_PORT;
 import static com.google.protobuf.ByteString.copyFrom;
 import static com.google.protobuf.ByteString.copyFromUtf8;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
@@ -32,6 +33,10 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.basho.riak.client.AllTests;
+import com.basho.riak.client.IRiakClient;
+import com.basho.riak.client.IRiakObject;
+import com.basho.riak.client.RiakFactory;
+import com.basho.riak.client.bucket.Bucket;
 import com.basho.riak.client.raw.pbc.PBClientAdapter;
 import com.basho.riak.client.util.CharsetUtils;
 import com.basho.riak.pbc.RequestMeta;
@@ -171,5 +176,17 @@ public class ITestDataLoad {
 
         assertEquals(originalVclock.size(), o.getVclock().size());
         c.delete(bucket, key);
+    }
+
+    @Test public void storeNullKey() throws Exception {
+        final IRiakClient c = RiakFactory.pbcClient(RIAK_HOST, RIAK_PORT);
+        c.setClientId("TSNK".getBytes());
+        final String bucket = UUID.randomUUID().toString();
+        final String key = null;
+
+        Bucket b = c.createBucket(bucket).allowSiblings(false).execute();
+        IRiakObject stored = b.store(key, ExpectedValues.CONTENT).returnBody(true).execute();
+        assertNotNull(stored.getKey());
+        assertEquals(ExpectedValues.CONTENT, stored.getValueAsString());
     }
 }


### PR DESCRIPTION
Based on a patch by broach (https://github.com/basho/riak-java-client/commit/d290303387f444a62b43dea74c95d75813db3679).
