### PR TITLE
Add jar with dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,40 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>jar-with-dependencies</id>
+            <activation>
+                <property>
+                    <name>bundle.fat</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <version>2.4</version>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/main/assembly/jar-with-dependencies.xml</descriptor>
+                            </descriptors>
+                            <archive>
+                            </archive>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>make-assembly</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
     <build>
         <plugins>

--- a/src/main/assembly/jar-with-dependencies.xml
+++ b/src/main/assembly/jar-with-dependencies.xml
@@ -1,0 +1,17 @@
+<assembly>
+  <id>jar-with-dependencies</id>
+  <formats>
+    <format>jar</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <dependencySets>
+    <dependencySet>
+      <unpack>true</unpack>
+      <scope>runtime</scope>
+      <outputDirectory>/</outputDirectory>
+      <excludes>
+        <exclude>junit:junit</exclude>
+      </excludes>
+    </dependencySet>
+  </dependencySets>
+</assembly>


### PR DESCRIPTION
Added a `jar-with-dependencies` profile which runs the `jar-with-dependencies/xml` assembly, which bundles all runtime dependencies into a single fat jar. To build it run:

```
mvn package -Dbundle.fat=true
```

PR for issue #437
