### PR TITLE
Expose Netty Connection Read Timeout

### DIFF
--- a/src/main/java/com/basho/riak/client/core/RiakNode.java
+++ b/src/main/java/com/basho/riak/client/core/RiakNode.java
@@ -176,7 +176,7 @@ public class RiakNode implements RiakResponseListener
         this.executor = builder.executor;
         this.connectionTimeout = builder.connectionTimeout;
         this.idleTimeoutInNanos = TimeUnit.NANOSECONDS.convert(builder.idleTimeout, TimeUnit.MILLISECONDS);
-		this.soTimeout = builder.soTimeout;
+        this.soTimeout = builder.soTimeout;
         this.minConnections = builder.minConnections;
         this.port = builder.port;
         this.remoteAddress = builder.remoteAddress;
@@ -252,10 +252,10 @@ public class RiakNode implements RiakResponseListener
             bootstrap.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectionTimeout);
         }
 
-	if (soTimeout > 0)
-	{
-	    bootstrap.option(ChannelOption.SO_TIMEOUT, soTimeout);
-	}
+        if (soTimeout > 0)
+        {
+            bootstrap.option(ChannelOption.SO_TIMEOUT, soTimeout);
+        }
 
         if (minConnections > 0)
         {
@@ -526,14 +526,14 @@ public class RiakNode implements RiakResponseListener
     /**
      * Sets the underlying socket SO (read) timeout in milliseconds.
      *
-	 * @param soTimeoutInMillis the SO (read) timeout to set
-	 * @return a reference to this RiakNode
-	 * @see Builder#withSOTimeout(int)
+     * @param soTimeoutInMillis the SO (read) timeout to set
+     * @return a reference to this RiakNode
+     * @see Builder#withSOTimeout(int)
      */
     public RiakNode setSOTimeout(int soTimeoutInMillis)
     {
         stateCheck(State.CREATED, State.RUNNING, State.HEALTH_CHECKING);
-		this.soTimeout = soTimeoutInMillis;
+        this.soTimeout = soTimeoutInMillis;
         bootstrap.option(ChannelOption.SO_TIMEOUT, connectionTimeout);
         return this;
     }

--- a/src/main/java/com/basho/riak/client/core/RiakNode.java
+++ b/src/main/java/com/basho/riak/client/core/RiakNode.java
@@ -176,7 +176,7 @@ public class RiakNode implements RiakResponseListener
         this.executor = builder.executor;
         this.connectionTimeout = builder.connectionTimeout;
         this.idleTimeoutInNanos = TimeUnit.NANOSECONDS.convert(builder.idleTimeout, TimeUnit.MILLISECONDS);
-	this.soTimeout = builder.soTimeout;
+		this.soTimeout = builder.soTimeout;
         this.minConnections = builder.minConnections;
         this.port = builder.port;
         this.remoteAddress = builder.remoteAddress;
@@ -524,15 +524,16 @@ public class RiakNode implements RiakResponseListener
     }
 
     /**
-     * Returns the SO timeout in milliseconds.
+     * Sets the underlying socket SO (read) timeout in milliseconds.
      *
-     * @return the SOTimeout
-     * @see Builder#withSOTimeout(int)
+	 * @param soTimeoutInMillis the SO (read) timeout to set
+	 * @return a reference to this RiakNode
+	 * @see Builder#withSOTimeout(int)
      */
     public RiakNode setSOTimeout(int soTimeoutInMillis)
     {
         stateCheck(State.CREATED, State.RUNNING, State.HEALTH_CHECKING);
-	this.soTimeout = soTimeoutInMillis;
+		this.soTimeout = soTimeoutInMillis;
         bootstrap.option(ChannelOption.SO_TIMEOUT, connectionTimeout);
         return this;
     }

