### PR TITLE
Fixes problem with idle connection reaping

### DIFF
--- a/src/main/java/com/basho/riak/pbc/RiakConnectionPool.java
+++ b/src/main/java/com/basho/riak/pbc/RiakConnectionPool.java
@@ -261,7 +261,13 @@ public class RiakConnectionPool {
                                     permits.release();
                                 }
                             }
+                        } else {
+                            // Since we are descending and this is a LIFO, 
+                            // if the current connection hasn't been idle beyond 
+                            // the threshold, there's no reason to descend further
+                            break;
                         }
+                        
                     }
                 }
             }, idleConnectionTTLNanos, idleConnectionTTLNanos, TimeUnit.NANOSECONDS);


### PR DESCRIPTION
The logic to reap idle connections from the RiakConnectionPool
was flawed and would hard loop under heavy load. This fixes that problem
and reduces the complexity by using a LinkedBlockingDeque to hold
connections.

Fixes #211
