### PR TITLE
Close connection when list keys not exhausted

### DIFF
--- a/src/main/java/com/basho/riak/pbc/RiakStreamClient.java
+++ b/src/main/java/com/basho/riak/pbc/RiakStreamClient.java
@@ -61,7 +61,7 @@ abstract class RiakStreamClient<T> implements Iterable<T> {
 				// the reference was lost; cancel this timer and
 				// close the connection
 				cancel();
-                conn.close();
+				conn.close();
 				conn.release();
 			} else if (conn.isClosed()) {
 				cancel();


### PR DESCRIPTION
Closes the underlying RiakConnection when a RiakStreamClient
hasn't been explicitly closed but the reference to it has
been lost.

fixes #185 

This issue would present itself under the following conditions: 
1. A list keys Riak operation caused Riak to respond with more than one MSG_ListKeysResp 
2. The KeySource (which extends RiakStreamClient) returned from a RiakClient.listKeys() operation was not explicitly closed or exhausted prior to reading all  MSG_ListKeysResp on the wire and was allowed to fall out of scope reducing the reference count to 0.  
3. There was a sufficient number of client operations occurring  that the RiakConnection would not get evicted from the pool by the idle reaper before being reused. 

When the reference count was reduced to 0 the TimerTask inside the RiakStreamClient would return the RiakConnection to the RiakConnectionPool with MSG_ListKeysResp protocol buffers still on the wire. If the RiakConnection was not expired by the RiakConnectionPool because of it being idle, it would be reused by the RiakClient for a new Riak Operation. When attempting to read the response for that operation, the client would encounter the orphaned MSG_ListKeysResp and throw an IOException. 

This example will reproduce the problem without this PR:  https://gist.github.com/c4f80cb175b842c25942
