### PR TITLE
Fixes RiakFuture get() implementations

### DIFF
--- a/src/main/java/com/basho/riak/client/api/RiakCommand.java
+++ b/src/main/java/com/basho/riak/client/api/RiakCommand.java
@@ -86,15 +86,7 @@ public abstract class RiakCommand<T,S>
     {
         RiakFuture<T,S> future = executeAsync(cluster);
         future.await();
-        if (future.isSuccess())
-        {
-            return future.get();
-        }
-        else
-        {
-            throw new ExecutionException(future.cause());
-        }
-        
+        return future.get();
     }
     protected abstract RiakFuture<T,S> executeAsync(RiakCluster cluster);    
 } 

--- a/src/main/java/com/basho/riak/client/api/commands/CoreFutureAdapter.java
+++ b/src/main/java/com/basho/riak/client/api/commands/CoreFutureAdapter.java
@@ -18,7 +18,9 @@ package com.basho.riak.client.api.commands;
 
 import com.basho.riak.client.core.RiakFuture;
 import com.basho.riak.client.core.RiakFutureListener;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  *
@@ -45,33 +47,31 @@ public abstract class CoreFutureAdapter<T2,S2,T,S> extends ListenableFuture<T2,S
     }
 
     @Override
-    public T2 get() throws InterruptedException
+    public T2 get() throws InterruptedException, ExecutionException
     {
-        T response = coreFuture.get();
-        if (response != null)
-        {
-            return convertResponse(coreFuture.get());
-        }
-        else 
-        {
-            return null;
-        }
+        return convertResponse(coreFuture.get());
     }
 
     @Override
-    public T2 get(long timeout, TimeUnit unit) throws InterruptedException
+    public T2 get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException
     {
         T response = coreFuture.get(timeout, unit);
-        if (response != null)
+        return convertResponse(response);
+    }
+
+    @Override
+    public T2 getNow()
+    {
+        if (coreFuture.isDone())
         {
-            return convertResponse(coreFuture.get(timeout, unit));
+            return convertResponse(coreFuture.getNow());
         }
         else
         {
             return null;
         }
     }
-
+    
     @Override
     public boolean isCancelled()
     {

--- a/src/main/java/com/basho/riak/client/api/commands/kv/MultiFetch.java
+++ b/src/main/java/com/basho/riak/client/api/commands/kv/MultiFetch.java
@@ -364,6 +364,19 @@ public final class MultiFetch extends RiakCommand<MultiFetch.Response, List<Loca
         }
 
         @Override
+        public Response getNow()
+        {
+            if (isDone())
+            {
+                return new Response(futures);
+            }
+            else
+            {
+                return null;
+            }
+        }
+        
+        @Override
         public boolean isCancelled()
         {
             return false;

--- a/src/main/java/com/basho/riak/client/api/commands/kv/UpdateValue.java
+++ b/src/main/java/com/basho/riak/client/api/commands/kv/UpdateValue.java
@@ -33,6 +33,7 @@ import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -198,6 +199,10 @@ public final class UpdateValue extends RiakCommand<UpdateValue.Response, Locatio
                             updateFuture.setException(ex);
                         }
                         catch (ConversionException ex)
+                        {
+                            updateFuture.setException(ex);
+                        }
+                        catch (ExecutionException ex)
                         {
                             updateFuture.setException(ex);
                         }
@@ -516,6 +521,12 @@ public final class UpdateValue extends RiakCommand<UpdateValue.Response, Locatio
         }
 
         @Override
+        public Response getNow()
+        {
+            return updateResponse;
+        }
+        
+        @Override
         public boolean isCancelled()
         {
             return false;
@@ -583,6 +594,10 @@ public final class UpdateValue extends RiakCommand<UpdateValue.Response, Locatio
                     
                 }
                 catch (InterruptedException ex) 
+                {
+                    setException(ex);
+                }
+                catch (ExecutionException ex)
                 {
                     setException(ex);
                 }

--- a/src/test/java/com/basho/riak/client/api/commands/ImmediateRiakFuture.java
+++ b/src/test/java/com/basho/riak/client/api/commands/ImmediateRiakFuture.java
@@ -49,6 +49,12 @@ class ImmediateRiakFuture<V,S> implements RiakFuture<V,S>
     }
 
     @Override
+    public V getNow()
+    {
+        return value;
+    }
+    
+    @Override
     public boolean isCancelled()
     {
         return false;

--- a/src/test/java/com/basho/riak/client/core/FutureOperationTest.java
+++ b/src/test/java/com/basho/riak/client/core/FutureOperationTest.java
@@ -128,7 +128,7 @@ public class FutureOperationTest
         assertNotNull(operation.get());
     }
 
-    @Test
+    @Test(expected=TimeoutException.class)
     public void notDoneBlocksGet() throws InterruptedException, ExecutionException, TimeoutException
     {
         final int NUM_TRIES = 3;

--- a/src/test/java/com/basho/riak/client/core/RiakClusterFixtureTest.java
+++ b/src/test/java/com/basho/riak/client/core/RiakClusterFixtureTest.java
@@ -129,7 +129,7 @@ public class RiakClusterFixtureTest
         
         try
         {
-            FetchOperation.Response response = operation.get();
+            operation.await();
             assertFalse(operation.isSuccess());
             assertNotNull(operation.cause());
         }

--- a/src/test/java/com/basho/riak/client/core/RiakNodeFixtureTest.java
+++ b/src/test/java/com/basho/riak/client/core/RiakNodeFixtureTest.java
@@ -260,7 +260,7 @@ public class RiakNodeFixtureTest extends FixtureTest
                     .build();
         
         boolean accepted = node.execute(operation);
-        FetchOperation.Response response = operation.get();
+        operation.await();
         assertFalse(operation.isSuccess());
         assertNotNull(operation.cause());
         node.shutdown().get();

--- a/src/test/java/com/basho/riak/client/core/operations/itest/ITestBase.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/ITestBase.java
@@ -222,6 +222,10 @@ public abstract class ITestBase
                 {
                     throw new RuntimeException(ex);
                 }
+                catch (ExecutionException ex)
+                {
+                    throw new RuntimeException(ex);
+                }
                 
                 semaphore.release();
                 received.incrementAndGet();

--- a/src/test/java/com/basho/riak/client/core/operations/itest/ITestListBucketsOperation.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/ITestListBucketsOperation.java
@@ -123,6 +123,10 @@ public class ITestListBucketsOperation extends ITestBase
                     {
                         throw new RuntimeException(ex);
                     }
+                    catch (ExecutionException ex)
+                    {
+                        throw new RuntimeException(ex);
+                    }
                     
                     semaphore.release();
                     received.incrementAndGet();

--- a/src/test/java/com/basho/riak/client/core/operations/itest/ITestListKeysOperation.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/ITestListKeysOperation.java
@@ -152,6 +152,10 @@ public class ITestListKeysOperation extends ITestBase
                 {
                     throw new RuntimeException(ex);
                 }
+                catch (ExecutionException ex)
+                {
+                    throw new RuntimeException(ex);
+                }
                 
             }
         };


### PR DESCRIPTION
The two get() methods in RiakFuture and its implementations now
conform to the behavior of core Java Future.

1) When calling either version of get() you will receive an ExecutionException
if the computation fails for any reason.
2) When calling get(timeout, timeunit) you will receive a TimeoutException
if the timer expires before the computation completes.

This means you will now either receive a (successful) response or an exception when using
get() which is the desired behavior.

This addresses #467 
