### PR TITLE
Fix yz tests

### DIFF
--- a/src/test/java/com/basho/riak/client/core/operations/itest/ITestBase.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/ITestBase.java
@@ -22,6 +22,7 @@ import com.basho.riak.client.core.RiakNode;
 import com.basho.riak.client.core.operations.DeleteOperation;
 import com.basho.riak.client.core.operations.ListKeysOperation;
 import com.basho.riak.client.core.operations.ResetBucketPropsOperation;
+import com.basho.riak.client.core.operations.YzFetchIndexOperation;
 import com.basho.riak.client.query.Location;
 import com.basho.riak.client.query.Namespace;
 import com.basho.riak.client.util.BinaryValue;
@@ -256,4 +257,20 @@ public abstract class ITestBase
 
     }
     
+    public static boolean assureIndexExists(String indexName) throws InterruptedException
+    {
+        for (int x = 0; x < 5; x++)
+        {
+            Thread.sleep(2000);
+            YzFetchIndexOperation fetch = new YzFetchIndexOperation.Builder().withIndexName(indexName).build();
+            cluster.execute(fetch);
+            fetch.await();
+            if (fetch.isSuccess())
+            {
+                return true;
+            }
+        }
+        
+        return false;
+    }
 }

--- a/src/test/java/com/basho/riak/client/core/operations/itest/ITestSearchOperation.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/ITestSearchOperation.java
@@ -72,7 +72,7 @@ public class ITestSearchOperation extends ITestBase
     @Test
     public void testYokozunaSearch() throws InterruptedException, ExecutionException
     {
-        //Assume.assumeTrue(testYokozuna);
+        Assume.assumeTrue(testYokozuna);
         
         // First we have to create an index and attach it to a bucket
         // and the 'default' bucket type can't be used for search
@@ -86,9 +86,7 @@ public class ITestSearchOperation extends ITestBase
         
         assertTrue(putOp.isSuccess());
         
-        // Without sleeping the bucket props operation will fail saying the 
-        // index does not exist.
-        Thread.sleep(10000);
+        assureIndexExists("test_index");
         
         Namespace namespace = new Namespace(yokozunaBucketType, searchBucket);
         StoreBucketPropsOperation propsOp = 

--- a/src/test/java/com/basho/riak/client/core/operations/itest/ITestYzAdminOperations.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/ITestYzAdminOperations.java
@@ -110,9 +110,7 @@ public class ITestYzAdminOperations extends ITestBase
         cluster.execute(putOp);
         putOp.get();
         
-        // Testing has shown that even though Riak responds to the create op ... 
-        // the index isn't actually created yet and the delete op return "not found" 
-        Thread.sleep(10000);
+        assertTrue("Index not created", assureIndexExists("test_index"));
         
         
         YzFetchIndexOperation fetchOp = 
@@ -139,7 +137,6 @@ public class ITestYzAdminOperations extends ITestBase
         
     }
     
-    // This ppears to also be broken in Riak as of pre7
     @Test
     public void testDeleteIndex() throws InterruptedException, ExecutionException
     {
@@ -150,9 +147,7 @@ public class ITestYzAdminOperations extends ITestBase
         cluster.execute(putOp);
         putOp.get();
         
-        // Testing has shown that even though Riak responds to the create op ... 
-        // the index isn't actually created yet and the delete op return "not found" 
-        Thread.sleep(5000);
+        assertTrue("Index not created", assureIndexExists("test_index5"));
         
         YzDeleteIndexOperation delOp = 
             new YzDeleteIndexOperation.Builder("test_index5").build();

--- a/src/test/java/com/basho/riak/client/operations/itest/ITestSearchMapReduce.java
+++ b/src/test/java/com/basho/riak/client/operations/itest/ITestSearchMapReduce.java
@@ -48,8 +48,8 @@ public class ITestSearchMapReduce extends ITestBase
     @Test
     public void serachMR() throws InterruptedException, ExecutionException
     {
-//        Assume.assumeTrue(testYokozuna);
-//        Assume.assumeTrue(testBucketType);
+        Assume.assumeTrue(testYokozuna);
+        Assume.assumeTrue(testBucketType);
         
         // First we have to create an index and attach it to a bucket
         // and the 'default' bucket type can't be used for search
@@ -58,9 +58,7 @@ public class ITestSearchMapReduce extends ITestBase
         StoreSearchIndex ssi = new StoreSearchIndex.Builder(index).build();
         client.execute(ssi);
         
-        // Without pausing, the index does not propogate in time for the bucket
-        // props op to succeed
-        Thread.sleep(10000);
+        assertTrue("Index not created", assureIndexExists("test_mr_index"));
         
         Namespace ns = new Namespace(bucketType.toString(), mrBucketName);
         StoreBucketProperties sbp = new StoreBucketProperties.Builder(ns)
@@ -96,7 +94,7 @@ public class ITestSearchMapReduce extends ITestBase
         sv = new StoreValue.Builder(ro).withLocation(location).build();
         client.execute(sv);
         
-        // Sleep some more or ... yeah, it doesn't work.
+        // Sleep some more or ... yeah, it doesn't work. 
         Thread.sleep(3000);
         
         SearchMapReduce smr = new SearchMapReduce.Builder()


### PR DESCRIPTION
This fixes  the YZ integration tests that were failing by adding new pauses.

The behavior of YZ has slightly changed, apparently, where now setting bucket props immediately after creating an index will fail telling you the index doesn't exist. Pausing for 10 seconds seems to do the trick.

This can be tested via:

`mvn clean install -Pitest,default -Dcom.basho.riak.yokozuna=true -Dcom.basho,riak.buckettype=true`

With search enabled and the `test_type` bucket type created and activated. 

fixes #422 
