### PR TITLE
Reworked channel handling in RiakNode.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,11 +209,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-all</artifactId>
-            <version>4.0.7.Final</version>
-        </dependency>
-        <dependency>
             <groupId>com.jayway.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <version>1.3.5</version>
@@ -228,6 +223,11 @@
             <groupId>com.basho.riak.protobuf</groupId>
             <artifactId>riak-pb</artifactId>
             <version>2.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+            <version>4.0.13.Final</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/basho/riak/client/core/FutureOperation.java
+++ b/src/main/java/com/basho/riak/client/core/FutureOperation.java
@@ -204,7 +204,6 @@ public abstract class FutureOperation<T, U> implements RiakFuture<T>
 
     public synchronized final Object channelMessage()
     {
-        stateCheck(State.CREATED, State.RETRY);
         Object message = createChannelMessage();
         state = State.WRITTEN;
         return message;

--- a/src/main/java/com/basho/riak/client/core/RiakResponseListener.java
+++ b/src/main/java/com/basho/riak/client/core/RiakResponseListener.java
@@ -15,6 +15,7 @@
  */
 package com.basho.riak.client.core;
 
+import com.basho.riak.client.core.netty.RiakResponseException;
 import io.netty.channel.Channel;
 
 /**
@@ -25,5 +26,6 @@ import io.netty.channel.Channel;
 public interface RiakResponseListener
 {
     public void onSuccess(Channel channel, RiakMessage response);
+    public void onRiakErrorResponse(Channel channel, RiakResponseException response); 
     public void onException(Channel channel, Throwable t);
 }

--- a/src/test/java/com/basho/riak/client/core/RiakNodeFixtureTest.java
+++ b/src/test/java/com/basho/riak/client/core/RiakNodeFixtureTest.java
@@ -60,7 +60,7 @@ public class RiakNodeFixtureTest extends FixtureTest
         PowerMockito.verifyPrivate(node, atLeastOnce()).invoke("checkHealth", new Object[0]);
         
     }
-    
+        
     @Test
     public void idleConnectionsAreRemoved() throws UnknownHostException, InterruptedException, Exception
     {
@@ -71,6 +71,11 @@ public class RiakNodeFixtureTest extends FixtureTest
                                .build();
         
         node.start();
+        
+        // The node has 10 connections that should never be reaped. We want to make
+        // it create 2 more by checking out 12, then return them all. The extra 2
+        // should get reaped.
+        
         List<Channel> channelList = new LinkedList<Channel>();
         for (int i = 0; i < 12; i++)
         {
@@ -196,8 +201,8 @@ public class RiakNodeFixtureTest extends FixtureTest
                     .build();
         
         boolean accepted = node.execute(operation);
-        FetchOperation.Response response = operation.get();
-    }
+            FetchOperation.Response response = operation.get();
+        }
     
     @Test(expected=ExecutionException.class)
     public void operationTimesOut() throws IOException, InterruptedException, ExecutionException

--- a/src/test/java/com/basho/riak/client/core/RiakNodeTest.java
+++ b/src/test/java/com/basho/riak/client/core/RiakNodeTest.java
@@ -247,7 +247,7 @@ public class RiakNodeTest
 
         for (int i = 0; i < 5; i++)
         {
-            ChannelFutureListener listener = Whitebox.getInternalState(node, "closeListener", RiakNode.class);
+            ChannelFutureListener listener = Whitebox.getInternalState(node, "inAvailableCloseListener", RiakNode.class);
             listener.operationComplete(future);
         }
 

--- a/src/test/java/com/basho/riak/client/core/fixture/NetworkTestFixture.java
+++ b/src/test/java/com/basho/riak/client/core/fixture/NetworkTestFixture.java
@@ -142,6 +142,7 @@ public class NetworkTestFixture implements Runnable
                                         break;
                                     case ACCEPT_THEN_CLOSE:
                                         client = h.getServerSocketChannel().accept();
+                                        Thread.sleep(100);
                                         client.close();
                                         break;
                                 }
@@ -169,6 +170,10 @@ public class NetworkTestFixture implements Runnable
                     catch (ClosedSelectorException e)
                     {
                         // no op
+                    }
+                    catch (InterruptedException ex)
+                    {
+                        ex.printStackTrace();
                     }
                 }
                 else


### PR DESCRIPTION
This addresses #337 

At some point Netty changed its behavior to where IOExceptions
(e.g. connection reset by peer) are no longer sent as exceptions
down the pipeline. Instead the channel simply closes and any
listeners to the close future are notified. In addition, you have
no idea what happened; the future.cause() will always return null.

To adjust for this and improve the channel handling in general I've
refactored RiakNode.
- The inUse list no longer exists. A channel is either in available
  or is the key in the inProgress Map.
- There are now two different close future listeners; one for when
  a channel is in available, and another for when it is in progress.
- The write listener adds the in progress close listener once it succeeds.
