### PR TITLE
Updates to support jackson 2.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,10 +4,10 @@
     <groupId>com.basho.riak</groupId>
     <artifactId>riak-client</artifactId>
     <packaging>bundle</packaging>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.0-jackson_2.1-SNAPSHOT</version>
     <name>Riak Client for Java</name>
-    <description>HttpClient-based client for Riak</description>
-    <url>https://github.com/basho/riak-java-client</url>
+    <description>HttpClient-based client for Riak - with jackson 2.1</description>
+    <url>https://github.com/mcaprari/riak-java-client</url>
 
     <licenses>
         <license>
@@ -40,9 +40,9 @@
     </developers>
 
     <scm>
-        <connection>scm:git:ssh://git@github.com/basho/riak-java-client.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/basho/riak-java-client.git</developerConnection>
-        <url>http://github.com/basho/riak-java-client</url>
+        <connection>scm:git:ssh://git@github.com/mcaprari/riak-java-client.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/mcaprari/riak-java-client.git</developerConnection>
+        <url>http://github.com/mcaprari/riak-java-client</url>
     </scm>
 
     <properties>
@@ -74,14 +74,19 @@
         </dependency>
         <!-- Protocol Buffers -->
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-core-asl</artifactId>
-            <version>1.9.11</version>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.1.2</version>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
-            <version>1.9.11</version>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.1.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.1.2</version>
         </dependency>
         <!-- Testing -->
         <dependency>

--- a/src/main/java/com/basho/riak/client/convert/JSONConverter.java
+++ b/src/main/java/com/basho/riak/client/convert/JSONConverter.java
@@ -21,15 +21,14 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
 
-import org.codehaus.jackson.JsonProcessingException;
-import org.codehaus.jackson.map.ObjectMapper;
-
 import com.basho.riak.client.IRiakObject;
 import com.basho.riak.client.RiakLink;
 import com.basho.riak.client.builders.RiakObjectBuilder;
 import com.basho.riak.client.cap.VClock;
 import com.basho.riak.client.http.util.Constants;
 import com.basho.riak.client.query.indexes.RiakIndexes;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Converts a RiakObject's value to an instance of T. T must have a field
