### PR TITLE
Fixed a typo in HTTPClientConfig Builder API

### DIFF
--- a/src/main/java/com/basho/riak/client/raw/http/HTTPClientConfig.java
+++ b/src/main/java/com/basho/riak/client/raw/http/HTTPClientConfig.java
@@ -359,24 +359,24 @@ public class HTTPClientConfig implements Configuration {
 		}
 
 		/**
-         * @deprecated As of 1.0.7, replaced by {@link #withMaxConnections(int)}
+		 * @deprecated As of 1.0.8, replaced by {@link #withMaxConnections(int)}
 		 * @see #withMaxConnections(int)
 		 */
-        @Deprecated
+		@Deprecated
 		public Builder withMaxConnctions(int maxConnections) {
 			return withMaxConnections(maxConnections);
 		}
 
-        /**
-         * Maximum number of connections this client may have open at any time.
-         *
-         * @param maxConnections The maximum of connections open in this client.
-         * @return this
-         */
-        public Builder withMaxConnections(int maxConnections) {
-            this.maxConnections = maxConnections;
-            return this;
-        }
+		/**
+		 * Maximum number of connections this client may have open at any time.
+		 *
+		 * @param maxConnections The maximum of connections open in this client.
+		 * @return this
+		 */
+		public Builder withMaxConnections(int maxConnections) {
+			this.maxConnections = maxConnections;
+			return this;
+		}
 
 		/**
 		 * Apache HttpClient treats some HTTP methods as retry-able, and


### PR DESCRIPTION
For API compatibility reasons, the old method remains but has been deprecated.
