### PR TITLE
Modified ops to take bucket type.

### DIFF
--- a/src/main/java/com/basho/riak/client/core/converters/GetRespConverter.java
+++ b/src/main/java/com/basho/riak/client/core/converters/GetRespConverter.java
@@ -40,11 +40,13 @@ public class GetRespConverter implements RiakResponseConverter<RiakKvPB.RpbGetRe
 
     private final ByteArrayWrapper key;
     private final ByteArrayWrapper bucket;
+    private final ByteArrayWrapper bucketType;
 
-    public GetRespConverter(ByteArrayWrapper bucket, ByteArrayWrapper key)
+    public GetRespConverter(ByteArrayWrapper bucketType, ByteArrayWrapper bucket, ByteArrayWrapper key)
     {
         this.bucket = bucket;
         this.key = key;
+        this.bucketType = bucketType;
     }
 
     @Override
@@ -56,6 +58,7 @@ public class GetRespConverter implements RiakResponseConverter<RiakKvPB.RpbGetRe
             List<RiakObject> objectList = new ArrayList<RiakObject>(1);
             objectList.add(RiakObject.create(bucket.unsafeGetValue())
                 .setKey(key.unsafeGetValue())
+                .setBucketType(bucketType != null ? bucketType.unsafeGetValue() : null)
                 .setNotFound(true)
                 .setModified(false));
             return objectList;
@@ -86,6 +89,7 @@ public class GetRespConverter implements RiakResponseConverter<RiakKvPB.RpbGetRe
             RiakObject riakObject =
                 RiakObject.create(bucket.unsafeGetValue())
                     .setKey(key.unsafeGetValue())
+                    .setBucketType(bucketType != null ? bucketType.unsafeGetValue() : null)
                     .unsafeSetValue(content.getValue().toByteArray())
                     .setVClock(vclock.toByteArray())
                     .setContentType(nullSafeByteStringToUtf8(content.getContentType()))

--- a/src/main/java/com/basho/riak/client/core/operations/DeleteOperation.java
+++ b/src/main/java/com/basho/riak/client/core/operations/DeleteOperation.java
@@ -39,6 +39,7 @@ public class DeleteOperation extends FutureOperation<Void, Void>
 
 	private final ByteArrayWrapper bucket;
 	private final ByteArrayWrapper key;
+    private ByteArrayWrapper bucketType;
 	private DeleteMeta deleteMeta;
 
     /**
@@ -67,7 +68,7 @@ public class DeleteOperation extends FutureOperation<Void, Void>
 	 * Sets the {@link DeleteMeta} to be used. If not set, the default options will be used
 	 *
 	 * @param deleteMeta
-	 * @return this
+	 * @return A reference to this object.
 	 */
 	public DeleteOperation withDeleteMeta(DeleteMeta deleteMeta)
 	{
@@ -75,6 +76,22 @@ public class DeleteOperation extends FutureOperation<Void, Void>
 		return this;
 	}
 
