### PR TITLE
Object mapper at JsonConverter is now a singleton instance.

### DIFF
--- a/src/main/java/com/basho/riak/client/convert/JSONConverter.java
+++ b/src/main/java/com/basho/riak/client/convert/JSONConverter.java
@@ -184,7 +184,7 @@ public class JSONConverter<T> implements Converter<T> {
      * This is a convenience method to allow changing its behavior.
      * @return The Jackson ObjectMapper
      */
-    public ObjectMapper getObjectMapper() {
+    public static ObjectMapper getObjectMapper() {
         return OBJECT_MAPPER;
     }
 


### PR DESCRIPTION
Object mapper at JsonConverter is now a singleton instance and by default registers RiakModule and JodaModule, also a convenient method added to register custom modules to this singleton ObjectMapper.
