### PR TITLE
Fixed M/R logical keyfilters

### DIFF
--- a/src/main/java/com/basho/riak/client/query/filter/AbstractLogicalFilter.java
+++ b/src/main/java/com/basho/riak/client/query/filter/AbstractLogicalFilter.java
@@ -29,14 +29,14 @@ public abstract class AbstractLogicalFilter implements LogicalFilter {
     public AbstractLogicalFilter(KeyFilter... filters) {
         synchronized (this.filters) {
             for (KeyFilter filter : filters) {
-                this.filters.add(filter.asArray());
+                this.filters.add(new Object[] { filter.asArray() });
             }
         }
     }
 
     public AbstractLogicalFilter add(KeyFilter filter) {
         synchronized (filter) {
-            filters.add(filter.asArray());
+            filters.add(new Object[] { filter.asArray() });
         }
         return this;
     }

--- a/src/test/java/com/basho/riak/client/query/filter/LogicalAndFilterTest.java
+++ b/src/test/java/com/basho/riak/client/query/filter/LogicalAndFilterTest.java
@@ -40,8 +40,11 @@ public class LogicalAndFilterTest {
         LogicalAndFilter laf = new LogicalAndFilter(filters);
         laf.add(new SimilarToFilter("hippo", 2));
         
-        assertArrayEquals(new Object[] { "and", new FloatToStringFilter().asArray(), new IntToStringFilter().asArray(),
-                                        new SetMemberFilter("rita", "sue", "bob").asArray(), new SimilarToFilter("hippo", 2).asArray() }, laf.asArray());
+        assertArrayEquals(new Object[] { "and", new Object[] { new FloatToStringFilter().asArray() }, 
+                                                new Object[] { new IntToStringFilter().asArray() },
+                                                new Object[] { new SetMemberFilter("rita", "sue", "bob").asArray() }, 
+                                                new Object[] { new SimilarToFilter("hippo", 2).asArray() }},
+                                                laf.asArray());
     }
 
 }


### PR DESCRIPTION
This fixes a bug that causes the output JSON to look like:
["and",["starts_with","p"],["ends_with","1"]]
when it should look like:
["and",[["starts_with","p"]],[["ends_with","1"]]]

This was occuring with all logical key filters (and,or, and not)
and actually would cause the M/R job to crash in riak and timeout
on the client side.

The test was also modified to test for the correct structure.

Fixes #181
