### PR TITLE
Joda Time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,11 @@
             <artifactId>jackson-databind</artifactId>
             <version>2.1.2</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-joda</artifactId>
+            <version>2.1.1</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/com/basho/riak/client/convert/JSONConverter.java
+++ b/src/main/java/com/basho/riak/client/convert/JSONConverter.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
 
 import com.basho.riak.client.IRiakObject;
 import com.basho.riak.client.RiakLink;
@@ -87,6 +88,7 @@ public class JSONConverter<T> implements Converter<T> {
         this.riakIndexConverter = new RiakIndexConverter<T>();
         this.riakLinksConverter = new RiakLinksConverter<T>();
         objectMapper.registerModule(new RiakJacksonModule());
+        objectMapper.registerModule(new JodaModule());
     }
 
     /**


### PR DESCRIPTION
As Joda time was removed from the core jackson libraries, it changes how RJC responded to serializing / deserializing Joda time. This goes and pulls it back into the standard JSONConvertor's Objectmapper.
