### PR TITLE
Fixes problems with MR tests

### DIFF
--- a/src/main/java/com/basho/riak/client/operations/mapreduce/BucketKeyInputSerializer.java
+++ b/src/main/java/com/basho/riak/client/operations/mapreduce/BucketKeyInputSerializer.java
@@ -10,36 +10,36 @@ import java.io.IOException;
 
 public class BucketKeyInputSerializer extends JsonSerializer<BucketKeyInput>
 {
-	@Override
-	public void serialize(BucketKeyInput input, JsonGenerator jg, SerializerProvider sp) throws IOException
-	{
 
-		jg.writeStartArray();
+    @Override
+    public void serialize(BucketKeyInput input, JsonGenerator jg, SerializerProvider sp) throws IOException
+    {
 
-	 	for (BucketKeyInput.IndividualInput i : input.getInputs())
-	  {
+        jg.writeStartArray();
 
-			jg.writeStartArray();
+        for (BucketKeyInput.IndividualInput i : input.getInputs())
+        {
 
-		  Location loc = i.location;
-		  jg.writeString(loc.getNamespace().getBucketNameAsString());
-		  jg.writeString(loc.getKeyAsString());
-          jg.writeObject(i.keyData);
-          
+            jg.writeStartArray();
+
+            Location loc = i.location;
+            jg.writeString(loc.getNamespace().getBucketNameAsString());
+            jg.writeString(loc.getKeyAsString());
+            jg.writeObject(i.keyData);
+
           // TODO: Remove this when bug in Riak is fixed.
-          
           // There's a bug in Riak where if you explicitly specify 
-          // "default" with the 4 argument version of input, it 
-          // blows up.
-          if (!loc.getNamespace().getBucketTypeAsString().equals(Namespace.DEFAULT_BUCKET_TYPE))
-          {
-            jg.writeString(loc.getNamespace().getBucketTypeAsString());
-          }
-		  jg.writeEndArray();
+            // "default" with the 4 argument version of input, it 
+            // blows up.
+            if (!loc.getNamespace().getBucketTypeAsString().equals(Namespace.DEFAULT_BUCKET_TYPE))
+            {
+                jg.writeString(loc.getNamespace().getBucketTypeAsString());
+            }
+            jg.writeEndArray();
 
-	  }
+        }
 
-		jg.writeEndArray();
+        jg.writeEndArray();
 
-	}
+    }
 }

--- a/src/test/java/com/basho/riak/client/core/operations/itest/ITestMapReduceOperation.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/ITestMapReduceOperation.java
@@ -103,8 +103,8 @@ public class ITestMapReduceOperation extends ITestBase
         cluster.execute(storeOp);
         storeOp.get();
             
-        String bName = bucketName.toString();
-        String bType = bucketType.toString();
+        String bName = namespace.getBucketNameAsString();
+        String bType = namespace.getBucketTypeAsString();
         
         String query = "{\"inputs\":[[\"" + bName + "\",\"p1\",\"\",\"" + bType + "\"]," +
             "[\"" + bName + "\",\"p2\",\"\",\"" + bType + "\"]," +
@@ -136,6 +136,8 @@ public class ITestMapReduceOperation extends ITestBase
         
         assertNotNull(resultMap.containsKey("the"));
         assertEquals(Integer.valueOf(8),resultMap.get("the"));
+        
+        resetAndEmptyBucket(namespace);
         
     }
 }