+    /**
+     * Set the bucket type.
+     * If unset "default" is used. 
+     * @param bucketType the bucket type to use
+     * @return A reference to this object.
+     */
+    public DeleteOperation withBucketType(ByteArrayWrapper bucketType)
+    {
+        if (null == bucketType || bucketType.length() == 0)
+        {
+            throw new IllegalArgumentException("Bucket type can not be null or zero length");
+        }
+        this.bucketType = bucketType;
+        return this;
+    }
+    
     @Override
     protected Void convert(List<Void> rawResponse) throws ExecutionException
     {
@@ -100,6 +117,11 @@ public class DeleteOperation extends FutureOperation<Void, Void>
 		RiakKvPB.RpbDelReq.Builder builder = RiakKvPB.RpbDelReq.newBuilder();
 		builder.setBucket(ByteString.copyFrom(bucket.unsafeGetValue()));
 		builder.setKey(ByteString.copyFrom(key.unsafeGetValue()));
+        
+        if (bucketType != null)
+        {
+            builder.setType(ByteString.copyFrom(bucketType.unsafeGetValue()));
+        }
 
 		if (deleteMeta.hasTimeout())
 		{

--- a/src/main/java/com/basho/riak/client/core/operations/FetchBucketPropsOperation.java
+++ b/src/main/java/com/basho/riak/client/core/operations/FetchBucketPropsOperation.java
@@ -36,21 +36,33 @@ import java.util.concurrent.ExecutionException;
 public class FetchBucketPropsOperation extends FutureOperation<BucketProperties, RiakPB.RpbGetBucketResp>
 {
 
-    private final ByteArrayWrapper bucketType;
+    private ByteArrayWrapper bucketType;
     private final ByteArrayWrapper bucketName;
     
-    public FetchBucketPropsOperation(ByteArrayWrapper bucketType, ByteArrayWrapper bucketName)
+    public FetchBucketPropsOperation(ByteArrayWrapper bucketName)
+    {
+        
+        if (null == bucketName || bucketName.length() == 0)
+        {
+            throw new IllegalArgumentException("Bucket name can not be null or zero length");
+        }
+        this.bucketName = bucketName;
+    }
+    
+    /**
+     * Set the bucket type.
+     * If unset "default" is used. 
+     * @param bucketType the bucket type to use
+     * @return A reference to this object.
+     */
+    public FetchBucketPropsOperation withBucketType(ByteArrayWrapper bucketType)
     {
         if (null == bucketType || bucketType.length() == 0)
         {
             throw new IllegalArgumentException("Bucket type can not be null or zero length");
         }
-        if (null == bucketName || bucketName.length() == 0)
-        {
-            throw new IllegalArgumentException("Bucket name can not be null or zero length");
-        }
         this.bucketType = bucketType;
-        this.bucketName = bucketName;
+        return this;
     }
     
     @Override
@@ -122,7 +134,10 @@ public class FetchBucketPropsOperation extends FutureOperation<BucketProperties,
         RiakPB.RpbGetBucketReq.Builder builder = 
             RiakPB.RpbGetBucketReq.newBuilder();
         
-        builder.setType(ByteString.copyFrom(bucketType.unsafeGetValue()));
+        if (bucketType !=null)
+        {
+            builder.setType(ByteString.copyFrom(bucketType.unsafeGetValue()));
+        }
         builder.setBucket(ByteString.copyFrom(bucketName.unsafeGetValue()));
         RiakPB.RpbGetBucketReq req = builder.build();
         return new RiakMessage(RiakMessageCodes.MSG_GetBucketReq, req.toByteArray());

--- a/src/main/java/com/basho/riak/client/core/operations/FetchCounterOperation.java
+++ b/src/main/java/com/basho/riak/client/core/operations/FetchCounterOperation.java
@@ -40,6 +40,7 @@ public class FetchCounterOperation extends FutureOperation<Long, RiakKvPB.RpbCou
 
 	private final ByteArrayWrapper bucket;
 	private final ByteArrayWrapper key;
+    private ByteArrayWrapper bucketType;
 	private FetchMeta fetchMeta = new FetchMeta.Builder().build();
 
 	public FetchCounterOperation(ByteArrayWrapper bucket, ByteArrayWrapper key)
@@ -59,6 +60,22 @@ public class FetchCounterOperation extends FutureOperation<Long, RiakKvPB.RpbCou
 		this.key = key;
 	}
 
+    /**
+     * Set the bucket type.
+     * If unset "default" is used. 
+     * @param bucketType the bucket type to use
+     * @return A reference to this object.
+     */
+    public FetchCounterOperation withBucketType(ByteArrayWrapper bucketType)
+    {
+        if (null == bucketType || bucketType.length() == 0)
+        {
+            throw new IllegalArgumentException("Bucket type can not be null or zero length");
+        }
+        this.bucketType = bucketType;
+        return this;
+    }
+    
 	@Override
 	protected Long convert(List<RiakKvPB.RpbCounterGetResp> responses) throws ExecutionException
 	{
@@ -100,6 +117,11 @@ public class FetchCounterOperation extends FutureOperation<Long, RiakKvPB.RpbCou
 		builder.setBucket(ByteString.copyFrom(bucket.unsafeGetValue()));
 		builder.setKey(ByteString.copyFrom(key.unsafeGetValue()));
 
+        if (bucketType != null)
+        {
+            builder.setType(ByteString.copyFrom(bucketType.unsafeGetValue()));
+        }
+        
 		if (fetchMeta.hasR())
 		{
 			builder.setR(fetchMeta.getR().getIntValue());

--- a/src/main/java/com/basho/riak/client/core/operations/ListBucketsOperation.java
+++ b/src/main/java/com/basho/riak/client/core/operations/ListBucketsOperation.java
@@ -32,6 +32,7 @@ public class ListBucketsOperation extends FutureOperation<List<ByteArrayWrapper>
 
     private final Integer timeout;
     private final boolean stream;
+    private ByteArrayWrapper bucketType;
 
     public ListBucketsOperation(int timeout, boolean stream)
     {
@@ -51,6 +52,22 @@ public class ListBucketsOperation extends FutureOperation<List<ByteArrayWrapper>
         this.stream = true;
     }
 
+     /**
+     * Set the bucket type.
+     * If unset "default" is used. 
+     * @param bucketType the bucket type to use
+     * @return A reference to this object.
+     */
+    public ListBucketsOperation withBucketType(ByteArrayWrapper bucketType)
+    {
+        if (null == bucketType || bucketType.length() == 0)
+        {
+            throw new IllegalArgumentException("Bucket type can not be null or zero length");
+        }
+        this.bucketType = bucketType;
+        return this;
+    }
+    
     @Override
     protected boolean done(RiakKvPB.RpbListBucketsResp message)
     {
@@ -80,6 +97,11 @@ public class ListBucketsOperation extends FutureOperation<List<ByteArrayWrapper>
         if (timeout != null)
         {
             request.setTimeout(timeout);
+        }
+        
+        if (bucketType != null)
+        {
+            request.setType(ByteString.copyFrom(bucketType.unsafeGetValue()));
         }
 
         return new RiakMessage(RiakMessageCodes.MSG_ListBucketsReq, request.build().toByteArray());

--- a/src/main/java/com/basho/riak/client/core/operations/ListKeysOperation.java
+++ b/src/main/java/com/basho/riak/client/core/operations/ListKeysOperation.java
@@ -32,6 +32,7 @@ public class ListKeysOperation extends FutureOperation<List<ByteArrayWrapper>, R
 
     private final Integer timeout;
     private final ByteArrayWrapper bucket;
+    private ByteArrayWrapper bucketType;
 
     public ListKeysOperation(ByteArrayWrapper bucket, Integer timeout)
     {
@@ -61,6 +62,22 @@ public class ListKeysOperation extends FutureOperation<List<ByteArrayWrapper>, R
         this.bucket = bucket;
     }
 
+    /**
+     * Set the bucket type.
+     * If unset "default" is used. 
+     * @param bucketType the bucket type to use
+     * @return A reference to this object.
+     */
+    public ListKeysOperation withBucketType(ByteArrayWrapper bucketType)
+    {
+        if (null == bucketType || bucketType.length() == 0)
+        {
+            throw new IllegalArgumentException("Bucket type can not be null or zero length");
+        }
+        this.bucketType = bucketType;
+        return this;
+    }
+    
     @Override
     protected List<ByteArrayWrapper> convert(List<RiakKvPB.RpbListKeysResp> rawResponse) throws ExecutionException
     {
@@ -84,6 +101,10 @@ public class ListKeysOperation extends FutureOperation<List<ByteArrayWrapper>, R
         if (timeout != null)
         {
             request.setTimeout(timeout);
+        }
+        if (bucketType != null)
+        {
+            request.setType(ByteString.copyFrom(bucketType.unsafeGetValue()));
         }
 
         return new RiakMessage(RiakMessageCodes.MSG_ListKeysReq, request.build().toByteArray());

--- a/src/main/java/com/basho/riak/client/core/operations/ResetBucketPropsOperation.java
+++ b/src/main/java/com/basho/riak/client/core/operations/ResetBucketPropsOperation.java
@@ -31,21 +31,32 @@ import java.util.concurrent.ExecutionException;
  */
 public class ResetBucketPropsOperation extends FutureOperation<Void, Void>
 {
-    private final ByteArrayWrapper bucketType;
+    private ByteArrayWrapper bucketType;
     private final ByteArrayWrapper bucketName;
     
-    public ResetBucketPropsOperation(ByteArrayWrapper bucketType, ByteArrayWrapper bucketName)
+    public ResetBucketPropsOperation(ByteArrayWrapper bucketName)
     {
-        if (null == bucketType || bucketType.length() == 0)
-        {
-            throw new IllegalArgumentException("Bucket type cannot be null or zero length");
-        }
         if (null == bucketName || bucketName.length() == 0)
         {
             throw new IllegalArgumentException("Bucket name cannot be null or zero length");
         }
-        this.bucketType = bucketType;
         this.bucketName = bucketName;
+    }
+    
+    /**
+     * Set the bucket type.
+     * If unset "default" is used. 
+     * @param bucketType the bucket type to use
+     * @return A reference to this object.
+     */
+    public ResetBucketPropsOperation withBucketType(ByteArrayWrapper bucketType)
+    {
+        if (null == bucketType || bucketType.length() == 0)
+        {
+            throw new IllegalArgumentException("Bucket type can not be null or zero length");
+        }
+        this.bucketType = bucketType;
+        return this;
     }
     
     @Override
@@ -57,11 +68,18 @@ public class ResetBucketPropsOperation extends FutureOperation<Void, Void>
     @Override
     protected RiakMessage createChannelMessage()
     {
+        RiakPB.RpbResetBucketReq.Builder builder = 
+            RiakPB.RpbResetBucketReq.newBuilder();
+        
+        if (bucketType != null)
+        {
+            builder.setType(ByteString.copyFrom(bucketType.unsafeGetValue()));
+        }
+        
         RiakPB.RpbResetBucketReq req = 
-            RiakPB.RpbResetBucketReq.newBuilder()
-                .setType(ByteString.copyFrom(bucketType.unsafeGetValue()))
-                .setBucket(ByteString.copyFrom(bucketName.unsafeGetValue()))
-                .build();
+            builder.setBucket(ByteString.copyFrom(bucketName.unsafeGetValue()))
+                   .build();
+        
         return new RiakMessage(RiakMessageCodes.MSG_ResetBucketReq, req.toByteArray());
     }
 

--- a/src/main/java/com/basho/riak/client/core/operations/UpdateCounterOperation.java
+++ b/src/main/java/com/basho/riak/client/core/operations/UpdateCounterOperation.java
@@ -38,6 +38,7 @@ public class UpdateCounterOperation extends FutureOperation<Long, RiakKvPB.RpbCo
     private final ByteArrayWrapper bucket;
     private final ByteArrayWrapper key;
     private final long amount;
+    private ByteArrayWrapper bucketType;
     private StoreMeta storeMeta;
 
     public UpdateCounterOperation(ByteArrayWrapper bucket, ByteArrayWrapper key, long amount)
@@ -58,6 +59,22 @@ public class UpdateCounterOperation extends FutureOperation<Long, RiakKvPB.RpbCo
         this.amount = amount;
     }
 
+    /**
+     * Set the bucket type.
+     * If unset "default" is used. 
+     * @param bucketType the bucket type to use
+     * @return A reference to this object.
+     */
+    public UpdateCounterOperation withBucketType(ByteArrayWrapper bucketType)
+    {
+        if (null == bucketType || bucketType.length() == 0)
+        {
+            throw new IllegalArgumentException("Bucket type can not be null or zero length");
+        }
+        this.bucketType = bucketType;
+        return this;
+    }
+    
     /**
      * The {@link StoreMeta} to use for this fetch operation
      *
@@ -103,6 +120,11 @@ public class UpdateCounterOperation extends FutureOperation<Long, RiakKvPB.RpbCo
         builder.setBucket(ByteString.copyFrom(bucket.unsafeGetValue()));
         builder.setKey(ByteString.copyFrom(key.unsafeGetValue()));
 
+        if (bucketType != null)
+        {
+            builder.setType(ByteString.copyFrom(bucketType.unsafeGetValue()));
+        }
+        
         if (storeMeta.hasW())
         {
             builder.setW(storeMeta.getW().getIntValue());

--- a/src/main/java/com/basho/riak/client/query/RiakObject.java
+++ b/src/main/java/com/basho/riak/client/query/RiakObject.java
@@ -75,6 +75,7 @@ public final class RiakObject
     private volatile byte[] key;
     private volatile byte[] bucket;
     private volatile byte[] value;
+    private volatile byte[] bucketType;
     
     // Mutable collections 
     private volatile RiakIndexes riakIndexes;
@@ -515,6 +516,183 @@ public final class RiakObject
             throw new IllegalArgumentException("bucket can not be zero length or null");
         }
         this.bucket = bucket;
+        return this;
+    }
+    
+    // Bucket type
+    
+    /**
+     * Returns the bucket type for this RiakObject as a {@link ByteArrayInputStream}
+     * @return a {@code ByteArrayInputStream} backed by the internal {@code byte[]} 
+     * or {@code null} if the bucket type has not been set.
+     */
+    public ByteArrayInputStream getBucketType()
+    {
+        if (bucketType != null)
+        {
+            return new ByteArrayInputStream(bucketType);
+        }
+        else
+        {
+            return null;
+        }
+    }
+
+    /**
+     * Returns the bucket type for this RiakObject as raw bytes.
+     * @riak.threadsafety A copy of the internal <code>byte[]</code> is returned.
+     * @return a copy of the internal {@code byte[]} or {@code null} if the bucket type has not been set.
+     */
+    public byte[] getBucketTypeAsBytes()
+    {
+        if (bucketType != null)
+        {
+            return Arrays.copyOf(bucketType, bucketType.length);
+        }
+        else
+        {
+            return null;
+        }
+    }
+    
+    /**
+     * Returns the bucket type for this RiakObject as raw bytes.
+     * @riak.threadsafety This method exposes the internal {<code>byte[]</code> directly.
+     * Modifying the contents of this array will lead to undefined behavior in 
+     * regard to thread safety and visibility.
+     * @return the internal {@code byte[]} or {@code null} if the bucket type has not been set.
+     */
+    public byte[] unsafeGetBucketTypeAsBytes()
+    {
+        return bucketType;
+    }
+    
+    /**
+     * Returns the bucket type for this RiakObject as a String. 
+     * <p>
+     * The bucket type is stored internally as a {@code byte[]}. This method converts those bytes to
+     * a {@code String} using your default {@code Charset}
+     * </p>
+     * @return The bucket type as a {@code String} or {@code null} if the bucket type has not been set.. 
+     */
+    public String getBucketTypeAsString()
+    {
+        if (bucketType != null) 
+        {
+            return new String(bucketType, Charset.defaultCharset());
+        }
+        else
+        {
+            return null;
+        }
+    }
+    
+    /**
+     * Returns the bucket type for this RiakObject as a String. 
+     * <p>
+     * The bucket type is stored internally as a {@code byte[]}. 
+     * This method returns those bytes encoded as a
+     * {@code String} using the supplied {@code Charset}.
+     * </p>
+     * @param charset the {@link Charset} to use
+     * @return The bucket type converted to a {@code String} using the supplied {@code Charset}
+     * or {@code null} if the bucket type has not been set.
+     */
+    public String getBucketTypeAsString(Charset charset) 
+    {
+        if (bucketType != null)
+        {
+            return new String(bucketType, charset);
+        }
+        else
+        {
+            return null;
+        }
+    }
+    
+    /**
+     * Set the bucket type for this RiakObject.
+     * <p>
+     * Riak is character set agnostic. The bucket type is stored as bytes. This method 
+     * will convert the supplied {@code String} using the default {@code Charset}.
+     * </p>
+     * @param bucketType the bucket type as a {@code String}
+     * @return a reference to this object
+     * @throws IllegalArgumentException if {@code bucketType} is {@code null} or zero length
+     */
+    public RiakObject setBucketType(String bucketType) 
+    {
+        if (null == bucketType || bucketType.isEmpty())
+        {
+            throw new IllegalArgumentException("Bucket type can not be null or zero length");
+        }
+        this.bucketType = bucketType.getBytes(Charset.defaultCharset());
+        return this;
+    }
+
+    /**
+     * Set the bucket type for this RiakObject
+     * <p>
+     * Riak is character set agnostic. The bucket type is stored as bytes. This method 
+     * will convert the provided {@code String} using the provided {@code Charset}.
+     * </p>
+     * @param bucketType the bucket type as a {@code String}
+     * @param charset the {@link Charset} to use 
+     * @return a reference to this object
+     * @throws IllegalArgumentException if {@code bucketType} is {@code null} or zero length
+     */
+    public RiakObject setBucketType(String bucketType, Charset charset) 
+    {
+        if (null == bucketType || bucketType.isEmpty())
+        {
+            throw new IllegalArgumentException("Bucket type can not be null or zero length");
+        }
+        this.bucketType = bucketType.getBytes(charset);
+        return this;
+    }
+        
+    /**
+     * Set the bucket type for this RiakObject.
+     * <p>
+     * Riak is character set agnostic. The bucket type is stored as bytes. 
+     * This method allows for raw bytes to be used directly.
+     * </p>
+     * @riak.threadsafety The supplied <code>byte[]</code> is copied.
+     * @param bucketType a {@code byte[]} to be copied and used as the bucket type
+     * @return a reference to this object
+     * @throws IllegalArgumentException if {@code bucketType} is {@code null} or zero length
+     */
+    public RiakObject setBucketType(byte[] bucketType)
+    {
+        if (null == bucketType || bucketType.length == 0)
+        {
+            throw new IllegalArgumentException("bucket type can not be zero length or null");
+        }
+        this.bucketType = Arrays.copyOf(bucketType, bucketType.length);
+        return this;
+    }
+    
+    /**
+     * Set the bucket type for this RiakObject.
+     * <p>
+     * Riak is character set agnostic. The bucket type is stored as bytes. 
+     * This method allows for raw bytes to be used directly.
+     * </p>
+     * @riak.threadsafety The supplied <code>byte[]</code> is not copied and the reference is used
+     * directly. Retaining a reference to this array and making subsequent
+     * changes will lead to undefined behavior in regard to thread safety and
+     * visibility. 
+     * @param bucketType a {@code byte[]} to be used as the bucket type
+     * @return a reference to this object
+     * @throws IllegalArgumentException if {@code bucketType} is {@code null} or zero length
+     */
+    public RiakObject unsafeSetBucketType(byte[] bucketType)
+    {
+        if (null == bucketType || bucketType.length == 0)
+        {
+            throw new IllegalArgumentException("bucket type can not be zero length or null");
+        }
+        this.bucketType = bucketType;
         return this;
     }
     


### PR DESCRIPTION
We originally hadn't included the bucket type for operations, this
adds it and a setter to all the ops that take it as an option.

I also added it to RiakObject but in doing so found I really dislike how
we're passing that to SotreOperation, but left it as-is here. I'll change it in
a different PR. 
