### PR TITLE
Add support for an optional mutation where the client can optionally write back to Riak

### DIFF
--- a/src/main/java/com/basho/riak/client/cap/CriteriaMutation.java
+++ b/src/main/java/com/basho/riak/client/cap/CriteriaMutation.java
@@ -1,0 +1,12 @@
+package com.basho.riak.client.cap;
+
+/**
+ * Created by IntelliJ IDEA.
+ * User: gmedina
+ * Date: 18-Oct-2012
+ * Time: 16:55:01
+ */
+public interface CriteriaMutation<T> extends Mutation<T>
+{
+  public boolean hasMutated();
+}


### PR DESCRIPTION
An interface that extends Mutation with one extra contract hasMutated(), if this is true, Java client won't write back to Riak and will return the original Object used as target.

For some cases we add a mutation to an Object and after applying the mutation we realize that the target Object hasn't changed, writing it back to Riak is sub-optimal, we have a use case where this saves thousands of round trips to Riak.

Because such interface is an extension, it leaves current mutation old functionality untouched and only add a check where the mutation if an instance of CriteriaMutation.
