### PR TITLE
NPE fixed in RiakMap getDatatype functions

### DIFF
--- a/src/main/java/com/basho/riak/client/core/query/crdt/types/RiakMap.java
+++ b/src/main/java/com/basho/riak/client/core/query/crdt/types/RiakMap.java
@@ -74,14 +74,14 @@ public class RiakMap extends RiakDatatype
      */
 	public RiakMap getMap(BinaryValue key)
 	{
-        if (entries.containsKey(key)) {
-            for (RiakDatatype dt : entries.get(key)) {
-                if (dt.isMap()) {
-                    return dt.getAsMap();
+            if (entries.containsKey(key)) {
+                for (RiakDatatype dt : entries.get(key)) {
+                    if (dt.isMap()) {
+                        return dt.getAsMap();
+                    }
                 }
             }
-        }
-		return null;
+            return null;
 	}
 
     /**
@@ -103,14 +103,14 @@ public class RiakMap extends RiakDatatype
      */
 	public RiakSet getSet(BinaryValue key)
 	{
-        if (entries.containsKey(key)) {
-            for (RiakDatatype dt : entries.get(key)) {
-                if (dt.isSet()) {
-                    return dt.getAsSet();
+            if (entries.containsKey(key)) {
+                for (RiakDatatype dt : entries.get(key)) {
+                    if (dt.isSet()) {
+                        return dt.getAsSet();
+                    }
                 }
             }
-        }
-		return null;
+            return null;
 	}
 
     /**
@@ -132,14 +132,14 @@ public class RiakMap extends RiakDatatype
      */
 	public RiakCounter getCounter(BinaryValue key)
 	{
-        if (entries.containsKey(key)) {
-            for (RiakDatatype dt : entries.get(key)) {
-                if (dt.isCounter()) {
-                    return dt.getAsCounter();
+            if (entries.containsKey(key)) {
+                for (RiakDatatype dt : entries.get(key)) {
+                    if (dt.isCounter()) {
+                        return dt.getAsCounter();
+                    }
                 }
             }
-        }
-		return null;
+            return null;
 	}
 
     /**
@@ -161,14 +161,14 @@ public class RiakMap extends RiakDatatype
      */
 	public RiakFlag getFlag(BinaryValue key)
 	{
-        if (entries.containsKey(key)) {
-            for (RiakDatatype dt : entries.get(key)) {
-                if (dt.isFlag()) {
-                    return dt.getAsFlag();
+            if (entries.containsKey(key)) {
+                for (RiakDatatype dt : entries.get(key)) {
+                    if (dt.isFlag()) {
+                        return dt.getAsFlag();
+                    }
                 }
             }
-        }
-		return null;
+            return null;
 	}
 
     /**
@@ -190,14 +190,14 @@ public class RiakMap extends RiakDatatype
      */
 	public RiakRegister getRegister(BinaryValue key)
 	{
-        if (entries.containsKey(key)) {
-            for (RiakDatatype dt : entries.get(key)) {
-                if (dt.isRegister()) {
-                    return dt.getAsRegister();
+            if (entries.containsKey(key)) {
+                for (RiakDatatype dt : entries.get(key)) {
+                    if (dt.isRegister()) {
+                        return dt.getAsRegister();
+                    }
                 }
             }
-        }
-		return null;
+            return null;
 	}
 
     /**


### PR DESCRIPTION
HashMap used to store the datatypes mapping in RiakMap,  returns null when there is no mapping for the given  key.  http://docs.oracle.com/javase/7/docs/api/java/util/HashMap.html#get(java.lang.Object)

This patch corrects the Null pointer exception thrown when querying the RiakMap for getMap(), getCounter() etc API calls and returns a null as specified in the javadoc.