@@ -59,7 +58,7 @@ public class JSONConverter<T> implements Converter<T> {
      * instances of <code>clazz</code>
      * 
      * @param clazz the type to convert to/from
-     * @param b the bucket
+     * @param bucket the bucket
      */
     public JSONConverter(Class<T> clazz, String bucket) {
         this(clazz, bucket, null);

--- a/src/main/java/com/basho/riak/client/convert/RiakBeanSerializerModifier.java
+++ b/src/main/java/com/basho/riak/client/convert/RiakBeanSerializerModifier.java
@@ -13,18 +13,19 @@
  */
 package com.basho.riak.client.convert;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.introspect.AnnotatedField;
+import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
+import com.fasterxml.jackson.databind.introspect.BasicBeanDescription;
+import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
+import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
+
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Field;
 import java.util.LinkedList;
 import java.util.List;
-
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.SerializationConfig;
-import org.codehaus.jackson.map.introspect.AnnotatedField;
-import org.codehaus.jackson.map.introspect.AnnotatedMember;
-import org.codehaus.jackson.map.introspect.BasicBeanDescription;
-import org.codehaus.jackson.map.ser.BeanPropertyWriter;
-import org.codehaus.jackson.map.ser.BeanSerializerModifier;
 
 /**
  * {@link BeanSerializerModifier} that drops {@link RiakKey} and
@@ -56,7 +57,7 @@ public class RiakBeanSerializerModifier extends BeanSerializerModifier {
      * org.codehaus.jackson.map.introspect.BasicBeanDescription, java.util.List)
      */
     @Override public List<BeanPropertyWriter> changeProperties(SerializationConfig config,
-                                                               BasicBeanDescription beanDesc,
+                                                               BeanDescription beanDesc,
                                                                List<BeanPropertyWriter> beanProperties) {
 
         List<BeanPropertyWriter> keptProperties = new LinkedList<BeanPropertyWriter>();

--- a/src/main/java/com/basho/riak/client/convert/RiakJacksonModule.java
+++ b/src/main/java/com/basho/riak/client/convert/RiakJacksonModule.java
@@ -13,8 +13,8 @@
  */
 package com.basho.riak.client.convert;
 
-import org.codehaus.jackson.Version;
-import org.codehaus.jackson.map.Module;
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.Module;
 
 /**
  * A <a href="">Jackson</a> {@link Module} that customises Jackson's object

--- a/src/main/java/com/basho/riak/client/convert/reflect/ClassUtil.java
+++ b/src/main/java/com/basho/riak/client/convert/reflect/ClassUtil.java
@@ -19,7 +19,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 /**
  * Reflection/class utilities. Delegates to
- * {@link org.codehaus.jackson.map.util.ClassUtil}.
+ * {@link com.fasterxml.jackson.databind.util.ClassUtil}.
  * 
  * @author russell
  * 
@@ -36,7 +36,7 @@ public final class ClassUtil {
      * @throw {@link IllegalArgumentException} if cannot set accessibility
      */
     public static <T extends Member> T checkAndFixAccess(T member) {
-        org.codehaus.jackson.map.util.ClassUtil.checkAndFixAccess(member);
+        com.fasterxml.jackson.databind.util.ClassUtil.checkAndFixAccess(member);
         return member;
     }
 

--- a/src/main/java/com/basho/riak/client/query/BucketKeyMapReduce.java
+++ b/src/main/java/com/basho/riak/client/query/BucketKeyMapReduce.java
@@ -18,11 +18,10 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedList;
 
-import org.codehaus.jackson.JsonGenerator;
-
 import com.basho.riak.client.IRiakClient;
 import com.basho.riak.client.raw.RawClient;
 import com.basho.riak.client.util.UnmodifiableIterator;
+import com.fasterxml.jackson.core.JsonGenerator;
 
 /**
  * Map/Reduce over a set of bucket/key/keydata inputs.

--- a/src/main/java/com/basho/riak/client/query/BucketMapReduce.java
+++ b/src/main/java/com/basho/riak/client/query/BucketMapReduce.java
@@ -19,13 +19,12 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedList;
 
-import org.codehaus.jackson.JsonGenerator;
-import org.codehaus.jackson.annotate.JsonProperty;
-
 import com.basho.riak.client.IRiakClient;
 import com.basho.riak.client.query.filter.KeyFilter;
 import com.basho.riak.client.raw.RawClient;
 import com.basho.riak.client.util.UnmodifiableIterator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonGenerator;
 
 /**
  * Map/Reduce over a bucket, optionally add Key Filters to narrow the inputs.

--- a/src/main/java/com/basho/riak/client/query/IndexMapReduce.java
+++ b/src/main/java/com/basho/riak/client/query/IndexMapReduce.java
@@ -15,11 +15,10 @@ package com.basho.riak.client.query;
 
 import java.io.IOException;
 
-import org.codehaus.jackson.JsonGenerator;
-
 import com.basho.riak.client.raw.RawClient;
 import com.basho.riak.client.raw.query.indexes.IndexQuery;
 import com.basho.riak.client.raw.query.indexes.IndexWriter;
+import com.fasterxml.jackson.core.JsonGenerator;
 
 /**
  * A {@link MapReduce} operation that takes a 2i index query as input

--- a/src/main/java/com/basho/riak/client/query/MapReduce.java
+++ b/src/main/java/com/basho/riak/client/query/MapReduce.java
@@ -18,11 +18,6 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.LinkedList;
 
-import org.codehaus.jackson.JsonEncoding;
-import org.codehaus.jackson.JsonFactory;
-import org.codehaus.jackson.JsonGenerator;
-import org.codehaus.jackson.map.ObjectMapper;
-
 import com.basho.riak.client.IRiakClient;
 import com.basho.riak.client.RiakException;
 import com.basho.riak.client.operations.RiakOperation;
@@ -30,6 +25,10 @@ import com.basho.riak.client.query.functions.Function;
 import com.basho.riak.client.query.serialize.FunctionToJson;
 import com.basho.riak.client.raw.RawClient;
 import com.basho.riak.client.raw.query.MapReduceSpec;
+import com.fasterxml.jackson.core.JsonEncoding;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * An operation for defining and runnig a Map/Reduce query on Riak.

--- a/src/main/java/com/basho/riak/client/query/NodeStats.java
+++ b/src/main/java/com/basho/riak/client/query/NodeStats.java
@@ -15,18 +15,19 @@
  */
 package com.basho.riak.client.query;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonProcessingException;
-import org.codehaus.jackson.JsonToken;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.DeserializationContext;
-import org.codehaus.jackson.map.JsonDeserializer;
-import org.codehaus.jackson.map.annotate.JsonDeserialize;
 
 /**
  * The encapsulation of the data returned by the Riak <code>/stats</code> 
@@ -61,7 +62,7 @@ import org.codehaus.jackson.map.annotate.JsonDeserialize;
 // We set this so as not to break is new stats are added to the Riak /stats operation
 
 
-@JsonIgnoreProperties(ignoreUnknown=true) 
+@JsonIgnoreProperties(ignoreUnknown=true)
 public class NodeStats implements Iterable<NodeStats>
 {
     

--- a/src/main/java/com/basho/riak/client/query/SearchMapReduce.java
+++ b/src/main/java/com/basho/riak/client/query/SearchMapReduce.java
@@ -15,10 +15,9 @@ package com.basho.riak.client.query;
 
 import java.io.IOException;
 
-import org.codehaus.jackson.JsonGenerator;
-import org.codehaus.jackson.annotate.JsonProperty;
-
 import com.basho.riak.client.raw.RawClient;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonGenerator;
 
 /**
  * A {@link MapReduce} operation that uses a Riak Search query as input.

--- a/src/main/java/com/basho/riak/client/query/functions/ReducePhaseOnlyOne.java
+++ b/src/main/java/com/basho/riak/client/query/functions/ReducePhaseOnlyOne.java
@@ -13,7 +13,7 @@
  */
 package com.basho.riak.client.query.functions;
 
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * An M/R function arg that mandates that Riak only run the reduce phase once,

--- a/src/main/java/com/basho/riak/client/query/serialize/FunctionToJson.java
+++ b/src/main/java/com/basho/riak/client/query/serialize/FunctionToJson.java
@@ -13,13 +13,12 @@
  */
 package com.basho.riak.client.query.serialize;
 
-import org.codehaus.jackson.JsonGenerator;
-
 import com.basho.riak.client.query.functions.Function;
 import com.basho.riak.client.query.functions.JSBucketKeyFunction;
 import com.basho.riak.client.query.functions.JSSourceFunction;
 import com.basho.riak.client.query.functions.NamedErlangFunction;
 import com.basho.riak.client.query.functions.NamedJSFunction;
+import com.fasterxml.jackson.core.JsonGenerator;
 
 /**
  * Helper to write a Function to a JsonGenerator

--- a/src/main/java/com/basho/riak/client/query/serialize/JSBucketKeyFunctionWriter.java
+++ b/src/main/java/com/basho/riak/client/query/serialize/JSBucketKeyFunctionWriter.java
@@ -15,9 +15,8 @@ package com.basho.riak.client.query.serialize;
 
 import java.io.IOException;
 
-import org.codehaus.jackson.JsonGenerator;
-
 import com.basho.riak.client.query.functions.JSBucketKeyFunction;
+import com.fasterxml.jackson.core.JsonGenerator;
 
 /**
  * Writes a {@link JSBucketKeyFunction} to a {@link JsonGenerator}

--- a/src/main/java/com/basho/riak/client/query/serialize/JSSourceFunctionWriter.java
+++ b/src/main/java/com/basho/riak/client/query/serialize/JSSourceFunctionWriter.java
@@ -15,9 +15,8 @@ package com.basho.riak.client.query.serialize;
 
 import java.io.IOException;
 
-import org.codehaus.jackson.JsonGenerator;
-
 import com.basho.riak.client.query.functions.JSSourceFunction;
+import com.fasterxml.jackson.core.JsonGenerator;
 
 /**
  * Writes a {@link JSSourceFunction} to a {@link JsonGenerator}

--- a/src/main/java/com/basho/riak/client/query/serialize/NamedErlangFunctionWriter.java
+++ b/src/main/java/com/basho/riak/client/query/serialize/NamedErlangFunctionWriter.java
@@ -15,9 +15,8 @@ package com.basho.riak.client.query.serialize;
 
 import java.io.IOException;
 
-import org.codehaus.jackson.JsonGenerator;
-
 import com.basho.riak.client.query.functions.NamedErlangFunction;
+import com.fasterxml.jackson.core.JsonGenerator;
 
 /**
  * Writes a {@link NamedErlangFunction} to a {@link JsonGenerator}

--- a/src/main/java/com/basho/riak/client/query/serialize/NamedJSFunctionWriter.java
+++ b/src/main/java/com/basho/riak/client/query/serialize/NamedJSFunctionWriter.java
@@ -15,9 +15,8 @@ package com.basho.riak.client.query.serialize;
 
 import java.io.IOException;
 
-import org.codehaus.jackson.JsonGenerator;
-
 import com.basho.riak.client.query.functions.NamedJSFunction;
+import com.fasterxml.jackson.core.JsonGenerator;
 
 /**
  * Writes a {@link NamedJSFunction} to a {@link JsonGenerator}

--- a/src/main/java/com/basho/riak/client/raw/JSONErrorParser.java
+++ b/src/main/java/com/basho/riak/client/raw/JSONErrorParser.java
@@ -17,11 +17,9 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.type.TypeFactory;
-
 import com.basho.riak.client.RiakException;
 import com.basho.riak.client.raw.query.MapReduceTimeoutException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Exceptions come back from Riak as JSON, parses exceptions, and throws the
@@ -99,7 +97,7 @@ public class JSONErrorParser {
      * @throws IOException
      */
     private static final Map<String, String> parseError(final String json) throws IOException {
-        return objectMapper.readValue(json, TypeFactory.mapType(HashMap.class, String.class, String.class));
+        return objectMapper.readValue(json, objectMapper.getTypeFactory().constructMapType(HashMap.class, String.class, String.class));
     }
 
     /**

--- a/src/main/java/com/basho/riak/client/raw/http/ConversionUtil.java
+++ b/src/main/java/com/basho/riak/client/raw/http/ConversionUtil.java
@@ -26,16 +26,17 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import com.fasterxml.jackson.core.JsonEncoding;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 import org.apache.http.impl.cookie.DateUtils;
-import org.codehaus.jackson.JsonEncoding;
-import org.codehaus.jackson.JsonFactory;
-import org.codehaus.jackson.JsonGenerator;
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.Version;
-import org.codehaus.jackson.map.JsonMappingException;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.module.SimpleModule;
-import org.codehaus.jackson.map.type.TypeFactory;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -119,7 +120,7 @@ public final class ConversionUtil {
     /**
      * Convert a {@link RiakObject} to an {@link IRiakObject}
      * 
-     * @param object
+     * @param o
      *            the {@link RiakObject} to convert
      * @return
      */
@@ -274,7 +275,7 @@ public final class ConversionUtil {
     }
 
     /**
-     * @param allIntIndexes
+     * @param intIndexes
      * @return
      */
     private static List<com.basho.riak.client.http.RiakIndex<Long>> convertIntIndexes(Map<IntIndex, Set<Long>> intIndexes) {
@@ -367,14 +368,14 @@ public final class ConversionUtil {
             throw new JsonMappingException("no 'props' field found");
         }
 
-        builder.allowSiblings(props.path(Constants.FL_SCHEMA_ALLOW_MULT).getBooleanValue());
-        builder.lastWriteWins(props.path(Constants.FL_SCHEMA_LAST_WRITE_WINS).getBooleanValue());
-        builder.nVal(props.path(Constants.FL_SCHEMA_NVAL).getIntValue());
-        builder.backend(props.path(Constants.FL_SCHEMA_BACKEND).getTextValue());
-        builder.smallVClock(props.path(Constants.FL_SCHEMA_SMALL_VCLOCK).getIntValue());
-        builder.bigVClock(props.path(Constants.FL_SCHEMA_BIG_VCLOCK).getIntValue());
-        builder.youngVClock(props.path(Constants.FL_SCHEMA_YOUNG_VCLOCK).getLongValue());
-        builder.oldVClock(props.path(Constants.FL_SCHEMA_OLD_VCLOCK).getLongValue());
+        builder.allowSiblings(props.path(Constants.FL_SCHEMA_ALLOW_MULT).booleanValue());
+        builder.lastWriteWins(props.path(Constants.FL_SCHEMA_LAST_WRITE_WINS).booleanValue());
+        builder.nVal(props.path(Constants.FL_SCHEMA_NVAL).intValue());
+        builder.backend(props.path(Constants.FL_SCHEMA_BACKEND).textValue());
+        builder.smallVClock(props.path(Constants.FL_SCHEMA_SMALL_VCLOCK).intValue());
+        builder.bigVClock(props.path(Constants.FL_SCHEMA_BIG_VCLOCK).intValue());
+        builder.youngVClock(props.path(Constants.FL_SCHEMA_YOUNG_VCLOCK).longValue());
+        builder.oldVClock(props.path(Constants.FL_SCHEMA_OLD_VCLOCK).longValue());
 
         for (JsonNode n : props.path(Constants.FL_SCHEMA_PRECOMMIT)) {
             if (n.path(Constants.FL_SCHEMA_FUN_NAME).isMissingNode()) {
@@ -400,17 +401,17 @@ public final class ConversionUtil {
             builder.pw(OBJECT_MAPPER.treeToValue(props.path(Constants.FL_SCHEMA_PW), Quorum.class));
         }
         if(!props.path(Constants.FL_SCHEMA_BASIC_QUORUM).isMissingNode()) {
-            builder.basicQuorum(props.path(Constants.FL_SCHEMA_BASIC_QUORUM).getBooleanValue());
+            builder.basicQuorum(props.path(Constants.FL_SCHEMA_BASIC_QUORUM).booleanValue());
         }
         if(!props.path(Constants.FL_SCHEMA_NOT_FOUND_OK).isMissingNode()) {
-            builder.notFoundOK(props.path(Constants.FL_SCHEMA_NOT_FOUND_OK).getBooleanValue());
+            builder.notFoundOK(props.path(Constants.FL_SCHEMA_NOT_FOUND_OK).booleanValue());
         }
 
         builder.chashKeyFunction(OBJECT_MAPPER.treeToValue(props.path(Constants.FL_SCHEMA_CHASHFUN),
                                                            NamedErlangFunction.class));
         builder.linkWalkFunction(OBJECT_MAPPER.treeToValue(props.path(Constants.FL_SCHEMA_LINKFUN),
                                                            NamedErlangFunction.class));
-        builder.search(props.path(Constants.FL_SCHEMA_SEARCH).getBooleanValue());
+        builder.search(props.path(Constants.FL_SCHEMA_SEARCH).booleanValue());
 
         return builder.build();
     }
@@ -596,7 +597,7 @@ public final class ConversionUtil {
 
             public <T> Collection<T> getResult(Class<T> resultType) throws ConversionException {
                 try {
-                    return OBJECT_MAPPER.readValue(getResultRaw(), TypeFactory.collectionType(Collection.class, resultType));
+                    return OBJECT_MAPPER.readValue(getResultRaw(), OBJECT_MAPPER.getTypeFactory().constructCollectionType(Collection.class, resultType));
                 } catch (IOException e) {
                     throw new ConversionException(e);
                 }

--- a/src/main/java/com/basho/riak/client/raw/http/HTTPClientAdapter.java
+++ b/src/main/java/com/basho/riak/client/raw/http/HTTPClientAdapter.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Set;
 
 import com.basho.riak.client.http.RiakConfig;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpStatus;
 
 import com.basho.riak.client.IRiakObject;
@@ -54,7 +55,6 @@ import com.basho.riak.client.raw.query.MapReduceTimeoutException;
 import com.basho.riak.client.raw.query.indexes.IndexQuery;
 import com.basho.riak.client.raw.query.indexes.IndexWriter;
 import com.basho.riak.client.util.CharsetUtils;
-import org.codehaus.jackson.map.ObjectMapper;
 
 /**
  * Adapts the http.{@link RiakClient} to the new {@link RawClient} interface.

--- a/src/main/java/com/basho/riak/client/raw/http/NamedErlangFunctionDeserializer.java
+++ b/src/main/java/com/basho/riak/client/raw/http/NamedErlangFunctionDeserializer.java
@@ -15,14 +15,14 @@ package com.basho.riak.client.raw.http;
 
 import java.io.IOException;
 
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonProcessingException;
-import org.codehaus.jackson.JsonToken;
-import org.codehaus.jackson.map.DeserializationContext;
-import org.codehaus.jackson.map.JsonDeserializer;
+import com.fasterxml.jackson.core.JsonParser;
 
 import com.basho.riak.client.http.util.Constants;
 import com.basho.riak.client.query.functions.NamedErlangFunction;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
 
 /**
  * Deserializes {@link NamedErlangFunction}s from JSON

--- a/src/main/java/com/basho/riak/client/raw/http/NamedJSFunctionDeserializer.java
+++ b/src/main/java/com/basho/riak/client/raw/http/NamedJSFunctionDeserializer.java
@@ -15,14 +15,13 @@ package com.basho.riak.client.raw.http;
 
 import java.io.IOException;
 
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonProcessingException;
-import org.codehaus.jackson.JsonToken;
-import org.codehaus.jackson.map.DeserializationContext;
-import org.codehaus.jackson.map.JsonDeserializer;
-
 import com.basho.riak.client.http.util.Constants;
 import com.basho.riak.client.query.functions.NamedJSFunction;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
 
 /**
  * @author russell

--- a/src/main/java/com/basho/riak/client/raw/http/QuorumDeserializer.java
+++ b/src/main/java/com/basho/riak/client/raw/http/QuorumDeserializer.java
@@ -15,20 +15,19 @@ package com.basho.riak.client.raw.http;
 
 import java.io.IOException;
 
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonProcessingException;
-import org.codehaus.jackson.JsonToken;
-import org.codehaus.jackson.map.DeserializationContext;
-import org.codehaus.jackson.map.JsonDeserializer;
-
 import com.basho.riak.client.cap.Quora;
 import com.basho.riak.client.cap.Quorum;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
 
 /**
  * @author russell
  *
  */
-public class QuorumDeserializer extends JsonDeserializer<Quorum>{
+public class QuorumDeserializer extends JsonDeserializer<Quorum> {
 
     /* (non-Javadoc)
      * @see org.codehaus.jackson.map.JsonDeserializer#deserialize(org.codehaus.jackson.JsonParser, org.codehaus.jackson.map.DeserializationContext)

--- a/src/main/java/com/basho/riak/client/raw/pbc/PBMapReduceResult.java
+++ b/src/main/java/com/basho/riak/client/raw/pbc/PBMapReduceResult.java
@@ -19,8 +19,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
 
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.type.TypeFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 import org.json.JSONArray;
 
 import com.basho.riak.client.convert.ConversionException;
@@ -100,7 +100,7 @@ public class PBMapReduceResult implements MapReduceResult {
      */
     public <T> Collection<T> getResult(Class<T> resultType) throws ConversionException {
         try {
-            return objectMapper.readValue(getResultRaw(), TypeFactory.collectionType(Collection.class, resultType));
+            return objectMapper.readValue(getResultRaw(), objectMapper.getTypeFactory().constructCollectionType(Collection.class, resultType));
         } catch (IOException e) {
             throw new ConversionException(e);
         }

--- a/src/test/java/com/basho/riak/client/convert/RiakBeanSerializerModifierTest.java
+++ b/src/test/java/com/basho/riak/client/convert/RiakBeanSerializerModifierTest.java
@@ -19,8 +19,8 @@ import static org.junit.Assert.assertTrue;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.ObjectMapper;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 
 /**

--- a/src/test/java/com/basho/riak/client/convert/RiakJacksonModuleTest.java
+++ b/src/test/java/com/basho/riak/client/convert/RiakJacksonModuleTest.java
@@ -17,7 +17,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import org.codehaus.jackson.map.Module.SetupContext;
+import com.fasterxml.jackson.databind.Module;
 import org.junit.Test;
 
 /**
@@ -28,11 +28,11 @@ public class RiakJacksonModuleTest {
 
     /**
      * Test method for
-     * {@link com.basho.riak.client.convert.RiakJacksonModule#setupModule(org.codehaus.jackson.map.Module.SetupContext)}
+     * {@link com.basho.riak.client.convert.RiakJacksonModule#setupModule(com.fasterxml.jackson.databind.Module.SetupContext)}
      * .
      */
     @Test public void setupAddsRiakbeanSerializerModifierToContext() {
-        SetupContext setupContext = mock(SetupContext.class);
+        Module.SetupContext setupContext = mock(Module.SetupContext.class);
         RiakJacksonModule module = new RiakJacksonModule();
         module.setupModule(setupContext);
         verify(setupContext, times(1)).addBeanSerializerModifier(RiakBeanSerializerModifier.getInstance());

--- a/src/test/java/com/basho/riak/client/itest/ITestMapReduce.java
+++ b/src/test/java/com/basho/riak/client/itest/ITestMapReduce.java
@@ -26,8 +26,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.type.TypeFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -178,10 +178,11 @@ public abstract class ITestMapReduce {
         		"{\"Date\":\"2010-01-06\",\"Open\":625.86,\"High\":625.86,\"Low\":606.36,\"Close\":608.26,\"Volume\":3978700,\"Adj. Close\":608.26}," +
         		"{\"Date\":\"2010-01-07\",\"Open\":609.4,\"High\":610,\"Low\":592.65,\"Close\":594.1,\"Volume\":6414300,\"Adj. Close\":594.1}," +
         		"{\"Date\":\"2010-01-08\",\"Open\":592,\"High\":603.25,\"Low\":589.11,\"Close\":602.02,\"Volume\":4724300,\"Adj. Close\":602.02}]";
-        
-        final LinkedList<GoogleStockDataItem> expected = new ObjectMapper()
+
+        final ObjectMapper objectMapper = new ObjectMapper();
+        final LinkedList<GoogleStockDataItem> expected = objectMapper
                                     .readValue(json, 
-                                               TypeFactory.collectionType(LinkedList.class, GoogleStockDataItem.class));
+                                               objectMapper.getTypeFactory().constructCollectionType(LinkedList.class, GoogleStockDataItem.class));
         
         final Bucket b = client.createBucket("goog").execute();
         final DomainBucket<GoogleStockDataItem> bucket = DomainBucket.builder(b, GoogleStockDataItem.class).build();
@@ -256,9 +257,10 @@ public abstract class ITestMapReduce {
                 "{\"Date\":\"2010-01-07\",\"Open\":609.4,\"High\":610,\"Low\":592.65,\"Close\":594.1,\"Volume\":6414300,\"Adj. Close\":594.1}," +
                 "{\"Date\":\"2010-01-08\",\"Open\":592,\"High\":603.25,\"Low\":589.11,\"Close\":602.02,\"Volume\":4724300,\"Adj. Close\":602.02}]";
 
-        final LinkedList<GoogleStockDataItem> expected = new ObjectMapper()
+        final ObjectMapper objectMapper = new ObjectMapper();
+        final LinkedList<GoogleStockDataItem> expected = objectMapper
                                     .readValue(json,
-                                               TypeFactory.collectionType(LinkedList.class, GoogleStockDataItem.class));
+                                            objectMapper.getTypeFactory().constructCollectionType(LinkedList.class, GoogleStockDataItem.class));
 
         final Bucket b = client.createBucket(bucketName).execute();
         final DomainBucket<GoogleStockDataItem> bucket = DomainBucket.builder(b, GoogleStockDataItem.class).build();

--- a/src/test/java/com/basho/riak/client/itest/ITestORM.java
+++ b/src/test/java/com/basho/riak/client/itest/ITestORM.java
@@ -26,8 +26,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.map.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Assume;
 import org.junit.Test;
 
@@ -156,9 +156,9 @@ public abstract class ITestORM extends ITestBucket {
         JsonNode value = new ObjectMapper().readTree(iro.getValueAsString());
 
         assertEquals(3, value.size());
-        assertEquals(username, value.get("username").getTextValue());
-        assertEquals(email, value.get("emailAddress").getTextValue());
-        assertEquals(null, value.get("shoeSize").getTextValue());
+        assertEquals(username, value.get("username").textValue());
+        assertEquals(email, value.get("emailAddress").textValue());
+        assertEquals(null, value.get("shoeSize").textValue());
         assertEquals(2, meta.size());
         assertEquals(languageCode, meta.get("language-pref"));
         assertEquals(blue, meta.get(favColor));

--- a/src/test/java/com/basho/riak/client/query/serialize/FunctionToJsonTest.java
+++ b/src/test/java/com/basho/riak/client/query/serialize/FunctionToJsonTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 
-import org.codehaus.jackson.JsonGenerator;
+import com.fasterxml.jackson.core.JsonGenerator;
 import org.junit.Test;
 
 import com.basho.riak.client.query.functions.Function;

--- a/src/test/java/com/basho/riak/client/raw/http/NamedErlangFunctionDeserializerTest.java
+++ b/src/test/java/com/basho/riak/client/raw/http/NamedErlangFunctionDeserializerTest.java
@@ -18,9 +18,9 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
-import org.codehaus.jackson.Version;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.module.SimpleModule;
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/src/test/java/com/basho/riak/client/raw/http/QuorumDeserializerTest.java
+++ b/src/test/java/com/basho/riak/client/raw/http/QuorumDeserializerTest.java
@@ -16,9 +16,9 @@ package com.basho.riak.client.raw.http;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import org.codehaus.jackson.Version;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.module.SimpleModule;
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/src/test/java/com/megacorp/commerce/Customer.java
+++ b/src/test/java/com/megacorp/commerce/Customer.java
@@ -17,11 +17,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-
 import com.basho.riak.client.convert.RiakIndex;
 import com.basho.riak.client.convert.RiakKey;
 import com.basho.riak.client.convert.RiakUsermeta;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * An other example entity, this time with user meta data

--- a/src/test/java/com/megacorp/commerce/Department.java
+++ b/src/test/java/com/megacorp/commerce/Department.java
@@ -15,11 +15,10 @@ package com.megacorp.commerce;
 
 import java.util.Collection;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-
 import com.basho.riak.client.RiakLink;
 import com.basho.riak.client.convert.RiakKey;
 import com.basho.riak.client.convert.RiakLinks;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * @author russell

--- a/src/test/java/com/megacorp/commerce/GoogleStockDataItem.java
+++ b/src/test/java/com/megacorp/commerce/GoogleStockDataItem.java
@@ -13,9 +13,8 @@
  */
 package com.megacorp.commerce;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-
 import com.basho.riak.client.convert.RiakKey;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class GoogleStockDataItem {
     //{"Date":"2010-01-05","Open":627.18,"High":627.84,"Low":621.54,"Close":623.99,"Volume":3004700,"Adj. Close":623.99}

--- a/src/test/java/com/megacorp/commerce/ShoppingCart.java
+++ b/src/test/java/com/megacorp/commerce/ShoppingCart.java
@@ -18,10 +18,9 @@ import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
-import org.codehaus.jackson.annotate.JsonCreator;
-import org.codehaus.jackson.annotate.JsonProperty;
-
 import com.basho.riak.client.convert.RiakKey;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * A simple domain object for the sake of ITests.
@@ -32,12 +31,14 @@ import com.basho.riak.client.convert.RiakKey;
 public class ShoppingCart implements Iterable<String> {
 
     @RiakKey private final String userId;
-    @JsonProperty private final Set<String> items;
+    @JsonProperty
+    private final Set<String> items;
 
     /**
      * @param userId
      */
-    @JsonCreator public ShoppingCart(@JsonProperty("userId") String userId) {
+    @JsonCreator
+    public ShoppingCart(@JsonProperty("userId") String userId) {
         this.userId = userId;
         items = new CopyOnWriteArraySet<String>();
     }


### PR DESCRIPTION
Hi,
I've just updates my fork deps and code to use jackson 2.1.1

The main reason to do this was to enable support for jackson-module-scala_2.10-2.1.3, which allows for better support for scala case classes, by adding the DefaultScalaModule to a JSONConverter objectMapper.

```
  val converter = new JSONConverter(t, name)
  converter.getObjectMapper.registerModule(DefaultScalaModule)
  DomainBucket.builder(bucket, t)
    .withConverter(converter)
    .build()
```

Cheers
-teo
