### PR TITLE
UpdateSet.Builder should be a static class

### DIFF
--- a/src/main/java/com/basho/riak/client/operations/UpdateSet.java
+++ b/src/main/java/com/basho/riak/client/operations/UpdateSet.java
@@ -74,7 +74,7 @@ public class UpdateSet extends UpdateDatatype<RiakSet, UpdateSet.Response, Locat
     }
     
     
-    public class Builder extends UpdateDatatype.Builder<Builder>
+    public static class Builder extends UpdateDatatype.Builder<Builder>
     {
         private final SetUpdate update;
         


### PR DESCRIPTION
Without this fix, I get the inscrutable error:

```
error: an enclosing instance that contains UpdateSet.Builder is required
            UpdateSet update = new UpdateSet.Builder(loc, set).build();
                               ^
```

All other builders that I can find are static.
