### PR TITLE
MapReduce failure using LogicalFilterGroup

### DIFF
--- a/src/main/java/com/basho/riak/client/query/filter/AbstractLogicalFilter.java
+++ b/src/main/java/com/basho/riak/client/query/filter/AbstractLogicalFilter.java
@@ -29,14 +29,22 @@ public abstract class AbstractLogicalFilter implements LogicalFilter {
     public AbstractLogicalFilter(KeyFilter... filters) {
         synchronized (this.filters) {
             for (KeyFilter filter : filters) {
-                this.filters.add(new Object[] { filter.asArray() });
+                if (filter instanceof LogicalFilterGroup) {
+                    this.filters.add(filter.asArray());
+                } else {
+                    this.filters.add(new Object[] { filter.asArray() });
+                }
             }
         }
     }
 
     public AbstractLogicalFilter add(KeyFilter filter) {
         synchronized (filter) {
-            filters.add(new Object[] { filter.asArray() });
+            if (filter instanceof LogicalFilterGroup) {
+                filters.add(filter.asArray());
+            } else {
+                filters.add(new Object[] { filter.asArray() });
+            }
         }
         return this;
     }


### PR DESCRIPTION
Fixes an issue where using the LogicalFilterGroup with an
AbstractLogicalFilter would result in incorrect JSON being
generated. Also adds integration testing to excercise
an AbstractLogicalFilter both with and without a
LogicalFilterGroup

fixes #216 
