### PR TITLE
Support InetSocketAddress on RiakClient and RiakNode

### DIFF
--- a/src/main/java/com/basho/riak/client/api/RiakClient.java
+++ b/src/main/java/com/basho/riak/client/api/RiakClient.java
@@ -18,9 +18,10 @@ package com.basho.riak.client.api;
 import com.basho.riak.client.core.RiakCluster;
 import com.basho.riak.client.core.RiakFuture;
 import com.basho.riak.client.core.RiakNode;
+
+import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.List;
-
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
@@ -95,7 +96,7 @@ public class RiakClient
     public static RiakClient newClient() throws UnknownHostException
     {
         RiakNode.Builder builder = new RiakNode.Builder()
-                                        .withMinConnections(10);
+                                        .withMinConnections(RiakNode.Builder.DEFAULT_MIN_CONNECTIONS);
         RiakCluster cluster = new RiakCluster.Builder(builder.build()).build();
         cluster.start();
         return new RiakClient(cluster);
@@ -114,6 +115,57 @@ public class RiakClient
     {
         return newClient(RiakNode.Builder.DEFAULT_REMOTE_PORT, remoteAddresses);
     }
+
+    /**
+     * Static factory method to create a new client instance.
+     * This method produces a client connected to the supplied addresses on
+     * the default port.
+     * @param remoteAddresses a array of IP addresses or hostnames
+     * @return a new client instance
+     * @throws UnknownHostException if a supplied hostname cannot be resolved.
+     */
+    public static RiakClient newClient(String... remoteAddresses) throws UnknownHostException
+    {
+        return newClient(RiakNode.Builder.DEFAULT_REMOTE_PORT, remoteAddresses);
+    }
+
+    /**
+     * Static factory method to create a new client instance.
+     * This method produces a client connected to the supplied addresses on
+     * the supplied port.
+     * @param remoteAddresses a array of InetSocketAddress
+     * @return a new client instance
+     * @throws UnknownHostException if a supplied hostname cannot be resolved.
+     */
+    public static RiakClient newClient(InetSocketAddress... remoteAddresses) throws UnknownHostException
+    {
+        RiakNode.Builder builder = new RiakNode.Builder()
+                                        .withMinConnections(RiakNode.Builder.DEFAULT_MIN_CONNECTIONS);
+        List<RiakNode> nodes = RiakNode.Builder.buildNodes(builder, remoteAddresses);
+        RiakCluster cluster = new RiakCluster.Builder(nodes).build();
+        cluster.start();
+        return new RiakClient(cluster);
+    }
+
+    /**
+     * Static factory method to create a new client instance.
+     * This method produces a client connected to the supplied addresses on
+     * the supplied port.
+     * @param remoteAddresses a array of IP addresses or hostnames
+     * @param port the port to connect to on the supplied hosts.
+     * @return a new client instance
+     * @throws UnknownHostException if a supplied hostname cannot be resolved.
+     */
+    public static RiakClient newClient(int port, String... remoteAddresses) throws UnknownHostException
+    {
+        RiakNode.Builder builder = new RiakNode.Builder()
+                                        .withRemotePort(port)
+                                        .withMinConnections(RiakNode.Builder.DEFAULT_MIN_CONNECTIONS);
+        List<RiakNode> nodes = RiakNode.Builder.buildNodes(builder, remoteAddresses);
+        RiakCluster cluster = new RiakCluster.Builder(nodes).build();
+        cluster.start();
+        return new RiakClient(cluster);
+    }
     
     /**
      * Static factory method to create a new client instance.
@@ -126,13 +178,7 @@ public class RiakClient
      */
     public static RiakClient newClient(int port, List<String> remoteAddresses) throws UnknownHostException
     {
-        RiakNode.Builder builder = new RiakNode.Builder()
-                                        .withRemotePort(port)
-                                        .withMinConnections(10);
-        List<RiakNode> nodes = RiakNode.Builder.buildNodes(builder, remoteAddresses);
-        RiakCluster cluster = new RiakCluster.Builder(nodes).build();
-        cluster.start();
-        return new RiakClient(cluster);
+        return newClient(port, remoteAddresses.toArray(new String[remoteAddresses.size()]));
     }
     
 	/**

--- a/src/main/java/com/basho/riak/client/core/RiakNode.java
+++ b/src/main/java/com/basho/riak/client/core/RiakNode.java
@@ -1445,10 +1445,49 @@ public class RiakNode implements RiakResponseListener
         public static List<RiakNode> buildNodes(Builder builder, List<String> remoteAddresses)
             throws UnknownHostException
         {
-            List<RiakNode> nodes = new ArrayList<RiakNode>(remoteAddresses.size());
+        	return buildNodes(builder, remoteAddresses.toArray(new String[remoteAddresses.size()]));
+        }
+
+        /**
+         * Build a set of RiakNodes.
+         * The provided builder will be used to construct a set of RiakNodes
+         * using the supplied addresses.
+         *
+         * @param builder         a configured builder
+         * @param remoteAddresses a array of IP addresses or FQDN
+         * @return a list of constructed RiakNodes
+         * @throws UnknownHostException if a supplied FQDN can not be resolved.
+         */
+        public static List<RiakNode> buildNodes(Builder builder, String... remoteAddresses)
+            throws UnknownHostException
+        {
+            List<RiakNode> nodes = new ArrayList<RiakNode>(remoteAddresses.length);
             for (String remoteAddress : remoteAddresses)
             {
                 builder.withRemoteAddress(remoteAddress);
+                nodes.add(builder.build());
+            }
+            return nodes;
+        }
+
+        /**
+         * Build a set of RiakNodes.
+         * The provided builder will be used to construct a set of RiakNodes
+         * using the supplied addresses on the supplied port.
+         *
+         * @param builder         a configured builder
+         * @param remoteAddresses a array of InetSocketAddress
+         * @return a list of constructed RiakNodes
+         * @throws UnknownHostException if a supplied FQDN can not be resolved.
+         */
+        public static List<RiakNode> buildNodes(Builder builder, InetSocketAddress... remoteAddresses)
+            throws UnknownHostException
+        {
+            List<RiakNode> nodes = new ArrayList<RiakNode>(remoteAddresses.length);
+            for (InetSocketAddress remoteAddress : remoteAddresses)
+            {
+                builder.withRemoteAddress(remoteAddress.getHostString());
+                builder.withRemotePort(remoteAddress.getPort());
                 nodes.add(builder.build());
             }
             return nodes;

--- a/src/test/java/com/basho/riak/client/RiakClientTest.java
+++ b/src/test/java/com/basho/riak/client/RiakClientTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2014 Kazuhiro Suzuki <kaz at basho dot com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.basho.riak.client;
+
+import static org.junit.Assert.*;
+
+import java.lang.reflect.Field;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Test;
+
+import com.basho.riak.client.api.RiakClient;
+import com.basho.riak.client.core.RiakCluster;
+import com.basho.riak.client.core.RiakNode;
+
+/**
+ * 
+ * @author Kazuhiro Suzuki <kaz at basho dot com>
+ */
+public class RiakClientTest {
+	private RiakClient client;
+
+	@After
+	public void teardown() {
+		if (client != null) {
+			client.shutdown();
+		}
+	}
+
+	@Test
+	public void newClientUsingStringList() throws Exception {
+		List<String> addresses = new ArrayList<String>();
+		addresses.add("localhost");
+		addresses.add("127.0.0.1");
+		client = RiakClient.newClient(addresses);
+
+		Field field = client.getClass().getDeclaredField("cluster");
+		field.setAccessible(true);
+		RiakCluster cluster = (RiakCluster) field.get(client);
+		List<RiakNode> nodes = cluster.getNodes();
+
+		for (int i = 0; i < addresses.size(); i++) {
+			assertEquals(addresses.get(i), nodes.get(i).getRemoteAddress());
+			assertEquals(8087, nodes.get(i).getPort());
+		}
+	}
+
+	@Test
+	public void newClientWithStringArray() throws Exception {
+		int port = 8000;
+		String[] addresses = new String[]{"localhost", "127.0.0.1"};
+		client = RiakClient.newClient(port, addresses);
+
+		Field field = client.getClass().getDeclaredField("cluster");
+		field.setAccessible(true);
+		RiakCluster cluster = (RiakCluster) field.get(client);
+		List<RiakNode> nodes = cluster.getNodes();
+
+		for (int i = 0; i < addresses.length; i++) {
+			assertEquals(addresses[i], nodes.get(i).getRemoteAddress());
+			assertEquals(port, nodes.get(i).getPort());
+		}
+	}
+
+	@Test
+	public void newClientWithInetSocketAddress() throws Exception {
+		InetSocketAddress[] addresses = new InetSocketAddress[] {
+				new InetSocketAddress("localhost", 1111),
+				new InetSocketAddress("127.0.0.1", 2222) };
+		client = RiakClient.newClient(addresses);
+
+		Field field = client.getClass().getDeclaredField("cluster");
+		field.setAccessible(true);
+		RiakCluster cluster = (RiakCluster) field.get(client);
+		List<RiakNode> nodes = cluster.getNodes();
+
+		for (int i = 0; i < addresses.length; i++) {
+			assertEquals(addresses[i].getHostString(), nodes.get(i).getRemoteAddress());
+			assertEquals(addresses[i].getPort(), nodes.get(i).getPort());
+		}
+	}
+}


### PR DESCRIPTION
Now, RiakClient and RiakNode can't handle different port number for each address. (ex. connect to 127.0.0.1:10018, 127.0.0.1:10028, 127.0.0.1:10038...) So, this PR allows the client to connect to such addresses.

I think the changes are helpful for the client's a failover test on local devrel environment, and more easy to setup RiakClient and RiakNode like this:

``` java
RiakClient client = RiakClient.newClient(new InetSocketAddress("localhost", 8087),
                                new InetSocketAddress("localhost", 8187),
                                new InetSocketAddress("localhost", 8287),
                                new InetSocketAddress("localhost", 8387),
                                new InetSocketAddress("localhost", 8487));
```

It is my concern that I used variable argument parameter `String... addresses`. It seems different from the current coding style.

Any advice is helpful. thanks.
