### PR TITLE
Fixed shutdown issues.

### DIFF
--- a/src/main/java/com/basho/riak/client/core/DefaultNodeManager.java
+++ b/src/main/java/com/basho/riak/client/core/DefaultNodeManager.java
@@ -113,8 +113,8 @@ public class DefaultNodeManager implements NodeManager, NodeStateListener
                     if (unhealthy.remove(node))
                     {
                         healthy.add(node);
-                        logger.info("NodeManager moved node to healthy list; {}", 
-                                    node.getRemoteAddress());
+                        logger.info("NodeManager moved node to healthy list; {}:{}", 
+                                    node.getRemoteAddress(), node.getPort());
                     }
                 }
                 finally
@@ -129,8 +129,8 @@ public class DefaultNodeManager implements NodeManager, NodeStateListener
                     if (healthy.remove(node))
                     {
                         unhealthy.add(node);
-                        logger.info("NodeManager moved node to unhealthy list; {}", 
-                                    node.getRemoteAddress());
+                        logger.info("NodeManager moved node to unhealthy list; {}:{}", 
+                                    node.getRemoteAddress(), node.getPort());
                     }
                 }
                 finally
@@ -140,18 +140,25 @@ public class DefaultNodeManager implements NodeManager, NodeStateListener
                 break;
             case SHUTTING_DOWN:
             case SHUTDOWN:
+                boolean removed = false;
                 try
                 {
                     lock.writeLock().lock();
-                    healthy.remove(node);
-                    unhealthy.remove(node);
+                    removed = healthy.remove(node);
+                    if (!removed)
+                    {
+                        unhealthy.remove(node);
+                    }
                 }
                 finally
                 {
                     lock.writeLock().unlock();
                 }
-                logger.info("NodeManager removed node due to it shutting down; {}",
-                                node.getRemoteAddress());
+                if (removed)
+                {
+                    logger.info("NodeManager removed node due to it shutting down; {}:{}",
+                                node.getRemoteAddress(), node.getPort());
+                }
                 break;
             default:
                 break;
@@ -195,8 +202,8 @@ public class DefaultNodeManager implements NodeManager, NodeStateListener
         {
             node.removeStateListener(this);
             node.shutdown();
-            logger.info("NodeManager removed and shutdown node; {}", 
-                        node.getRemoteAddress());
+            logger.info("NodeManager removed and shutdown node; {}:{}", 
+                        node.getRemoteAddress(), node.getPort());
         }
         return removed;
     }

--- a/src/main/java/com/basho/riak/client/core/RiakCluster.java
+++ b/src/main/java/com/basho/riak/client/core/RiakCluster.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,12 +56,14 @@ public class  RiakCluster implements OperationRetrier, NodeStateListener
     private final AtomicInteger inFlightCount = new AtomicInteger();
     private final ScheduledExecutorService executor;
     private final Bootstrap bootstrap;
-    private final List<RiakNode> nodes;
+    private final List<RiakNode> nodeList;
+    private final ReentrantReadWriteLock nodeListLock = new ReentrantReadWriteLock();
     private final LinkedBlockingQueue<FutureOperation> retryQueue =
         new LinkedBlockingQueue<FutureOperation>();
     
-    private ScheduledFuture<?> shutdownFuture;
-    private ScheduledFuture<?> retrierFuture;
+    
+    private volatile ScheduledFuture<?> shutdownFuture;
+    private volatile ScheduledFuture<?> retrierFuture;
     
     private volatile State state;
     private final CountDownLatch shutdownLatch = new CountDownLatch(1);
@@ -99,16 +102,17 @@ public class  RiakCluster implements OperationRetrier, NodeStateListener
             executor = new ScheduledThreadPoolExecutor(2);
         }
         
-        nodes = Collections.synchronizedList(new ArrayList<RiakNode>(builder.riakNodes.size()));
+        nodeList = new ArrayList<RiakNode>(builder.riakNodes.size());
         for (RiakNode node : builder.riakNodes)
         {
             node.setExecutor(executor);
             node.setBootstrap(bootstrap);
             node.addStateListener(nodeManager);
-            nodes.add(node);
+            nodeList.add(node);
         }
         
