### PR TITLE
Gh251 reset bucket properties 1.4

### DIFF
--- a/src/main/java/com/basho/riak/client/DefaultRiakClient.java
+++ b/src/main/java/com/basho/riak/client/DefaultRiakClient.java
@@ -22,6 +22,8 @@ import com.basho.riak.client.raw.Transport;
 import com.basho.riak.client.raw.http.HTTPClientAdapter;
 import com.basho.riak.client.raw.pbc.PBClientAdapter;
 import com.basho.riak.client.raw.query.indexes.IndexQuery;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * The default implementation of IRiakClient.
@@ -120,6 +122,18 @@ public final class DefaultRiakClient implements IRiakClient {
         return new WriteBucket(rawClient, bucketName, retrier);
     }
 
+    /**
+     * (non-Javadoc)
+     * @see RawClient#resetBucketProperties(java.lang.String) 
+     * 
+     */
+    public void resetBucket(String bucketName) throws RiakException {
+        try {
+            rawClient.resetBucketProperties(bucketName);
+        } catch (IOException ex) {
+            throw new RiakException(ex);
+        }
+    }
     // CLIENT ID
 
     /* (non-Javadoc)

--- a/src/main/java/com/basho/riak/client/IRiakClient.java
+++ b/src/main/java/com/basho/riak/client/IRiakClient.java
@@ -140,6 +140,12 @@ public interface IRiakClient {
     WriteBucket createBucket(String bucketName);
 
     /**
+     * Reset a bucket's properties back to the defaults
+     * @param bucketName 
+     */
+    void resetBucket(String bucketName) throws RiakException;
+    
+    /**
      * Create a {@link LinkWalk} operation that starts at startObject.
      * 
      * See also <a href="http://wiki.basho.com/Links.html">Link Walking</a> on the basho site.

--- a/src/main/java/com/basho/riak/client/http/RiakClient.java
+++ b/src/main/java/com/basho/riak/client/http/RiakClient.java
@@ -107,6 +107,10 @@ public class RiakClient {
         }
     }
 
+    public HttpResponse resetBucketSchema(String bucket) {
+        return helper.resetBucketSchema(bucket);
+    }
+    
     /* (non-Javadoc)
      * @see com.basho.riak.client.HttpRiakClient#getBucketSchema(java.lang.String)
      */

--- a/src/main/java/com/basho/riak/client/http/util/ClientHelper.java
+++ b/src/main/java/com/basho/riak/client/http/util/ClientHelper.java
@@ -129,6 +129,15 @@ public class ClientHelper {
         return listBucket(bucket, meta, false);
     }
 
