### PR TITLE
Allows withoutFetch() in DomainBucket

### DIFF
--- a/src/main/java/com/basho/riak/client/bucket/DomainBucket.java
+++ b/src/main/java/com/basho/riak/client/bucket/DomainBucket.java
@@ -89,6 +89,7 @@ public class DomainBucket<T> {
     private final DeleteMeta deleteMeta;
     private final Class<T> clazz;
     private final Retrier retrier;
+    private final boolean withoutFetch;
 
   
     /**
@@ -116,10 +117,13 @@ public class DomainBucket<T> {
      *            the Class type of the DomainBucket
      * @param retrier
      *            the {@link Retrier} to use for each operation
+     * @param withoutFetch
+     *            controls whether a store operation should do a fetch first
+     *            @see StoreObject#withoutFetch() 
      */
     public DomainBucket(Bucket bucket, ConflictResolver<T> resolver, Converter<T> converter,
             MutationProducer<T> mutationProducer, StoreMeta storeMeta, FetchMeta fetchMeta, DeleteMeta deleteMeta,
-            Class<T> clazz, final Retrier retrier) {
+            Class<T> clazz, final Retrier retrier, boolean withoutFetch) {
         this.bucket = bucket;
         this.resolver = resolver;
         this.converter = converter;
@@ -129,8 +133,15 @@ public class DomainBucket<T> {
         this.deleteMeta = deleteMeta;
         this.clazz = clazz;
         this.retrier = retrier;
+        this.withoutFetch = withoutFetch;
     }
 
+    public DomainBucket(Bucket bucket, ConflictResolver<T> resolver, Converter<T> converter,
+            MutationProducer<T> mutationProducer, StoreMeta storeMeta, FetchMeta fetchMeta, DeleteMeta deleteMeta,
+            Class<T> clazz, final Retrier retrier) {
+        this(bucket, resolver, converter, mutationProducer, storeMeta, fetchMeta, deleteMeta, clazz, retrier, false);
+    }
+    
     /**
      * Store <code>o</code> in Riak.
      * <code>T</code> must have a field annotated with {@link RiakKey}.
@@ -155,6 +166,10 @@ public class DomainBucket<T> {
             .withMutator(mutation)
             .withResolver(resolver)
             .withRetrier(retrier);
+        
+        if (withoutFetch) {
+            so.withoutFetch();
+        }
 
         if (fetchMeta.getR() != null) {
             so.r(fetchMeta.getR());

--- a/src/main/java/com/basho/riak/client/builders/DomainBucketBuilder.java
+++ b/src/main/java/com/basho/riak/client/builders/DomainBucketBuilder.java
@@ -55,6 +55,7 @@ public class DomainBucketBuilder<T> {
     private Mutation<T> mutation;
     private MutationProducer<T> mutationProducer;
     private Retrier retrier = DefaultRetrier.attempts(3);
+    private boolean withoutFetch;
 
     private FetchMeta.Builder fetchMetaBuilder = new FetchMeta.Builder();
     private StoreMeta.Builder storeMetaBuilder = new StoreMeta.Builder();
@@ -96,7 +97,7 @@ public class DomainBucketBuilder<T> {
 
         return new DomainBucket<T>(bucket, resolver, converter, mutationProducer,
                     storeMetaBuilder.returnBody(returnBody).build(), fetchMetaBuilder.build(), deleteMetaBuilder.build(),
-                    clazz, retrier);
+                    clazz, retrier, withoutFetch);
     }
 
     /**
@@ -319,4 +320,19 @@ public class DomainBucketBuilder<T> {
         this.converter = converter;
         return this;
     }
+    
+    /**
+     * Sets whether a store operation should fetch existing value(s) from Riak 
+     * (and the vector clock) and perform conflict resolution if required.
+     * 
+     * Note this should only be used if you understand the ramifications. 
+     * @see com.basho.riak.client.operations.StoreObject#withoutFetch() 
+     * @param withoutFetch
+     * @return this
+     */
+    public DomainBucketBuilder<T> withoutFetch(boolean withoutFetch) {
+        this.withoutFetch = withoutFetch;
+        return this;
+    }
+    
 }


### PR DESCRIPTION
This is a simple change allowing a boolean to be set when
constructing a DomainBucket that is then used to call
withoutFetch() on the underlying StoreObject

Addresses #232
