### PR TITLE
Scan all methods to inherit super class annotations.

### DIFF
--- a/src/main/java/com/basho/riak/client/convert/reflect/AnnotationScanner.java
+++ b/src/main/java/com/basho/riak/client/convert/reflect/AnnotationScanner.java
@@ -117,7 +117,7 @@ public class AnnotationScanner implements Callable<AnnotationInfo> {
             currentClass = currentClass.getSuperclass();
         }
         
-        final Method[] methods = classToScan.getDeclaredMethods();
+        final Method[] methods = classToScan.getMethods();
         for (Method method : methods) {
             if (method.isAnnotationPresent(RiakIndex.class)) {
                 indexMethods.add(new RiakIndexMethod(ClassUtil.checkAndFixAccess(method)));


### PR DESCRIPTION
Scan all methods to inherit super class annotations, for `@RiakKey` and `@RiakIndex`
Before it was only scanning declared methods which was ignoring inherited ones, we have an abstract class `RiakKeyValue` which contains template methods including `@RiakKey getKey()` which for us is not a property but calculated, without this change the key is never detected which creates a dynamic Riak key.
