### PR TITLE
Enable @RiakIndex annotation at POJO methods

### DIFF
--- a/src/main/java/com/basho/riak/client/convert/RiakIndex.java
+++ b/src/main/java/com/basho/riak/client/convert/RiakIndex.java
@@ -59,7 +59,7 @@ import com.basho.riak.client.bucket.DefaultBucket;
  * @see JSONConverter
  * @see DefaultBucket
  */
-@Retention(RetentionPolicy.RUNTIME) @Target(ElementType.FIELD) public @interface RiakIndex {
+@Retention(RetentionPolicy.RUNTIME) @Target({ ElementType.FIELD, ElementType.METHOD }) public @interface RiakIndex {
     /**
      * @return the index name
      */

--- a/src/main/java/com/basho/riak/client/convert/reflect/AnnotationInfo.java
+++ b/src/main/java/com/basho/riak/client/convert/reflect/AnnotationInfo.java
@@ -15,6 +15,7 @@ package com.basho.riak.client.convert.reflect;
 
 import static com.basho.riak.client.convert.reflect.ClassUtil.getFieldValue;
 import static com.basho.riak.client.convert.reflect.ClassUtil.setFieldValue;
+import static com.basho.riak.client.convert.reflect.ClassUtil.getMethodValue;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
@@ -48,6 +49,7 @@ public class AnnotationInfo {
     private final List<UsermetaField> usermetaItemFields;
     private final Field usermetaMapField;
     private final List<RiakIndexField> indexFields;
+    private final List<RiakIndexMethod> indexMethods;
     private final Field riakLinksField;
     private final Field riakVClockField;
 
@@ -55,15 +57,18 @@ public class AnnotationInfo {
      * @param riakKeyField
      * @param usermetaItemFields
      * @param usermetaMapField
-     * @param riakLinksField 
-     * @param indexFields 
+     * @param riakLinksField
+     * @param indexFields
      */
-    public AnnotationInfo(Field riakKeyField, List<UsermetaField> usermetaItemFields, Field usermetaMapField, List<RiakIndexField> indexFields, Field riakLinksField, Field riakVClockField) {
+    public AnnotationInfo(Field riakKeyField, List<UsermetaField> usermetaItemFields, Field usermetaMapField,
+            List<RiakIndexField> indexFields, List<RiakIndexMethod> indexMethods, Field riakLinksField,
+            Field riakVClockField) {
         this.riakKeyField = riakKeyField;
         this.usermetaItemFields = usermetaItemFields;
         validateUsermetaMapField(usermetaMapField);
         this.usermetaMapField = usermetaMapField;
         this.indexFields = indexFields;
+        this.indexMethods = indexMethods;
         validateRiakLinksField(riakLinksField);
         this.riakLinksField = riakLinksField;
         this.riakVClockField = riakVClockField;
@@ -140,43 +145,42 @@ public class AnnotationInfo {
     public boolean hasRiakVClock() {
         return riakVClockField != null;
     }
-    
+
     public <T> VClock getRiakVClock(T obj) {
         if (!hasRiakVClock()) {
             throw new IllegalStateException(NO_RIAK_VCLOCK_FIELD_PRESENT);
         }
-        
+
         VClock vclock;
-        
+
         // We allow the annotated field to be either an actual VClock, or
         // a byte array. This is enforced in the AnnotationScanner
-        
+
         if (riakVClockField.getType().isAssignableFrom(VClock.class)) {
             vclock = (VClock) getFieldValue(riakVClockField, obj);
         } else {
             vclock = new BasicVClock((byte[]) getFieldValue(riakVClockField, obj));
         }
-        
+
         return vclock;
-        
+
     }
-    
+
     public <T> void setRiakVClock(T obj, VClock vclock) {
         if (!hasRiakVClock()) {
             throw new IllegalStateException(NO_RIAK_VCLOCK_FIELD_PRESENT);
         }
-            
+
         // We allow the annotated field to be either an actual VClock, or
         // a byte array. This is enforced in the AnnotationScanner
-        
+
         if (riakVClockField.getType().isAssignableFrom(VClock.class)) {
             setFieldValue(riakVClockField, obj, vclock);
         } else {
             setFieldValue(riakVClockField, obj, vclock.getBytes());
         }
     }
-    
-    
+
     @SuppressWarnings({ "unchecked", "rawtypes" }) public <T> Map<String, String> getUsermetaData(T obj) {
         final Map<String, String> usermetaData = new LinkedHashMap<String, String>();
         Map<String, String> objectMetaMap = null;
@@ -186,7 +190,7 @@ public class AnnotationInfo {
             String val = o == null ? null : o.toString();
             String key = f.getUsermetaDataKey();
             // null is not a user meta datum
-            if(o != null) {
+            if (o != null) {
                 usermetaData.put(key, val);
             }
         }
@@ -214,21 +218,22 @@ public class AnnotationInfo {
         }
 
         // set a catch all map field
-        if(usermetaMapField != null) {
+        if (usermetaMapField != null) {
             setFieldValue(usermetaMapField, obj, localMetaCopy);
         }
     }
 
     /**
      * @return a {@link RiakIndexes} made of the values of the RiakIndex
-     *         annotated fields
+     *         annotated fields and methods. For methods it is expected to be a
+     *         Set of String or Integer
      */
-    public <T> RiakIndexes getIndexes(T obj) {
+    @SuppressWarnings("unchecked") public <T> RiakIndexes getIndexes(T obj) {
         final RiakIndexes riakIndexes = new RiakIndexes();
 
         for (RiakIndexField f : indexFields) {
             if (Set.class.isAssignableFrom(f.getType())) {
-                Type t = f.getField().getGenericType();
+                final Type t = f.getField().getGenericType();
                 if (t instanceof ParameterizedType) {
                     Class genericType = (Class)((ParameterizedType)t).getActualTypeArguments()[0];
                     if (String.class.equals(genericType)) {
@@ -246,7 +251,7 @@ public class AnnotationInfo {
                     }
                 }
             } else {
-                Object val = getFieldValue(f.getField(), obj);
+                final Object val = getFieldValue(f.getField(), obj);
                 // null is not an index value
                 if (val != null) {
                     if (val instanceof String) {
@@ -261,10 +266,48 @@ public class AnnotationInfo {
             }
         }
 
+        for (RiakIndexMethod m : indexMethods) {
+            if (Set.class.isAssignableFrom(m.getType())) {
+                final Type t = m.getMethod().getGenericReturnType();
+                if (t instanceof ParameterizedType) {
+                    final Object val = getMethodValue(m.getMethod(), obj);
+                    if (val != null) {
+                        final Class<?> genericType = (Class<?>) ((ParameterizedType) t).getActualTypeArguments()[0];
+                        if (String.class.equals(genericType)) {
+                            riakIndexes.addBinSet(m.getIndexName(), (Set<String>) val);
+                        } else if (Long.class.equals(genericType)) {
+                            riakIndexes.addIntSet(m.getIndexName(), (Set<Long>) val);
+                        } else if (Integer.class.equals(genericType)) {
+                            // Supporting Integer as legacy. All new code should use Long
+                            Set<Integer> iSet = (Set<Integer>) val;
+                            Set<Long> lSet = new HashSet<Long>();
+                            for (Integer i : iSet) {
+                                lSet.add(i.longValue());
+                            }
+                            riakIndexes.addIntSet(m.getIndexName(), lSet);
+                        }
+                    }
+                }
+            } else {
+                final Object val = getMethodValue(m.getMethod(), obj);
+                // null is not an index value
+                if (val != null) {
+                    if (val instanceof String) {
+                        riakIndexes.add(m.getIndexName(), (String) val);
+                    } else if (val instanceof Long) {
+                        riakIndexes.add(m.getIndexName(), (Long) val);
+                    } else if (val instanceof Integer) {
+                        riakIndexes.add(m.getIndexName(), ((Integer) val).longValue());
+                    }
+                }
+            }
+        }
         return riakIndexes;
     }
 
     /**
+     * TODO Set multi-value indexes for methods when fetched back from Riak
+     * 
      * @param <T>
      * @param indexes
      *            the RiakIndexes to copy to the domain object
@@ -275,11 +318,11 @@ public class AnnotationInfo {
         // copy the index values to the correct fields
         for (RiakIndexField f : indexFields) {
             Set<?> val = null;
-            
+
             if (Set.class.isAssignableFrom(f.getType())) {
-                Type t = f.getField().getGenericType();
+                final Type t = f.getField().getGenericType();
                 if (t instanceof ParameterizedType) {
-                    Class genericType = (Class)((ParameterizedType)t).getActualTypeArguments()[0];
+                    final Class<?> genericType = (Class<?>) ((ParameterizedType) t).getActualTypeArguments()[0];
                     if (String.class.equals(genericType)) {
                         val = indexes.getBinIndex(f.getIndexName());
                     } else if (Integer.class.equals(genericType)) {
@@ -287,7 +330,7 @@ public class AnnotationInfo {
                     }
                 }
                 if (val != null && !val.isEmpty()) {
-                    setFieldValue(f.getField(), obj, val); 
+                    setFieldValue(f.getField(), obj, val);
                 }
             } else {
                 if (Integer.class.equals(f.getType()) || int.class.equals(f.getType())) {
@@ -303,7 +346,7 @@ public class AnnotationInfo {
                 } else if (Long.class.equals(f.getType()) || long.class.equals(f.getType())) {
                     val = indexes.getIntIndex(f.getIndexName());
                 } 
-            
+
                 if (val != null && !val.isEmpty()) {
                     setFieldValue(f.getField(), obj, val.iterator().next()); // take the first value
                 }

--- a/src/main/java/com/basho/riak/client/convert/reflect/AnnotationScanner.java
+++ b/src/main/java/com/basho/riak/client/convert/reflect/AnnotationScanner.java
@@ -13,12 +13,13 @@
  */
 package com.basho.riak.client.convert.reflect;
 
-import com.basho.riak.client.cap.VClock;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
 
+import com.basho.riak.client.cap.VClock;
 import com.basho.riak.client.convert.RiakIndex;
 import com.basho.riak.client.convert.RiakKey;
 import com.basho.riak.client.convert.RiakLinks;
@@ -53,6 +54,7 @@ public class AnnotationScanner implements Callable<AnnotationInfo> {
         Field linksField = null;
         List<UsermetaField> usermetaItemFields = new ArrayList<UsermetaField>();
         List<RiakIndexField> indexFields = new ArrayList<RiakIndexField>();
+        List<RiakIndexMethod> indexMethods = new ArrayList<RiakIndexMethod>();
 
         Class currentClass = classToScan;
         while(currentClass != Object.class) {
@@ -101,6 +103,13 @@ public class AnnotationScanner implements Callable<AnnotationInfo> {
             }
             currentClass = currentClass.getSuperclass();
         }
-        return new AnnotationInfo(riakKeyField, usermetaItemFields, usermetaMapField, indexFields, linksField, riakVClockField);
+        final Method[] methods = classToScan.getDeclaredMethods();
+        for (Method method : methods) {
+            if (method.isAnnotationPresent(RiakIndex.class)) {
+                indexMethods.add(new RiakIndexMethod(ClassUtil.checkAndFixAccess(method)));
+            }
+        }
+
+        return new AnnotationInfo(riakKeyField, usermetaItemFields, usermetaMapField, indexFields, indexMethods, linksField, riakVClockField);
     }
 }

--- a/src/main/java/com/basho/riak/client/convert/reflect/ClassUtil.java
+++ b/src/main/java/com/basho/riak/client/convert/reflect/ClassUtil.java
@@ -14,7 +14,9 @@
 package com.basho.riak.client.convert.reflect;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Member;
+import java.lang.reflect.Method;
 
 /**
  * Reflection/class utilities. Delegates to
@@ -53,6 +55,21 @@ public final class ClassUtil {
             value = f.get(obj);
         } catch (IllegalAccessException e) {
             throw new IllegalStateException("Unable to get Riak annotated field value", e);
+        }
+
+        return value;
+    }
+
+    public static <T> Object getMethodValue(Method m, T obj) {
+        Object value = null;
+        try {
+            value = m.invoke(obj);
+        } catch (IllegalAccessException e) {
+            throw new IllegalStateException("Unable to get Riak annotated method value", e);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalStateException("Unable to get Riak annotated method value", e);
+        } catch (InvocationTargetException e) {
+            throw new IllegalStateException("Unable to get Riak annotated method value", e);
         }
 
         return value;

--- a/src/main/java/com/basho/riak/client/convert/reflect/RiakIndexField.java
+++ b/src/main/java/com/basho/riak/client/convert/reflect/RiakIndexField.java
@@ -14,11 +14,11 @@
 package com.basho.riak.client.convert.reflect;
 
 import java.lang.reflect.Field;
-
-import com.basho.riak.client.convert.RiakIndex;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Set;
+
+import com.basho.riak.client.convert.RiakIndex;
 
 /**
  * @author russell
@@ -81,8 +81,8 @@ public class RiakIndexField {
     public String getIndexName() {
         return indexName;
     }
-    
-    @SuppressWarnings("rawtypes") public Class getType() {
+
+    public Class<?> getType() {
         return type;
     }
 }

--- a/src/main/java/com/basho/riak/client/convert/reflect/RiakIndexMethod.java
+++ b/src/main/java/com/basho/riak/client/convert/reflect/RiakIndexMethod.java
@@ -1,0 +1,84 @@
+/*
+ * This file is provided to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.basho.riak.client.convert.reflect;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Set;
+
+import com.basho.riak.client.convert.RiakIndex;
+
+/**
+ * @author guido A copy of RiakIndexField for Methods.
+ */
+public class RiakIndexMethod {
+
+    private final Method method;
+    private final String indexName;
+    private final Class<?> type;
+
+    /**
+     * The method that is to be wrapped
+     * 
+     * @param method
+     */
+    public RiakIndexMethod(final Method method) {
+        if (method == null || method.getAnnotation(RiakIndex.class) == null ||
+            "".equals(method.getAnnotation(RiakIndex.class).name()) ||
+            (!method.getReturnType().equals(String.class) &&
+             !method.getReturnType().equals(Integer.class) &&
+             !method.getReturnType().equals(int.class)) &&
+             !method.getReturnType().equals(Long.class) &&
+             !method.getReturnType().equals(long.class) &&
+             !Set.class.isAssignableFrom(method.getReturnType())) {
+            throw new IllegalArgumentException(method.getReturnType().toString());
+        }
+
+        if (Set.class.isAssignableFrom(method.getReturnType())) {
+            // Verify it's a Set<String> or Set<Integer>
+            final Type t = method.getGenericReturnType();
+            if (t instanceof ParameterizedType) {
+                final Class<?> genericType = (Class<?>) ((ParameterizedType) t).getActualTypeArguments()[0];
+                if (!genericType.equals(String.class) && !genericType.equals(Integer.class)) {
+                    throw new IllegalArgumentException(method.getReturnType().toString());
+                }
+            } else {
+                throw new IllegalArgumentException(method.getReturnType().toString());
+            }
+        }
+        this.method = method;
+        this.indexName = method.getAnnotation(RiakIndex.class).name();
+        this.type = method.getReturnType();
+    }
+
+    /**
+     * @return the method
+     */
+    public Method getMethod() {
+        return method;
+    }
+
+    /**
+     * @return the indexName
+     */
+    public String getIndexName() {
+        return indexName;
+    }
+
+    public Class<?> getType() {
+        return type;
+    }
+
+}

--- a/src/test/java/com/basho/riak/client/convert/RiakIndexConverterTest.java
+++ b/src/test/java/com/basho/riak/client/convert/RiakIndexConverterTest.java
@@ -13,74 +13,87 @@
  */
 package com.basho.riak.client.convert;
 
-import com.basho.riak.client.query.indexes.RiakIndexes;
-import java.util.Set;
-import java.util.HashSet;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import java.util.Arrays;
-import org.junit.Test;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.junit.Before;
-import static org.junit.Assert.*;
+import org.junit.Test;
+
+import com.basho.riak.client.query.indexes.RiakIndexes;
 
 /**
- *
+ * 
  * @author roach
  */
-public class RiakIndexConverterTest
-{
+public class RiakIndexConverterTest {
     private RiakIndexConverter<DomainObject> converter;
-    
-    @Before 
-    public void setUp()
-    {
+
+    @Before public void setUp() {
         this.converter = new RiakIndexConverter<DomainObject>();
     }
-    
-    @Test
-    public void setGetPopulatedIndexes()
-    {
-        final String[] languages = {"c","erlang","java"};
+
+    @Test public void setGetPopulatedIndexes() {
+        final String[] languages = { "c", "erlang", "java" };
         final HashSet<String> langSet = new HashSet<String>(Arrays.asList(languages));
-        final Integer[] numbers = {1,2,7};
+        final Integer[] numbers = { 1, 2, 7 };
         final HashSet<Integer> luckySet = new HashSet<Integer>(Arrays.asList(numbers));
-        
-        
+
         RiakIndexes rIndexes = new RiakIndexes();
         rIndexes.addBinSet("favorite_languages", langSet);
         rIndexes.addIntSet("lucky_numbers", luckySet);
         rIndexes.addIntSet("other_numbers", luckySet);
-        
+
         DomainObject obj = new DomainObject();
-        
+
         converter.populateIndexes(rIndexes, obj);
-        
+
         assertNotNull("Expected bin index field to be populated", obj.favoriteLanguages);
         assertNotNull("Expected int index field to be populated", obj.otherNumbers);
         assertEquals(langSet.size(), obj.favoriteLanguages.size());
         assertEquals(luckySet.size(), obj.otherNumbers.size());
         assertEquals(1, obj.lucky_number); // should be first in set
-        
+
         rIndexes = converter.getIndexes(obj);
-        
-        assertNotNull("Expected RiakIndexes BinIndexes to be populated", 
-                      rIndexes.getBinIndex("favorite_languages"));
-        assertNotNull("Expected RiakIndexes IntIndexes to be populated", 
-                      rIndexes.getBinIndex("other_numbers"));
+
+        assertNotNull("Expected RiakIndexes BinIndexes to be populated", rIndexes.getBinIndex("favorite_languages"));
+        assertNotNull("Expected RiakIndexes IntIndexes to be populated", rIndexes.getIntIndex("other_numbers"));
+        assertNotNull("Expected Method RiakIndexes IntIndexes to be populated",
+                      rIndexes.getIntIndex("calculated_numbers"));
+        assertNotNull("Expected Method RiakIndexes BinIndexes to be populated",
+                      rIndexes.getBinIndex("calculated_strings"));
         assertEquals(langSet.size(), rIndexes.getBinIndex("favorite_languages").size());
         assertEquals(luckySet.size(), rIndexes.getIntIndex("other_numbers").size());
-        assertEquals(1, rIndexes.getIntIndex("lucky_numbers").size()); 
-        
+        assertEquals(1, rIndexes.getIntIndex("lucky_numbers").size());
+        assertEquals(DomainObject.CALCULATIONS_COUNT, rIndexes.getIntIndex("calculated_numbers").size());
+        assertEquals(DomainObject.CALCULATIONS_COUNT, rIndexes.getBinIndex("calculated_strings").size());
     }
-    
-    private static final class DomainObject
-    {
-        @RiakIndex(name = "favorite_languages") 
-        public Set<String> favoriteLanguages;
+
+    private static final class DomainObject {
+        public static final int CALCULATIONS_COUNT = 5;
+        @RiakIndex(name = "favorite_languages") public Set<String> favoriteLanguages;
         // int field should end up with first entry of index set
-        @RiakIndex(name = "lucky_numbers")
-        public int lucky_number;
-        @RiakIndex(name = "other_numbers")
-        public Set<Integer> otherNumbers;
+        @RiakIndex(name = "lucky_numbers") public int lucky_number;
+        @RiakIndex(name = "other_numbers") public Set<Integer> otherNumbers;
+
+        @RiakIndex(name = "calculated_numbers") public Set<Integer> getCalculatedNumbers() {
+            final Set<Integer> calculatedNumbers = new HashSet<Integer>();
+            for (int i = 0; i < CALCULATIONS_COUNT; i++) {
+                calculatedNumbers.add(i);
+            }
+            return calculatedNumbers;
+        }
+
+        @RiakIndex(name = "calculated_strings") public Set<String> getCalculatedStrings() {
+            final Set<String> calculatedStrings = new HashSet<String>();
+            for (int i = 0; i < CALCULATIONS_COUNT; i++) {
+                calculatedStrings.add(String.valueOf(i));
+            }
+            return calculatedStrings;
+        }
     }
-    
-    
+
 }


### PR DESCRIPTION
Enables @RiakIndex annotation support for methods where return types are String, Integer, Long or a parametrized Set of any of those. This support avoid having a pseudo property just to store an index value(s) inside the Object, for most cases indexes are meant to be calculated values obtained via methods and not at properties, specially if they depend on the real properties of such POJO.
