### PR TITLE
Create Makefile for buildbot CI.

### DIFF
--- a/buildbot/Makefile
+++ b/buildbot/Makefile
@@ -13,14 +13,14 @@ preconfigure:
 	echo "ssl.cacertfile = ${CERTS_DIR}/cacert.pem" >> ${RIAK_CONF}
 
 configure:
-	@${RIAK_ADMIN} bucket-type create test_type '{"props":{}}'
-	@${RIAK_ADMIN} bucket-type create counters '{"props":{"datatype":"counter"}}'
-	@${RIAK_ADMIN} bucket-type create sets '{"props":{"datatype":"set"}}'
-	@${RIAK_ADMIN} bucket-type create maps '{"props":{"datatype":"map"}}'
-	@${RIAK_ADMIN} bucket-type activate test_type
-	@${RIAK_ADMIN} bucket-type activate counters
-	@${RIAK_ADMIN} bucket-type activate sets
-	@${RIAK_ADMIN} bucket-type activate maps
+	${RIAK_ADMIN} bucket-type create test_type '{"props":{}}'
+	${RIAK_ADMIN} bucket-type create counters '{"props":{"datatype":"counter"}}'
+	${RIAK_ADMIN} bucket-type create sets '{"props":{"datatype":"set"}}'
+	${RIAK_ADMIN} bucket-type create maps '{"props":{"datatype":"map"}}'
+	${RIAK_ADMIN} bucket-type activate test_type
+	${RIAK_ADMIN} bucket-type activate counters
+	${RIAK_ADMIN} bucket-type activate sets
+	${RIAK_ADMIN} bucket-type activate maps
 
 compile:
 	@cd ..; mvn clean compile


### PR DESCRIPTION
- Configures Riak 2.0 with search enabled and LevelDB backend, plus  the included security stuff in src/test/resources.
- Runs the tests with all features except security, then turns security on and tests again.
- Includes a 'lint' task that could be used in the future for checking style and other non-functional things. Other clients (e.g. Python, Erlang) may use this for analysis tools (e.g. PEP8, dialyzer).

There is a forthcoming PR on basho/basho_buildbot for this.
