### PR TITLE
Fix pb streaming op cancel

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.basho.riak</groupId>
     <artifactId>riak-client</artifactId>
     <packaging>bundle</packaging>
-    <version>1.4.2</version>
+    <version>1.4.3-SNAPSHOT</version>
     <name>Riak Client for Java</name>
     <description>HttpClient-based client for Riak</description>
     <url>https://github.com/basho/riak-java-client</url>

--- a/src/main/java/com/basho/riak/client/raw/pbc/PBStreamingOperation.java
+++ b/src/main/java/com/basho/riak/client/raw/pbc/PBStreamingOperation.java
@@ -50,7 +50,7 @@ public abstract class PBStreamingOperation<S,T> implements StreamingOperation<T>
 
     public void cancel()
     {
-        client.close();
+        client.cancel();
     }
 
     public Iterator<T> iterator()

--- a/src/main/java/com/basho/riak/pbc/RiakStreamClient.java
+++ b/src/main/java/com/basho/riak/pbc/RiakStreamClient.java
@@ -87,6 +87,14 @@ public abstract class RiakStreamClient<T> implements Iterable<T> {
 		}
 	}
 	
+    public synchronized void cancel() {
+        if (!isClosed())
+        {
+            conn.close();
+            close();
+        }
+    }
+    
 	public synchronized void close() {
 		if (!isClosed()) {
 			reaper.cancel();


### PR DESCRIPTION
The original PB client's close() for a streaming op doesn't do what one
would think. It happily returns a connection back to the pool with
data still on the wire.

This adds a real cancel() method that punts the connection.

Fixes #333 
