### PR TITLE
StoreObject will mutate passed object if without fetch is set

### DIFF
--- a/src/main/java/com/basho/riak/client/bucket/DefaultBucket.java
+++ b/src/main/java/com/basho/riak/client/bucket/DefaultBucket.java
@@ -370,7 +370,7 @@ public class DefaultBucket implements Bucket {
      */
     public StoreObject<IRiakObject> store(final String key, final byte[] value) {
 
-        return new StoreObject<IRiakObject>(client, name, key, retrier).withMutator(new Mutation<IRiakObject>() {
+        return new StoreObject<IRiakObject>(client, name, null, key, retrier).withMutator(new Mutation<IRiakObject>() {
             public IRiakObject apply(IRiakObject original) {
                 if (original == null) {
                     return RiakObjectBuilder.newBuilder(name, key).withValue(value).withContentType(Constants.CTYPE_OCTET_STREAM).build();
@@ -466,7 +466,7 @@ public class DefaultBucket implements Bucket {
         
         Converter<T> converter = getDefaultConverter(clazz);
 
-        return new StoreObject<T>(client, name, key, retrier)
+        return new StoreObject<T>(client, name, o, key, retrier)
             .withConverter(converter)
                 .withMutator(new ClobberMutation<T>(o))
                   .withResolver(new DefaultResolver<T>());
@@ -514,7 +514,7 @@ public class DefaultBucket implements Bucket {
     public <T> StoreObject<T> store(final String key, final T o) {
         @SuppressWarnings("unchecked") final Class<T> clazz = (Class<T>) o.getClass();
         Converter<T> converter = getDefaultConverter(clazz, key);
-        return new StoreObject<T>(client, name, key, retrier).
+        return new StoreObject<T>(client, name, o, key, retrier).
         withConverter(converter)
             .withMutator(new ClobberMutation<T>(o)).withResolver(new DefaultResolver<T>());
     }

--- a/src/test/java/com/basho/riak/client/operations/StoreObjectTest.java
+++ b/src/test/java/com/basho/riak/client/operations/StoreObjectTest.java
@@ -70,7 +70,7 @@ public class StoreObjectTest {
         MockitoAnnotations.initMocks(this);
         retrier = new DefaultRetrier(1);
         conflictResolver = new DefaultResolver<String>();
-        store = new StoreObject<String>(rawClient, BUCKET, KEY, retrier);
+        store = new StoreObject<String>(rawClient, BUCKET, null, KEY, retrier);
     }
 
     /**


### PR DESCRIPTION
When doing the operation:

```
T object = ...
bucket.store(object).withoutFetch().returnBody(true).withMutator(myMutator).execute();
```

The mutator will modify the passed object which per user's needs it could come up from an in-memory cache so there is no need to fetch BUT it needs to be passed to the mutation to do its job on that object.
