### PR TITLE
Add profile for OSX to pom.xml to fix develop build for Mac users

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <packaging>jar</packaging>
     <version>2.0.0-SNAPSHOT</version>
     <name>Riak Client for Java</name>
-  
+
     <licenses>
         <license>
             <name>The Apache Software License, Version 2.0</name>
@@ -42,13 +42,39 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <powermock.version>1.5</powermock.version>
     </properties>
-    
+
     <profiles>
         <profile>
             <id>default</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
+                    <file>
+                        <exists>${java.home}/../lib/tools.jar</exists>
+                    </file>
             </activation>
+            <properties>
+                <toolsjar>${java.home}/../lib/tools.jar</toolsjar>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-nop</artifactId>
+                    <version>1.7.5</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>osx</id>
+            <activation>
+              <activeByDefault>false</activeByDefault>
+              <file>
+                  <exists>${java.home}/../Classes/classes.jar</exists>
+              </file>
+            </activation>
+            <properties>
+                <toolsjar>${java.home}/../Classes/classes.jar</toolsjar>
+            </properties>
             <dependencies>
                 <dependency>
                     <groupId>org.slf4j</groupId>
@@ -188,7 +214,7 @@
             <artifactId>tools</artifactId>
             <version>1.4.2</version>
             <scope>system</scope>
-            <systemPath>${java.home}/../lib/tools.jar</systemPath>
+            <systemPath>${toolsjar}</systemPath>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Fix the develop branch build on OSX by adding an OSX profile to
resolve the following error: 

```
Could not find artifact
com.sun:tools:jar:1.4.2 at specified path
/System/Library/Java/JavaVirtualMachines/1.6.0.jdk/Contents/Home/../lib/tools.jar.
```

I am not sure if this is the best way to solve this problem. It won't hurt my feelings if you close this in favor of a better method, but it does resolve the issue for me. I also tested that building still works on Ubuntu Linux. 

Here is the complete failed build output:

```
15:55:23:riak-java-client(fix-osx-build *) $ mvn clean compile
[INFO] Scanning for projects...
[WARNING]
[WARNING] Some problems were encountered while building the effective model for com.basho.riak:riak-client:jar:2.0.0-SNAPSHOT
[WARNING] 'dependencies.dependency.systemPath' for com.sun:tools:jar refers to a non-existing file /System/Library/Java/JavaVirtualMachines/1.6.0.jdk/Contents/Home/../lib/tools.jar. Please verify that you run Maven using a JDK and not just a JRE. @ line 217, column 25
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] Building Riak Client for Java 2.0.0-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 0.598s
[INFO] Finished at: Mon May 12 16:10:28 MDT 2014
[INFO] Final Memory: 3M/81M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal on project riak-client: Could not resolve dependencies for project com.basho.riak:riak-client:jar:2.0.0-SNAPSHOT: Could not find artifact com.sun:tools:jar:1.4.2 at specified path /System/Library/Java/JavaVirtualMachines/1.6.0.jdk/Contents/Home/../lib/tools.jar -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/DependencyResolutionException
```

And the output with this change:

```
16:15:57:riak-java-client(fix-osx-build) $ mvn clean compile
[INFO] Scanning for projects...
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] Building Riak Client for Java 2.0.0-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO]
[INFO] --- maven-clean-plugin:2.4.1:clean (default-clean) @ riak-client ---
[INFO] Deleting /Users/kelly/basho/repos/riak-java-client/target
[INFO]
[INFO] --- jacoco-maven-plugin:0.6.3.201306030806:prepare-agent (jacoco-initialize) @ riak-client ---
[INFO] argLine set to -javaagent:/Users/kelly/.m2/repository/org/jacoco/org.jacoco.agent/0.6.3.201306030806/org.jacoco.agent-0.6.3.201306030806-runtime.jar=destfile=/Users/kelly/basho/repos/riak-java-client/target/jacoco.exec
[INFO]
[INFO] --- maven-resources-plugin:2.4.3:resources (default-resources) @ riak-client ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /Users/kelly/basho/repos/riak-java-client/src/main/resources
[INFO]
[INFO] --- maven-compiler-plugin:3.1:compile (default-compile) @ riak-client ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 221 source files to /Users/kelly/basho/repos/riak-java-client/target/classes
[WARNING] /Users/kelly/basho/repos/riak-java-client/src/main/java/com/basho/riak/client/javadoc/JavadocFilter.java:[78,25] warning: [unchecked] unchecked call to add(E) as a member of the raw type java.util.List
[WARNING] /Users/kelly/basho/repos/riak-java-client/src/main/java/com/basho/riak/client/javadoc/JavadocFilter.java:[85,32] warning: [unchecked] unchecked call to <T>toArray(T[]) as a member of the raw type java.util.List
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 3.534s
[INFO] Finished at: Mon May 12 16:18:20 MDT 2014
[INFO] Final Memory: 17M/81M
[INFO] ------------------------------------------------------------------------
```
