### PR TITLE
Added future for RiakCluster and RiakNode shutdown

### DIFF
--- a/src/main/java/com/basho/riak/client/App.java
+++ b/src/main/java/com/basho/riak/client/App.java
@@ -69,7 +69,7 @@ public class App implements RiakFutureListener<RiakObject>
             System.out.println("value: " + ro.getValue());
             System.out.println(ro.isDeleted());
         }
-        cluster.stop();
+        cluster.shutdown();
     }
     
     public static void main( String[] args ) throws Exception
@@ -87,7 +87,7 @@ public class App implements RiakFutureListener<RiakObject>
             System.out.println("value: " + ro.getValue());
             System.out.println(ro.isDeleted());
             
-            cluster.stop();
+            cluster.shutdown();
         }
         catch (InterruptedException ex)
         {

--- a/src/test/java/com/basho/riak/client/core/RiakClusterFixtureTest.java
+++ b/src/test/java/com/basho/riak/client/core/RiakClusterFixtureTest.java
@@ -95,7 +95,7 @@ public class RiakClusterFixtureTest
             
         }
         
-        cluster.stop();
+        cluster.shutdown().get();
         
     }
     
@@ -129,7 +129,7 @@ public class RiakClusterFixtureTest
         }
         finally
         {
-            cluster.stop();
+            cluster.shutdown().get();
         }
     }
     

--- a/src/test/java/com/basho/riak/client/core/operations/itest/ITestBase.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/ITestBase.java
@@ -94,7 +94,7 @@ public abstract class ITestBase
     public static void tearDown() throws InterruptedException, ExecutionException
     {
         resetAndEmptyBucket(bucketName);
-        cluster.stop();
+        cluster.shutdown().get();
     }
     
     public static void resetAndEmptyBucket(ByteArrayWrapper name) throws InterruptedException, ExecutionException


### PR DESCRIPTION
Also renamed RiakCluster.stop() to RiakCluster.shutdown()
to be consistent.

Closes #307 