--- a/src/main/java/com/basho/riak/client/core/netty/RiakChannelInitializer.java
+++ b/src/main/java/com/basho/riak/client/core/netty/RiakChannelInitializer.java
@@ -20,6 +20,10 @@ import com.basho.riak.client.core.util.Constants;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.timeout.IdleStateHandler;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+
+import java.util.concurrent.TimeUnit;
 
 /**
  *
@@ -29,10 +33,13 @@ import io.netty.channel.socket.SocketChannel;
 public class RiakChannelInitializer extends ChannelInitializer<SocketChannel>
 {
     private final RiakResponseListener listener;
-    public RiakChannelInitializer(RiakResponseListener listener)
+	private volatile int readTimeout;
+
+	public RiakChannelInitializer(RiakResponseListener listener, int readTimeoutMillis)
     {
         super();
         this.listener = listener;
+		this.readTimeout = readTimeoutMillis;
     }
 
     @Override
@@ -42,6 +49,16 @@ public class RiakChannelInitializer extends ChannelInitializer<SocketChannel>
         p.addLast(Constants.MESSAGE_CODEC, new RiakMessageCodec());
         p.addLast(Constants.OPERATION_ENCODER, new RiakOperationEncoder());
         p.addLast(Constants.RESPONSE_HANDLER, new RiakResponseHandler(listener));
+        p.addLast(Constants.READ_TIMEOUT_HANDLER, new ReadTimeoutHandler(readTimeout, TimeUnit.MILLISECONDS));
     }
-    
+
+    public int getReadTimeout()
+    {
+        return readTimeout;
+    }
+
+    public void setReadTimeout(int readTimeoutMillis)
+    {
+        readTimeout = readTimeoutMillis;
+    }
 }

--- a/src/main/java/com/basho/riak/client/core/netty/RiakSecurityDecoder.java
+++ b/src/main/java/com/basho/riak/client/core/netty/RiakSecurityDecoder.java
@@ -109,7 +109,7 @@ public class RiakSecurityDecoder extends ByteToMessageDecoder
                                 promise.tryFailure((riakErrorToException(protobuf)));
                                 break;
                             default:
-				logger.debug("Invalid return code during StartTLS from {}:{}", remoteAddr, remotePort);
+				logger.debug("Invalid return code during StartTLS from {}:{} code", remoteAddr, remotePort, code);
                                 promise.tryFailure(new RiakResponseException(0,
                                     "Invalid return code during StartTLS; " + code));
                         }
@@ -228,7 +228,7 @@ public class RiakSecurityDecoder extends ByteToMessageDecoder
             }
             else
             {
-                logger.debug("SSLHandshake Failed with {}:{}.", remoteAddr, remotePort);
+                logger.warn("SSLHandshake Failed with {}:{}.", remoteAddr, remotePort, future.cause());
                 promise.tryFailure(future.cause());
             }
         }

--- a/src/main/java/com/basho/riak/client/core/netty/RiakSecurityDecoder.java
+++ b/src/main/java/com/basho/riak/client/core/netty/RiakSecurityDecoder.java
@@ -49,14 +49,18 @@ public class RiakSecurityDecoder extends ByteToMessageDecoder
     private final String username;
     private final String password;
     private final Logger logger = LoggerFactory.getLogger(RiakSecurityDecoder.class);
-    private volatile DefaultPromise<Void> promise;
+	private final String remoteAddr;
+	private final int remotePort;
+	private volatile DefaultPromise<Void> promise;
     
     private enum State { TLS_START, TLS_WAIT, SSL_WAIT, AUTH_WAIT }
     
     private volatile State state = State.TLS_START;
     
-    public RiakSecurityDecoder(SSLEngine engine, String username, String password)
+    public RiakSecurityDecoder(String remoteAddress, int port, SSLEngine engine, String username, String password)
     {
+		this.remoteAddr = remoteAddress;
+		this.remotePort = port;
         this.sslEngine = engine;
         this.username = username;
         this.password = password;
@@ -88,7 +92,7 @@ public class RiakSecurityDecoder extends ByteToMessageDecoder
                         switch(code)
                         {
                             case RiakMessageCodes.MSG_StartTls:
-                                logger.debug("Received MSG_RpbStartTls reply");
+                                logger.debug("Received MSG_RpbStartTls reply from {}:{}", remoteAddr, remotePort);
                                 // change state
                                 this.state = State.SSL_WAIT;
                                 // insert SSLHandler
@@ -101,10 +105,11 @@ public class RiakSecurityDecoder extends ByteToMessageDecoder
                                 chc.channel().pipeline().addFirst(Constants.SSL_HANDLER, sslHandler);
                                 break;
                             case RiakMessageCodes.MSG_ErrorResp:
-                                logger.debug("Received MSG_ErrorResp reply to startTls");
+                                logger.debug("Received MSG_ErrorResp reply to startTls from {}:{}", remoteAddr, remotePort);
                                 promise.tryFailure((riakErrorToException(protobuf)));
                                 break;
                             default:
+				logger.debug("Invalid return code during StartTLS from {}:{}", remoteAddr, remotePort);
                                 promise.tryFailure(new RiakResponseException(0,
                                     "Invalid return code during StartTLS; " + code));
                         }
@@ -114,21 +119,22 @@ public class RiakSecurityDecoder extends ByteToMessageDecoder
                         switch(code)
                         {
                             case RiakMessageCodes.MSG_AuthResp:
-                                logger.debug("Received MSG_RpbAuthResp reply");
+                                logger.debug("Received MSG_RpbAuthResp reply from {}:{}", remoteAddr, remotePort);
                                 promise.trySuccess(null);
                                 break;
                             case RiakMessageCodes.MSG_ErrorResp:
-                                logger.debug("Received MSG_ErrorResp reply to auth");
+                                logger.debug("Received MSG_ErrorResp reply to Auth from {}:{}", remoteAddr, remotePort);
                                 promise.tryFailure(riakErrorToException(protobuf));
                                 break;
                             default:
+                                logger.debug("Invalid return code during Auth from {}:{}", remoteAddr, remotePort);
                                 promise.tryFailure(new RiakResponseException(0,
                                     "Invalid return code during Auth; " + code));
                         }
                         break;
                     default:
                         // WTF?
-                        logger.error("Received message while not in TLS_WAIT or AUTH_WAIT");
+                        logger.error("Received message while not in TLS_WAIT or AUTH_WAIT from {}:{}", remoteAddr, remotePort);
                         promise.tryFailure(new IllegalStateException("Received message while not in TLS_WAIT or AUTH_WAIT"));
                 }
             }
@@ -208,6 +214,7 @@ public class RiakSecurityDecoder extends ByteToMessageDecoder
         {
             if (future.isSuccess())
             {
+                logger.debug("SSLHandshake Completed with {}:{}. Authenticating.", remoteAddr, remotePort);
                 Channel c = future.getNow();
                 state = State.AUTH_WAIT;
                 RiakPB.RpbAuthReq authReq = 
@@ -221,6 +228,7 @@ public class RiakSecurityDecoder extends ByteToMessageDecoder
             }
             else
             {
+                logger.debug("SSLHandshake Failed with {}:{}.", remoteAddr, remotePort);
                 promise.tryFailure(future.cause());
             }
         }

--- a/src/main/java/com/basho/riak/client/core/util/Constants.java
+++ b/src/main/java/com/basho/riak/client/core/util/Constants.java
@@ -95,6 +95,7 @@ public interface Constants {
     public static final String MESSAGE_CODEC = "codec";
     public static final String OPERATION_ENCODER = "operationEncoder";
     public static final String RESPONSE_HANDLER = "responseHandler";
+    public static final String READ_TIMEOUT_HANDLER = "readTimeoutHandler";
     public static final String SSL_HANDLER = "sslHandler";
     public static final String HEALTHCHECK_CODEC = "healthCheckCodec";
     

--- a/src/test/java/com/basho/riak/client/core/RiakNodeTest.java
+++ b/src/test/java/com/basho/riak/client/core/RiakNodeTest.java
@@ -63,7 +63,7 @@ public class RiakNodeTest
         assertEquals(node.getMaxConnections(), Integer.MAX_VALUE);
         assertEquals(node.getConnectionTimeout(), RiakNode.Builder.DEFAULT_CONNECTION_TIMEOUT);
         assertEquals(node.getIdleTimeout(), RiakNode.Builder.DEFAULT_IDLE_TIMEOUT);
-	assertEquals(node.getSOTimeout(), RiakNode.Builder.DEFAULT_SO_TIMEOUT);
+		assertEquals(node.getSOTimeout(), RiakNode.Builder.DEFAULT_SO_TIMEOUT);
         assertEquals(node.getMinConnections(), RiakNode.Builder.DEFAULT_MIN_CONNECTIONS);
         assertEquals(node.availablePermits(), Integer.MAX_VALUE);
     }
@@ -76,8 +76,7 @@ public class RiakNodeTest
         final int MIN_CONNECTIONS = 2002;
         final int MAX_CONNECTIONS = 2003;
         final int PORT = 2004;
-        final int READ_TIMEOUT = 2005;
-	final int SO_TIMEOUT = 2006;
+		final int SO_TIMEOUT = 2006;
         final String REMOTE_ADDRESS = "localhost";
         final ScheduledExecutorService EXECUTOR = Executors.newSingleThreadScheduledExecutor();
         final Bootstrap BOOTSTRAP = PowerMockito.spy(new Bootstrap());
@@ -93,7 +92,7 @@ public class RiakNodeTest
             .withRemoteAddress(REMOTE_ADDRESS)
             .withExecutor(EXECUTOR)
             .withBootstrap(BOOTSTRAP)
-	    .withSOTimeout(SO_TIMEOUT)
+	    	.withSOTimeout(SO_TIMEOUT)
             .build();
 
         assertEquals(node.getRemoteAddress(), REMOTE_ADDRESS);
@@ -106,7 +105,7 @@ public class RiakNodeTest
         assertEquals(node.getRemoteAddress(), REMOTE_ADDRESS);
         assertEquals(node.availablePermits(), MAX_CONNECTIONS);
         assertEquals(node.getPort(), PORT);
-	assertEquals(node.getSOTimeout(), SO_TIMEOUT);
+		assertEquals(node.getSOTimeout(), SO_TIMEOUT);
 
     }
 

--- a/src/test/java/com/basho/riak/client/core/RiakNodeTest.java
+++ b/src/test/java/com/basho/riak/client/core/RiakNodeTest.java
@@ -63,7 +63,7 @@ public class RiakNodeTest
         assertEquals(node.getMaxConnections(), Integer.MAX_VALUE);
         assertEquals(node.getConnectionTimeout(), RiakNode.Builder.DEFAULT_CONNECTION_TIMEOUT);
         assertEquals(node.getIdleTimeout(), RiakNode.Builder.DEFAULT_IDLE_TIMEOUT);
-		assertEquals(node.getSOTimeout(), RiakNode.Builder.DEFAULT_SO_TIMEOUT);
+        assertEquals(node.getSOTimeout(), RiakNode.Builder.DEFAULT_SO_TIMEOUT);
         assertEquals(node.getMinConnections(), RiakNode.Builder.DEFAULT_MIN_CONNECTIONS);
         assertEquals(node.availablePermits(), Integer.MAX_VALUE);
     }
@@ -76,7 +76,7 @@ public class RiakNodeTest
         final int MIN_CONNECTIONS = 2002;
         final int MAX_CONNECTIONS = 2003;
         final int PORT = 2004;
-		final int SO_TIMEOUT = 2006;
+        final int SO_TIMEOUT = 2006;
         final String REMOTE_ADDRESS = "localhost";
         final ScheduledExecutorService EXECUTOR = Executors.newSingleThreadScheduledExecutor();
         final Bootstrap BOOTSTRAP = PowerMockito.spy(new Bootstrap());
@@ -92,7 +92,7 @@ public class RiakNodeTest
             .withRemoteAddress(REMOTE_ADDRESS)
             .withExecutor(EXECUTOR)
             .withBootstrap(BOOTSTRAP)
-	    	.withSOTimeout(SO_TIMEOUT)
+            .withSOTimeout(SO_TIMEOUT)
             .build();
 
         assertEquals(node.getRemoteAddress(), REMOTE_ADDRESS);
@@ -105,7 +105,7 @@ public class RiakNodeTest
         assertEquals(node.getRemoteAddress(), REMOTE_ADDRESS);
         assertEquals(node.availablePermits(), MAX_CONNECTIONS);
         assertEquals(node.getPort(), PORT);
-		assertEquals(node.getSOTimeout(), SO_TIMEOUT);
+        assertEquals(node.getSOTimeout(), SO_TIMEOUT);
 
     }
 

--- a/src/test/java/com/basho/riak/client/core/RiakNodeTest.java
+++ b/src/test/java/com/basho/riak/client/core/RiakNodeTest.java
@@ -63,7 +63,7 @@ public class RiakNodeTest
         assertEquals(node.getMaxConnections(), Integer.MAX_VALUE);
         assertEquals(node.getConnectionTimeout(), RiakNode.Builder.DEFAULT_CONNECTION_TIMEOUT);
         assertEquals(node.getIdleTimeout(), RiakNode.Builder.DEFAULT_IDLE_TIMEOUT);
-        assertEquals(node.getSOTimeout(), RiakNode.Builder.DEFAULT_SO_TIMEOUT);
+        assertEquals(node.getReadTimeout(), RiakNode.Builder.DEFAULT_READ_TIMEOUT);
         assertEquals(node.getMinConnections(), RiakNode.Builder.DEFAULT_MIN_CONNECTIONS);
         assertEquals(node.availablePermits(), Integer.MAX_VALUE);
     }
@@ -76,7 +76,7 @@ public class RiakNodeTest
         final int MIN_CONNECTIONS = 2002;
         final int MAX_CONNECTIONS = 2003;
         final int PORT = 2004;
-        final int SO_TIMEOUT = 2006;
+        final int READ_TIMEOUT = 2006;
         final String REMOTE_ADDRESS = "localhost";
         final ScheduledExecutorService EXECUTOR = Executors.newSingleThreadScheduledExecutor();
         final Bootstrap BOOTSTRAP = PowerMockito.spy(new Bootstrap());
@@ -92,7 +92,7 @@ public class RiakNodeTest
             .withRemoteAddress(REMOTE_ADDRESS)
             .withExecutor(EXECUTOR)
             .withBootstrap(BOOTSTRAP)
-            .withSOTimeout(SO_TIMEOUT)
+            .withReadTimeout(READ_TIMEOUT)
             .build();
 
         assertEquals(node.getRemoteAddress(), REMOTE_ADDRESS);
@@ -105,7 +105,7 @@ public class RiakNodeTest
         assertEquals(node.getRemoteAddress(), REMOTE_ADDRESS);
         assertEquals(node.availablePermits(), MAX_CONNECTIONS);
         assertEquals(node.getPort(), PORT);
-        assertEquals(node.getSOTimeout(), SO_TIMEOUT);
+        assertEquals(node.getReadTimeout(), READ_TIMEOUT);
 
     }
 

--- a/src/test/java/com/basho/riak/client/core/RiakNodeTest.java
+++ b/src/test/java/com/basho/riak/client/core/RiakNodeTest.java
@@ -63,6 +63,7 @@ public class RiakNodeTest
         assertEquals(node.getMaxConnections(), Integer.MAX_VALUE);
         assertEquals(node.getConnectionTimeout(), RiakNode.Builder.DEFAULT_CONNECTION_TIMEOUT);
         assertEquals(node.getIdleTimeout(), RiakNode.Builder.DEFAULT_IDLE_TIMEOUT);
+	assertEquals(node.getSOTimeout(), RiakNode.Builder.DEFAULT_SO_TIMEOUT);
         assertEquals(node.getMinConnections(), RiakNode.Builder.DEFAULT_MIN_CONNECTIONS);
         assertEquals(node.availablePermits(), Integer.MAX_VALUE);
     }
@@ -76,6 +77,7 @@ public class RiakNodeTest
         final int MAX_CONNECTIONS = 2003;
         final int PORT = 2004;
         final int READ_TIMEOUT = 2005;
+	final int SO_TIMEOUT = 2006;
         final String REMOTE_ADDRESS = "localhost";
         final ScheduledExecutorService EXECUTOR = Executors.newSingleThreadScheduledExecutor();
         final Bootstrap BOOTSTRAP = PowerMockito.spy(new Bootstrap());
@@ -91,6 +93,7 @@ public class RiakNodeTest
             .withRemoteAddress(REMOTE_ADDRESS)
             .withExecutor(EXECUTOR)
             .withBootstrap(BOOTSTRAP)
+	    .withSOTimeout(SO_TIMEOUT)
             .build();
 
         assertEquals(node.getRemoteAddress(), REMOTE_ADDRESS);
@@ -103,6 +106,7 @@ public class RiakNodeTest
         assertEquals(node.getRemoteAddress(), REMOTE_ADDRESS);
         assertEquals(node.availablePermits(), MAX_CONNECTIONS);
         assertEquals(node.getPort(), PORT);
+	assertEquals(node.getSOTimeout(), SO_TIMEOUT);
 
     }
 


### PR DESCRIPTION
We were debugging an issue with network connectivity, and noticed that having a setting for the SO timeout would be useful, so that unresponsive sockets timeout instead of hanging forever.

Still wracking my brain as to how best to test this, so for now all I have is the validation tests that verify that get getters and setters work.