+    public HttpResponse resetBucketSchema(String bucket) {
+        if (null == bucket || bucket.equalsIgnoreCase("")) {
+            throw new IllegalArgumentException("bucket name can not be null or empty");
+        }
+        String url = config.getBaseUrl() + "/buckets/" + ClientUtils.urlEncode(bucket) + "/props";
+        HttpDelete delete = new HttpDelete(url);
+        return executeMethod(null, null, delete, null, false);
+    }
+    
     /**
      * List the buckets in Riak
      * 

--- a/src/main/java/com/basho/riak/client/raw/ClusterClient.java
+++ b/src/main/java/com/basho/riak/client/raw/ClusterClient.java
@@ -208,6 +208,11 @@ public abstract class ClusterClient<T extends Configuration> implements RawClien
         delegate.updateBucket(name, bucketProperties);
     }
 
+    public void resetBucketProperties(String bucketName) throws IOException {
+        final RawClient delegate = getDelegate();
+        delegate.resetBucketProperties(bucketName);
+    }
+    
     /*
      * (non-Javadoc)
      * 

--- a/src/main/java/com/basho/riak/client/raw/RawClient.java
+++ b/src/main/java/com/basho/riak/client/raw/RawClient.java
@@ -204,6 +204,12 @@ public interface RawClient {
     void updateBucket(String name, BucketProperties bucketProperties) throws IOException;
 
     /**
+     * Reset the bucket properties for this bucket back to the default values
+     * @param bucketName 
+     */
+    void resetBucketProperties(String bucketName) throws IOException;
+    
+    /**
      * An unmodifiable view of the keys for the bucket named
      * <code>bucketName</code>
      * 

--- a/src/main/java/com/basho/riak/client/raw/http/HTTPClientAdapter.java
+++ b/src/main/java/com/basho/riak/client/raw/http/HTTPClientAdapter.java
@@ -352,6 +352,18 @@ public class HTTPClientAdapter implements RawClient {
         }
     }
 
+    /**
+     * (non-Javadoc)
+     * 
+     * @see RawClient#resetBucketProperties(java.lang.String) 
+     */
+    public void resetBucketProperties(String bucketName) throws IOException {
+        HttpResponse response = client.resetBucketSchema(bucketName);
+        if (!response.isSuccess()) {
+            throw new IOException(response.getBodyAsString());
+        }
+    }
+    
     /*
      * (non-Javadoc)
      * 

--- a/src/main/java/com/basho/riak/client/raw/pbc/PBClientAdapter.java
+++ b/src/main/java/com/basho/riak/client/raw/pbc/PBClientAdapter.java
@@ -278,6 +278,13 @@ public class PBClientAdapter implements RawClient {
 
     }
 
+    public void resetBucketProperties(String bucket) throws IOException {
+        if (null == bucket || bucket.equalsIgnoreCase("")) {
+            throw new IllegalArgumentException("Bucket name can not be null or empty");
+        }
+        client.resetBucketProperties(ByteString.copyFromUtf8(bucket));
+    }
+    
     /*
      * (non-Javadoc)
      * 

--- a/src/main/java/com/basho/riak/pbc/RiakClient.java
+++ b/src/main/java/com/basho/riak/pbc/RiakClient.java
@@ -733,6 +733,19 @@ public class RiakClient implements RiakMessageCodes {
 			release(c);
 		}
 	}
+    
+    public void resetBucketProperties(ByteString bucket) throws IOException {
+        RiakPB.RpbResetBucketReq req = RiakPB.RpbResetBucketReq.newBuilder().setBucket(
+            bucket).build();
+        
+        RiakConnection c = getConnection();
+        try {
+            c.send(MSG_ResetBucketReq, req);
+            c.receive_code(MSG_ResetBucketResp);
+        } finally {
+            release(c);
+        }
+    }
 
 	// /////////////////////
 

--- a/src/main/java/com/basho/riak/pbc/RiakMessageCodes.java
+++ b/src/main/java/com/basho/riak/pbc/RiakMessageCodes.java
@@ -49,5 +49,9 @@ interface RiakMessageCodes {
 	public static final int MSG_MapRedResp = 24;
 	public static final int MSG_IndexReq = 25;
 	public static final int MSG_IndexResp = 26;
+    public static final int MSG_SearchQueryReq = 27;
+    public static final int MSG_SearchQueryResp = 28;
+    public static final int MSG_ResetBucketReq = 29;
+    public static final int MSG_ResetBucketResp = 30;
 
 }

--- a/src/test/java/com/basho/riak/client/itest/ITestClientBasic.java
+++ b/src/test/java/com/basho/riak/client/itest/ITestClientBasic.java
@@ -106,6 +106,26 @@ public abstract class ITestClientBasic {
         client.updateBucket(b).allowSiblings(false).nVal(3).execute();
     }
 
+    @Test public void resetBucketProps() throws RiakException, InterruptedException {
+        Bucket b = client.createBucket(bucketName).nVal(4).r(2).w(2).allowSiblings(true).execute();
+        assertNotNull(b);
+        assertEquals(bucketName, b.getName());
+        assertEquals(new Integer(4), b.getNVal());
+        assertTrue(b.getAllowSiblings());
+        assertEquals(2, b.getR().getIntValue());
+        assertEquals(2, b.getW().getIntValue());
+        
+        client.resetBucket(bucketName);
+        b = client.fetchBucket(bucketName).execute();
+
+        assertNotNull(b);
+        assertEquals(bucketName, b.getName());
+        assertEquals(new Integer(3), b.getNVal());
+        assertFalse(b.getAllowSiblings());
+        assertEquals(b.getR().getSymbolicValue(), Quora.QUORUM);
+        assertEquals(b.getW().getSymbolicValue(), Quora.QUORUM);
+    }
+    
     @Test public void clientIds() throws Exception {
         final byte[] clientId = CharsetUtils.utf8StringToBytes("abcd");
 


### PR DESCRIPTION
You can now use the reset bucket properties operation via both HTTP and PB. This is exposed at the top level via IRiakClient.resetBucket(bucketName);

Addresses #251 

**Do not merge to master until after 1.1.2 has been cut**
