### PR TITLE
Remove TCP timeout handler and option

### DIFF
--- a/src/main/java/com/basho/riak/client/util/Constants.java
+++ b/src/main/java/com/basho/riak/client/util/Constants.java
@@ -94,7 +94,6 @@ public interface Constants {
     // Netty Channel handler constants
     public static final String MESSAGE_CODEC = "codec";
     public static final String OPERATION_ENCODER = "operationEncoder";
-    public static final String TIMEOUT_HANDLER = "timeoutHandler";
     public static final String RESPONSE_HANDLER = "responseHandler";
     
 }


### PR DESCRIPTION
This removes the TCP timeout option and handler. 

We don't need this since individual operations have timeouts now (and, it's ugly anyway). 

Fixes #344 
