### PR TITLE
Added static factory methods for RiakClient

### DIFF
--- a/src/main/java/com/basho/riak/client/RiakClient.java
+++ b/src/main/java/com/basho/riak/client/RiakClient.java
@@ -17,6 +17,9 @@ package com.basho.riak.client;
 
 import com.basho.riak.client.core.RiakCluster;
 import com.basho.riak.client.core.RiakFuture;
+import com.basho.riak.client.core.RiakNode;
+import java.net.UnknownHostException;
+import java.util.List;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -33,17 +36,79 @@ public class RiakClient
 
 	private final RiakCluster cluster;
 
-	/**
-	 * Create a new RiakClient to perform operations on the given cluster
-	 *
-	 * @param cluster
-	 * 	the cluster to perform operations against
+    /**
+	 * Create a new RiakClient to perform operations on the given cluster.
+     * <p>
+     * The RiakClient provides a user API on top of the client core. Once 
+     * instantiated, commands are submitted to it for execution on Riak. 
+     * </p>
+     * <pre>
+     * RiakClient client = RiakClient.newClient();
+     * Namespace ns = new Namespace("default","my_bucket");
+     * Location loc = new Location(ns, "my_key");
+     * FetchValue fv = new FetchValue.Builder(loc).build();
+     * FetchValue.Response response = client.execute(fv);
+     * RiakObject obj = response.getValue(RiakObject.class);
+     * client.shutdown();
+     * </pre>
+     * 
+	 * @param cluster the started RiakCluster to use.
 	 */
 	public RiakClient(RiakCluster cluster)
 	{
 		this.cluster = cluster;
 	}
 
+    /**
+     * Static factory method to create a new client instance.
+     * This method produces a client that connects to 127.0.0.1.
+     *  
+     * @return a new client instance.
+     * @throws UnknownHostException 
+     */
+    public static RiakClient newClient() throws UnknownHostException
+    {
+        RiakNode.Builder builder = new RiakNode.Builder()
+                                        .withMinConnections(10);
+        RiakCluster cluster = new RiakCluster.Builder(builder.build()).build();
+        cluster.start();
+        return new RiakClient(cluster);
+        
+    }
+    
+    /**
+     * Static factory method to create a new client instance.
+     * This method produces a client connected to the supplied addresses on
+     * the default port.
+     * @param remoteAddresses a list of IP addresses or hostnames
+     * @return a new client instance
+     * @throws UnknownHostException if a supplied hostname cannot be resolved.
+     */
+    public static RiakClient newClient(List<String> remoteAddresses) throws UnknownHostException
+    {
+        return newClient(RiakNode.Builder.DEFAULT_REMOTE_PORT, remoteAddresses);
+    }
+    
+    /**
+     * Static factory method to create a new client instance.
+     * This method produces a client connected to the supplied addresses on
+     * the supplied port.
+     * @param remoteAddresses a list of IP addresses or hostnames
+     * @param port the port to connect to on the supplied hosts.
+     * @return a new client instance
+     * @throws UnknownHostException if a supplied hostname cannot be resolved.
+     */
+    public static RiakClient newClient(int port, List<String> remoteAddresses) throws UnknownHostException
+    {
+        RiakNode.Builder builder = new RiakNode.Builder()
+                                        .withRemotePort(port)
+                                        .withMinConnections(10);
+        List<RiakNode> nodes = RiakNode.Builder.buildNodes(builder, remoteAddresses);
+        RiakCluster cluster = new RiakCluster.Builder(nodes).build();
+        cluster.start();
+        return new RiakClient(cluster);
+    }
+    
 	/**
 	 * Execute a command against Riak
 	 *


### PR DESCRIPTION
This adds simple static factory methods for instantiating a new
client with a default configuration.

Addresses #416 