--- a/src/test/java/com/basho/riak/client/operations/indexes/itest/ITestBinIndexQuery.java
+++ b/src/test/java/com/basho/riak/client/operations/indexes/itest/ITestBinIndexQuery.java
@@ -44,7 +44,7 @@ public class ITestBinIndexQuery extends ITestBase
     @Test
     public void testMatchQuery() throws ExecutionException, InterruptedException
     {
-        //Assume.assumeTrue(test2i);
+        Assume.assumeTrue(test2i);
         
         RiakClient client = new RiakClient(cluster);
         

--- a/src/test/java/com/basho/riak/client/operations/itest/ITestBucketMapReduce.java
+++ b/src/test/java/com/basho/riak/client/operations/itest/ITestBucketMapReduce.java
@@ -19,6 +19,7 @@ package com.basho.riak.client.operations.itest;
 import com.basho.riak.client.RiakClient;
 import com.basho.riak.client.core.RiakFuture;
 import com.basho.riak.client.core.operations.itest.ITestBase;
+import com.basho.riak.client.operations.StoreBucketProperties;
 import com.basho.riak.client.operations.kv.StoreValue;
 import com.basho.riak.client.operations.mapreduce.BucketMapReduce;
 import com.basho.riak.client.operations.mapreduce.MapReduce;
@@ -41,6 +42,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import org.junit.Assume;
+import org.junit.Before;
 
 /**
  *
@@ -48,8 +50,19 @@ import org.junit.Assume;
  */
 public class ITestBucketMapReduce extends ITestBase
 {
-    private final RiakClient client = new RiakClient(cluster);
-    private final  String mrBucketName = bucketName.toString() + "_mr";
+    private final static RiakClient client = new RiakClient(cluster);
+    private final static String mrBucketName = bucketName.toString() + "_mr";
+    
+    @Before
+    public void changeBucketProps() throws ExecutionException, InterruptedException
+    {
+        if (testBucketType)
+        {
+            Namespace ns = new Namespace(bucketType.toString(), mrBucketName);
+            StoreBucketProperties op = new StoreBucketProperties.Builder(ns).withAllowMulti(false).build();
+            client.execute(op);
+        }
+    }
     
     @After
     public void cleanUp() throws InterruptedException, ExecutionException

--- a/src/test/java/com/basho/riak/client/operations/itest/ITestIndexMapReduce.java
+++ b/src/test/java/com/basho/riak/client/operations/itest/ITestIndexMapReduce.java
@@ -19,6 +19,7 @@ package com.basho.riak.client.operations.itest;
 import com.basho.riak.client.RiakClient;
 import com.basho.riak.client.core.RiakFuture;
 import com.basho.riak.client.core.operations.itest.ITestBase;
+import com.basho.riak.client.operations.StoreBucketProperties;
 import com.basho.riak.client.operations.kv.StoreValue;
 import com.basho.riak.client.operations.mapreduce.IndexMapReduce;
 import com.basho.riak.client.operations.mapreduce.MapReduce;
@@ -32,6 +33,7 @@ import java.util.concurrent.ExecutionException;
 import static junit.framework.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import org.junit.Assume;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -42,6 +44,17 @@ public class ITestIndexMapReduce extends ITestBase
 {
     private final RiakClient client = new RiakClient(cluster);
     private final  String mrBucketName = bucketName.toString() + "_mr";
+    
+    @Before
+    public void changeBucketProps() throws ExecutionException, InterruptedException
+    {
+        if (testBucketType)
+        {
+            Namespace ns = new Namespace(bucketType.toString(), mrBucketName);
+            StoreBucketProperties op = new StoreBucketProperties.Builder(ns).withAllowMulti(false).build();
+            client.execute(op);
+        }
+    }
     
     private void initValues(String bucketType) throws InterruptedException
     {


### PR DESCRIPTION
There were a couple problems with the MR integration tests caused
by siblings/tombstones on the non-default bucket type.
This is now corrected by setting allow_mult to false for these
tests.

There is still one MR test that fails and it is legitimate. Using the
4-arity input (bucket, key, keydata, type) with the `default` bucket
type is still broken in Riak. You must use the 3-arity version which
does not specify a type. 

I ended up working (read: hacking) around this 
in the top-level user API that generates a query
by using the 3-arity when the type is `default`
but left the core test that manually constructs the 
JSON for a MR query there to show this is indeed broken. 

Testing these fixes can be done via:

`mvn clean install -Pitest,default -Dcom.basho.riak.buckettype=true -Dcom.basho.riak.2i=true`

With leveldb as the backend and the `test_type` bucket type created and enabled. 
