### PR TITLE
Changed connection pool from FIFO to LIFO

### DIFF
--- a/src/main/java/com/basho/riak/pbc/RiakConnection.java
+++ b/src/main/java/com/basho/riak/pbc/RiakConnection.java
@@ -35,7 +35,7 @@ import com.google.protobuf.MessageLite;
  *
  * See <a href="http://wiki.basho.com/PBC-API.html">Basho Wiki</a> for more details.
  */
-class RiakConnection
+class RiakConnection implements Comparable<RiakConnection>
 {
 
 	static final int DEFAULT_RIAK_PB_PORT = 8087;
@@ -219,4 +219,18 @@ class RiakConnection
 	{
 		return clientId != null && clientId.length > 0;
 	}
+
+    /** 
+     * The natural ordering is descending by idle start time
+     */ 
+    public int compareTo(RiakConnection c)
+    {
+        if (c.getIdleStartTimeNanos() < this.getIdleStartTimeNanos()) {
+            return -1;
+        } else if (c.getIdleStartTimeNanos() > this.getIdleStartTimeNanos()) {
+            return 1;
+        } else {
+            return 0;
+        }
+    }
 }

--- a/src/main/java/com/basho/riak/pbc/RiakConnectionPool.java
+++ b/src/main/java/com/basho/riak/pbc/RiakConnectionPool.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 import com.basho.riak.client.raw.pbc.PoolSemaphore;
 import com.basho.riak.protobuf.RiakKvPB.RpbSetClientIdReq;
 import com.google.protobuf.ByteString;
+import java.util.concurrent.PriorityBlockingQueue;
 
 /**
  * A bounded or boundless pool of {@link RiakConnection}s to be reused by {@link RiakClient}
@@ -132,7 +133,7 @@ public class RiakConnectionPool {
     private final InetAddress host;
     private final int port;
     private final Semaphore permits;
-    private final ConcurrentLinkedQueue<RiakConnection> available;
+    private final PriorityBlockingQueue<RiakConnection> available;
     private final ConcurrentLinkedQueue<RiakConnection> inUse;
     private final long connectionWaitTimeoutNanos;
     private final int bufferSizeKb;
@@ -215,7 +216,7 @@ public class RiakConnectionPool {
             long connectionWaitTimeoutMillis, int bufferSizeKb, long idleConnectionTTLMillis,
             int requestTimeoutMillis) throws IOException {
         this.permits = poolSemaphore;
-        this.available = new ConcurrentLinkedQueue<RiakConnection>();
+        this.available = new PriorityBlockingQueue<RiakConnection>();
         this.inUse = new ConcurrentLinkedQueue<RiakConnection>();
         this.bufferSizeKb = bufferSizeKb;
         this.host = host;
@@ -255,12 +256,7 @@ public class RiakConnectionPool {
                                 }
                             }
                             c = available.peek();
-                        } else {
-                            // since the queue is FIFO short-circuit and stop
-                            // looking, if the first element isn't too old, the
-                            // rest can't be
-                            c = null;
-                        }
+                        } 
                     }
                 }
             }, idleConnectionTTLNanos, idleConnectionTTLNanos, TimeUnit.NANOSECONDS);


### PR DESCRIPTION
Small optimization that should help the PB client evict connections
which are no longer needed.

By returning a just-used connection to the front of the queue it ensures that only as many connections that are needed (determined by load) are held open in the pool as the idle reaper will take ones off the end. 