-        nodeManager.init(nodes);
+        // Pass a *copy* of the list to the NodeManager
+        nodeManager.init(new ArrayList(nodeList));
         state = State.CREATED;
     }
     
@@ -128,16 +132,20 @@ public class  RiakCluster implements OperationRetrier, NodeStateListener
     {
         stateCheck(State.CREATED);
         
-        for (RiakNode node : nodes)
+        // Completely unneeded *right now* but operating on a copy
+        // of the nodeList defensively prevents a deadlock occuring 
+        // if a callback were to try and modify the list.
+        for (RiakNode node : getNodes())
         {
             node.start();
         }
+        
         retrierFuture = executor.schedule(new RetryTask(), 0, TimeUnit.SECONDS);
         logger.info("RiakCluster is starting.");
         state = State.RUNNING;
     }
 
-    public synchronized Future<Void> shutdown()
+    public synchronized Future<Boolean> shutdown()
     {
         stateCheck(State.RUNNING);
         logger.info("RiakCluster is shutting down.");
@@ -149,23 +157,22 @@ public class  RiakCluster implements OperationRetrier, NodeStateListener
                                                          500, 500, 
                                                          TimeUnit.MILLISECONDS);
         
-        return new Future<Void>() {
+        return new Future<Boolean>() {
             @Override
             public boolean cancel(boolean mayInterruptIfRunning)
             {
                 return false;
             }
             @Override
-            public Void get() throws InterruptedException
+            public Boolean get() throws InterruptedException
             {
                 shutdownLatch.await();
-                return null;
+                return true;
             }
             @Override
-            public Void get(long timeout, TimeUnit unit) throws InterruptedException
+            public Boolean get(long timeout, TimeUnit unit) throws InterruptedException
             {
-                shutdownLatch.await(timeout, unit);
-                return null;
+                return shutdownLatch.await(timeout, unit);
             }
             @Override
             public boolean isCancelled()
@@ -200,14 +207,25 @@ public class  RiakCluster implements OperationRetrier, NodeStateListener
      * The node can not have been started nor have its Bootstrap or Executor
      * set.
      * @param node the RiakNode to add
+     * @throws java.net.UnknownHostException if the RiakNode's hostname cannot be resolved
      * @throws IllegalArgumentException if the node's Bootstrap or Executor are already set.
      */
-    public synchronized void addNode(RiakNode node) throws UnknownHostException
+    public void addNode(RiakNode node) throws UnknownHostException
     {
         stateCheck(State.CREATED, State.RUNNING);
         node.setExecutor(executor);
         node.setBootstrap(bootstrap);
-        nodes.add(node);
+        
+        try
+        {
+            nodeListLock.writeLock().lock();
+            nodeList.add(node);
+        }
+        finally
+        {
+            nodeListLock.writeLock().unlock();
+        }
+        
         nodeManager.addNode(node);
     }
     
@@ -216,21 +234,40 @@ public class  RiakCluster implements OperationRetrier, NodeStateListener
      * @param node
      * @return true if the node was in the cluster, false otherwise.
      */
-    public synchronized boolean removeNode(RiakNode node)
+    public boolean removeNode(RiakNode node)
     {
         stateCheck(State.CREATED, State.RUNNING);
-        nodes.remove(node);
-        return nodeManager.removeNode(node);
+        boolean removed = false;
+        try
+        {
+            nodeListLock.writeLock().lock();
+            removed = nodeList.remove(node);
+        }
+        finally
+        {
+            nodeListLock.writeLock().unlock();
+        }
+        nodeManager.removeNode(node);
+        return removed;
     }
     
     /**
-     * Returns the list of nodes in this cluster.
-     * @return An unmodifiable list of RiakNodes
+     * Returns a copy of the list of nodes in this cluster.
+     * @return A copy of the list of RiakNodes
      */
     public List<RiakNode> getNodes()
     {
-        stateCheck(State.CREATED, State.RUNNING);
-        return Collections.unmodifiableList(nodes);
+        stateCheck(State.CREATED, State.RUNNING, State.SHUTTING_DOWN);
+        try
+        {
+            nodeListLock.readLock().lock();
+            return new ArrayList(nodeList);
+        }
+        finally
+        {
+            nodeListLock.readLock().unlock();
+        }
+        
     }
     
     int inFlightCount()
@@ -245,17 +282,26 @@ public class  RiakCluster implements OperationRetrier, NodeStateListener
         // to shutdown.
         if (state == RiakNode.State.SHUTDOWN)
         {
-            nodes.remove(node);
-            nodeManager.removeNode(node);
-            
-            if (nodes.isEmpty())
+            logger.debug("Node state changed to shutdown; {}:{}", node.getRemoteAddress(), node.getPort());
+            try
             {
-                this.state = State.SHUTDOWN;
-                executor.shutdown();
-                bootstrap.group().shutdownGracefully();
-                logger.debug("RiakCluster shut down bootstrap");
-                logger.info("RiakCluster has shut down");
-                shutdownLatch.countDown();
+                nodeListLock.writeLock().lock();
+                nodeList.remove(node);
+                logger.debug("Active nodes remaining: {}", nodeList.size());
+            
+                if (nodeList.isEmpty())
+                {
+                    this.state = State.SHUTDOWN;
+                    executor.shutdown();
+                    bootstrap.group().shutdownGracefully();
+                    logger.debug("RiakCluster shut down bootstrap");
+                    logger.info("RiakCluster has shut down");
+                    shutdownLatch.countDown();
+                }
+            }
+            finally
+            {
+                nodeListLock.writeLock().unlock();
             }
         }
     }
@@ -317,12 +363,17 @@ public class  RiakCluster implements OperationRetrier, NodeStateListener
             if (inFlightCount.get() == 0)
             {
                 logger.info("All operations have completed");
+
                 retrierFuture.cancel(true);
-                for (RiakNode node : nodes)
+                
+                // Copying the list avoids any potential deadlocks on the callbacks.
+                for (RiakNode node : getNodes())
                 {
                     node.addStateListener(RiakCluster.this);
+                    logger.debug("calling shutdown on node {}:{}", node.getRemoteAddress(), node.getPort());
                     node.shutdown();
                 }
+                
                 shutdownFuture.cancel(false);
             }
         }

