### PR TITLE
Fix RiakConnection.get_code(int)

### DIFF
--- a/src/main/java/com/basho/riak/pbc/RiakConnection.java
+++ b/src/main/java/com/basho/riak/pbc/RiakConnection.java
@@ -139,7 +139,7 @@ class RiakConnection implements Comparable<RiakConnection>
 		try {
 			len = din.readInt();
 			get_code = din.read();
-			if (code == RiakClient.MSG_ErrorResp) {
+			if (get_code == RiakClient.MSG_ErrorResp) {
 				RpbErrorResp err = com.basho.riak.protobuf.RiakPB.RpbErrorResp.parseFrom(din);
 				throw new RiakError(err);
 			}


### PR DESCRIPTION
This is a backport of #351 to the 1.1.x client.
