### PR TITLE
Sane ping() for ClusterClient

### DIFF
--- a/src/main/java/com/basho/riak/client/raw/ClusterClient.java
+++ b/src/main/java/com/basho/riak/client/raw/ClusterClient.java
@@ -267,12 +267,14 @@ public abstract class ClusterClient<T extends Configuration> implements RawClien
         return delegate.getClientId();
     }
 
-    /* (non-Javadoc)
-     * @see com.basho.riak.client.raw.RawClient#ping()
+    /* 
+     * Pings every node in the cluster. If any node is down, will
+     * throw an exception.
      */
     public void ping() throws IOException {
-        final RawClient delegate = getDelegate();
-        delegate.ping();
+        for(RawClient rc : cluster) {
+            rc.ping();
+        }
     }
 
     /* (non-Javadoc)

--- a/src/test/java/com/basho/riak/client/raw/ClusterClientTest.java
+++ b/src/test/java/com/basho/riak/client/raw/ClusterClientTest.java
@@ -77,11 +77,10 @@ public class ClusterClientTest {
     }
 
     @Test public void ping() throws IOException {
-        for (int i = 0; i < 4; i++) {
-            client.ping();
-        }
+        client.ping();
+        
 
-        verify(client1, times(2)).ping();
+        verify(client1, times(1)).ping();
         verify(client2, times(1)).ping();
         verify(client3, times(1)).ping();
     }


### PR DESCRIPTION
The ClusterClient ping is really not useful currently as
it pings a random single node. You might get an exception,
might not. Without Breaking the IRiakClient interface this
makes it so ping() tells you if _all_ nodes are up in the
cluster.