--- a/src/main/java/com/basho/riak/client/core/RiakNode.java
+++ b/src/main/java/com/basho/riak/client/core/RiakNode.java
@@ -222,7 +222,7 @@ public class RiakNode implements RiakResponseListener
         return this;
     }
 
-    public synchronized Future<Void> shutdown()
+    public synchronized Future<Boolean> shutdown()
     {
         stateCheck(State.RUNNING, State.HEALTH_CHECKING);
         state = State.SHUTTING_DOWN;
@@ -240,23 +240,22 @@ public class RiakNode implements RiakResponseListener
 
         executor.schedule(new ShutdownTask(), 0, TimeUnit.SECONDS);
         
-        return new Future<Void>() {
+        return new Future<Boolean>() {
             @Override
             public boolean cancel(boolean mayInterruptIfRunning)
             {
                 return false;
             }
             @Override
-            public Void get() throws InterruptedException
+            public Boolean get() throws InterruptedException
             {
                 shutdownLatch.await();
-                return null;
+                return true;
             }
             @Override
-            public Void get(long timeout, TimeUnit unit) throws InterruptedException
+            public Boolean get(long timeout, TimeUnit unit) throws InterruptedException
             {
-                shutdownLatch.await(timeout, unit);
-                return null;
+                return shutdownLatch.await(timeout, unit);
             }
             @Override
             public boolean isCancelled()


### PR DESCRIPTION
I wasn't synchronizing on the original SynchronizedList which led
to non-deterministic behavior. In correcting that I found another
race condition in nodeStateChanged in regard to removing a RiakNode
from the list then checking the size of the list.

Converting over to using a RW lock and defensively copying the list
when performing start/stop operations on the nodes is way safer and
actually works properly.

I also improved the logging in the DefaultNodeManager and changed the futures returned to be Future&lt;Boolean&gt;
