### PR TITLE
TODO cleanup, slight healthcheck refactor

### DIFF
--- a/src/main/java/com/basho/riak/client/core/RiakCluster.java
+++ b/src/main/java/com/basho/riak/client/core/RiakCluster.java
@@ -182,7 +182,6 @@ public class  RiakCluster implements OperationRetrier, NodeStateListener
         
     }
     
-    // TODO: Harden to keep operations from being execute multiple times?
     public void execute(FutureOperation operation)
     {
         stateCheck(State.RUNNING);
@@ -191,7 +190,6 @@ public class  RiakCluster implements OperationRetrier, NodeStateListener
         this.execute(operation, null);
     }
     
-    // TODO: Streaming also
     private void execute(FutureOperation operation, RiakNode previousNode) 
     {
         nodeManager.executeOnNode(operation, previousNode);


### PR DESCRIPTION
Removed a few TODO items that I feel are no longer issues.

Refactored healthcheck slightly. It now purges the recentlyClosed
sliding window first then makes a decision on whether to healthcheck
the node. Also decided that the timing and window are fine and
really don't need to be user settable (avoid ETTOMANYOPTIONS). We
know Riak's and the protocol's expected behavior.
