### PR TITLE
Add support for Oracle's KeyTool cert system

### DIFF
--- a/src/test/java/com/basho/riak/client/core/operations/itest/ITestJKSSecuredConnection.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/ITestJKSSecuredConnection.java
@@ -8,9 +8,13 @@ import org.powermock.reflect.Whitebox;
 
 import com.basho.riak.client.core.RiakCluster;
 import com.basho.riak.client.core.RiakNode;
+import org.junit.Assume;
 
 public class ITestJKSSecuredConnection {
 
+    private static boolean security;
+    private static boolean securityClientCert;
+    
     @BeforeClass
     public static void setUp() {
 
@@ -50,10 +54,14 @@ public class ITestJKSSecuredConnection {
          *
          *  7) Run the Test suit
          */
+        security = Boolean.parseBoolean(System.getProperty("com.basho.riak.security"));
+        securityClientCert = Boolean.parseBoolean(System.getProperty("com.basho.riak.security.clientcert"));
+
     }
 
     @Test
     public void testCetificateBasedAuthentication() throws Exception {
+        Assume.assumeTrue(securityClientCert);
         RiakCluster cluster = RiakJKSConnection.getRiakCluster("riak_cert_user","riak_cert_user","riak_cert_user.jks","riak123","riak_cert_user");
 
         for (RiakNode node : cluster.getNodes()){
@@ -65,6 +73,7 @@ public class ITestJKSSecuredConnection {
 
     @Test
     public void testTrustBasedAuthentication() throws Exception {
+        Assume.assumeTrue(security);
         RiakCluster cluster = RiakJKSConnection.getRiakCluster("riak_trust_user","riak_trust_user");
 
         for (RiakNode node : cluster.getNodes()){
@@ -76,6 +85,7 @@ public class ITestJKSSecuredConnection {
 
     @Test
     public void testPasswordBasedAuthentication() throws Exception {
+        Assume.assumeTrue(security);
         RiakCluster cluster = RiakJKSConnection.getRiakCluster("riak_passwd_user","riak_passwd_user");
 
         for (RiakNode node : cluster.getNodes()){

--- a/src/test/java/com/basho/riak/client/core/operations/itest/ITestJKSSecuredConnection.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/ITestJKSSecuredConnection.java
@@ -1,0 +1,87 @@
+package com.basho.riak.client.core.operations.itest;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.powermock.reflect.Whitebox;
+
+import com.basho.riak.client.core.RiakCluster;
+import com.basho.riak.client.core.RiakNode;
+
+public class ITestJKSSecuredConnection {
+
+    @BeforeClass
+    public static void setUp() {
+
+        /**
+         * Riak security.
+         *
+         * If you want to test SSL/AUTH, you need to:
+         *  1) configure riak with the certs included in test/resources
+         *      ssl.certfile = $(platform_etc_dir)/cert.pem
+         *      ssl.keyfile = $(platform_etc_dir)/key.pem
+         *      ssl.cacertfile = $(platform_etc_dir)/cacert.pem
+         *
+         *  2) create a user "riak_cert_user" with the password "riak_cert_user" and configure it with certificate as a source
+         *      riak-admin security add-user riak_cert_user password=riak_cert_user
+         *      riak-admin security add-source riak_cert_user 0.0.0.0/0 certificate
+         *
+         *  3) create a user "riak_trust_user" with the password "riak_trust_user" and configure it with trust as a source
+         *      riak-admin security add-user riak_trust_user password=riak_trust_user
+         *      riak-admin security add-source riak_trust_user 0.0.0.0/0 trust
+         *
+         *  4) create a user "riak_passwd_user" with the password "riak_passwd_user" and configure it with password as a source
+         *      riak-admin security add-user riak_passwd_user password=riak_passwd_user
+         *      riak-admin security add-source riak_passwd_user 0.0.0.0/0 password
+         *
+         *  5) Import cacert.pem and cert.pem as a Trusted Certs in truststore.jks
+         *      $JAVA_HOME/bin/keytool -import -trustcacerts -keystore truststore.jks -file cacert.pem -alias cacert -storepass riak123
+         *      $JAVA_HOME/bin/keytool -import -trustcacerts -keystore truststore.jks -file cert.pem -alias servercert -storepass riak123
+         *
+         *  6) For Certificate Based Authentication, create user certificate and sign it using cacert.pem
+         *      $JAVA_HOME/bin/keytool -genkey -dname "CN=riak_cert_user, OU=rjc test, O=The Sample Company, L=Metropolis, S=New York, C=US" -keyalg RSA -alias riak_cert_user -keystore riak_cert_user.jks -storepass riak123 -keypass riak_cert_user -validity 3650 -keysize 2048
+         *      $JAVA_HOME/bin/keytool -keystore riak_cert_user.jks -certreq -alias riak_cert_user -keyalg RSA -storepass riak123 -keypass riak_cert_user -file riak_cert_user.csr
+         *
+         *      openssl x509 -req -days 3650 -in riak_cert_user.csr -CA cacert.pem -CAkey cacert.key -CAcreateserial -out riak_cert_user.pem
+         *
+         *      $JAVA_HOME/bin/keytool -import -trustcacerts -keystore riak_cert_user.jks -file cacert.pem -alias cacert -storepass riak123
+         *      $JAVA_HOME/bin/keytool -import -keystore riak_cert_user.jks -file riak_cert_user.pem -alias riak_cert_user -storepass riak123 -keypass riak_cert_user
+         *
+         *  7) Run the Test suit
+         */
+    }
+
+    @Test
+    public void testCetificateBasedAuthentication() throws Exception {
+        RiakCluster cluster = RiakJKSConnection.getRiakCluster("riak_cert_user","riak_cert_user","riak_cert_user.jks","riak123","riak_cert_user");
+
+        for (RiakNode node : cluster.getNodes()){
+            assertNotNull(Whitebox.invokeMethod(node, "getConnection", new Object[0]));
+        }
+
+        cluster.shutdown();
+    }
+
+    @Test
+    public void testTrustBasedAuthentication() throws Exception {
+        RiakCluster cluster = RiakJKSConnection.getRiakCluster("riak_trust_user","riak_trust_user");
+
+        for (RiakNode node : cluster.getNodes()){
+            assertNotNull(Whitebox.invokeMethod(node, "getConnection", new Object[0]));
+        }
+
+        cluster.shutdown();
+    }
+
+    @Test
+    public void testPasswordBasedAuthentication() throws Exception {
+        RiakCluster cluster = RiakJKSConnection.getRiakCluster("riak_passwd_user","riak_passwd_user");
+
+        for (RiakNode node : cluster.getNodes()){
+            assertNotNull(Whitebox.invokeMethod(node, "getConnection", new Object[0]));
+        }
+
+        cluster.shutdown();
+    }
+}

--- a/src/test/java/com/basho/riak/client/core/operations/itest/ITestListBucketsOperation.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/ITestListBucketsOperation.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import static org.junit.Assert.*;
 import static org.junit.Assume.assumeTrue;
@@ -151,7 +152,7 @@ public class ITestListBucketsOperation extends ITestBase
             cluster.execute(storeOp);
         }
         
-        latch.await();
+        latch.await(2, TimeUnit.MINUTES);
         
         ListBucketsOperation listOp = new ListBucketsOperation.Builder()
                                         .withBucketType(BinaryValue.createFromUtf8(bucketType))

--- a/src/test/java/com/basho/riak/client/core/operations/itest/ITestListKeysOperation.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/ITestListKeysOperation.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import static org.junit.Assert.*;
 import static org.junit.Assume.assumeTrue;
@@ -175,7 +176,7 @@ public class ITestListKeysOperation extends ITestBase
             cluster.execute(storeOp);
         }
         
-        latch.await();
+        latch.await(2, TimeUnit.MINUTES);
         ITestBase.resetAndEmptyBucket(ns);
         
     }

--- a/src/test/java/com/basho/riak/client/core/operations/itest/ITestPemSecuredConnection.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/ITestPemSecuredConnection.java
@@ -1,0 +1,83 @@
+package com.basho.riak.client.core.operations.itest;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.powermock.reflect.Whitebox;
+
+import com.basho.riak.client.core.RiakCluster;
+import com.basho.riak.client.core.RiakNode;
+
+public class ITestPemSecuredConnection {
+
+    @BeforeClass
+    public static void setUp() {
+
+        /**
+         * Riak security.
+         *
+         * If you want to test SSL/AUTH, you need to:
+         *  1) configure riak with the certs included in test/resources
+         *      ssl.certfile = $(platform_etc_dir)/cert.pem
+         *      ssl.keyfile = $(platform_etc_dir)/key.pem
+         *      ssl.cacertfile = $(platform_etc_dir)/cacert.pem
+         *
+         *  2) create a user "riak_cert_user" with the password "riak_cert_user" and configure it with certificate as a source
+         *      riak-admin security add-user riak_cert_user password=riak_cert_user
+         *      riak-admin security add-source riak_cert_user 0.0.0.0/0 certificate
+         *
+         *  3) create a user "riak_trust_user" with the password "riak_trust_user" and configure it with trust as a source
+         *      riak-admin security add-user riak_trust_user password=riak_trust_user
+         *      riak-admin security add-source riak_trust_user 0.0.0.0/0 trust
+         *
+         *  4) create a user "riak_passwd_user" with the password "riak_passwd_user" and configure it with password as a source
+         *      riak-admin security add-user riak_passwd_user password=riak_passwd_user
+         *      riak-admin security add-source riak_passwd_user 0.0.0.0/0 password
+         *
+         *  5) For Certificate Based Authentication, create user certificate and sign it using cacert.pem
+         *      openssl genrsa -out riak_cert_user_key.pem 2048
+         *      openssl req -new -key riak_cert_user_key.pem -out riak_cert_user.csr -subj "/C=US/ST=New York/L=Metropolis/O=The Sample Company/OU=rjc test/CN=riak_cert_user/emailAddress=riak_cert_user@basho.com"
+         *
+         *      #Sign the cert with CA.
+         *      openssl x509 -req -days 3650 -in riak_cert_user.csr -CA cacert.pem -CAkey cacert.key -CAcreateserial -out riak_cert_user_cert.pem
+         *
+         *      openssl pkcs8 -topk8 -inform PEM -outform PEM -in riak_cert_user_key.pem -out riak_cert_user_key_pkcs8.pem -nocrypt
+         *
+         *  6) Run the Test suit
+         */
+    }
+
+    @Test
+    public void testCetificateBasedAuthentication() throws Exception {
+        RiakCluster cluster = RiakPemConnection.getRiakCluster("riak_cert_user","riak_cert_user","riak_cert_user_key_pkcs8.pem", "riak_cert_user_cert.pem");
+
+        for (RiakNode node : cluster.getNodes()){
+            assertNotNull(Whitebox.invokeMethod(node, "getConnection", new Object[0]));
+        }
+
+        cluster.shutdown();
+    }
+
+    @Test
+    public void testTrustBasedAuthentication() throws Exception {
+        RiakCluster cluster = RiakPemConnection.getRiakCluster("riak_trust_user","riak_trust_user");
+
+        for (RiakNode node : cluster.getNodes()){
+            assertNotNull(Whitebox.invokeMethod(node, "getConnection", new Object[0]));
+        }
+
+        cluster.shutdown();
+    }
+
+    @Test
+    public void testPasswordBasedAuthentication() throws Exception {
+        RiakCluster cluster = RiakPemConnection.getRiakCluster("riak_passwd_user","riak_passwd_user");
+
+        for (RiakNode node : cluster.getNodes()){
+            assertNotNull(Whitebox.invokeMethod(node, "getConnection", new Object[0]));
+        }
+
+        cluster.shutdown();
+    }
+}

--- a/src/test/java/com/basho/riak/client/core/operations/itest/ITestPemSecuredConnection.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/ITestPemSecuredConnection.java
@@ -8,9 +8,13 @@ import org.powermock.reflect.Whitebox;
 
 import com.basho.riak.client.core.RiakCluster;
 import com.basho.riak.client.core.RiakNode;
+import org.junit.Assume;
 
 public class ITestPemSecuredConnection {
 
+    private static boolean security;
+    private static boolean securityClientCert;
+    
     @BeforeClass
     public static void setUp() {
 
@@ -46,10 +50,14 @@ public class ITestPemSecuredConnection {
          *
          *  6) Run the Test suit
          */
+        security = Boolean.parseBoolean(System.getProperty("com.basho.riak.security"));
+        securityClientCert = Boolean.parseBoolean(System.getProperty("com.basho.riak.security.clientcert"));
+
     }
 
     @Test
     public void testCetificateBasedAuthentication() throws Exception {
+        Assume.assumeTrue(securityClientCert);
         RiakCluster cluster = RiakPemConnection.getRiakCluster("riak_cert_user","riak_cert_user","riak_cert_user_key_pkcs8.pem", "riak_cert_user_cert.pem");
 
         for (RiakNode node : cluster.getNodes()){
@@ -61,6 +69,7 @@ public class ITestPemSecuredConnection {
 
     @Test
     public void testTrustBasedAuthentication() throws Exception {
+        Assume.assumeTrue(security);
         RiakCluster cluster = RiakPemConnection.getRiakCluster("riak_trust_user","riak_trust_user");
 
         for (RiakNode node : cluster.getNodes()){
@@ -72,6 +81,7 @@ public class ITestPemSecuredConnection {
 
     @Test
     public void testPasswordBasedAuthentication() throws Exception {
+        Assume.assumeTrue(security);
         RiakCluster cluster = RiakPemConnection.getRiakCluster("riak_passwd_user","riak_passwd_user");
 
         for (RiakNode node : cluster.getNodes()){

--- a/src/test/java/com/basho/riak/client/core/operations/itest/RiakJKSConnection.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/RiakJKSConnection.java
@@ -1,0 +1,153 @@
+package com.basho.riak.client.core.operations.itest;
+
+import java.io.IOException;
+import java.net.UnknownHostException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+
+import com.basho.riak.client.api.RiakClient;
+import com.basho.riak.client.core.RiakCluster;
+import com.basho.riak.client.core.RiakNode;
+
+public class RiakJKSConnection {
+
+    private static final String trustStorePasswd = "riak123";
+    private static final String trustStrorePath = "truststore.jks";
+    private static final KeyStore trustStore = loadKeystore(trustStrorePath,trustStorePasswd);
+
+    /**
+     * Load Keystore using the storeFilePath and storePassword
+     * @param storePath path to the Keystore file
+     * @param storePasswd passowrd of Keystore file
+     * @return a keystore with all certificate entries loaded
+     */
+    private static KeyStore loadKeystore(String storePath, String storePasswd){
+        KeyStore store = null;
+        try {
+            store = KeyStore.getInstance("JKS");
+            store.load(Thread.currentThread().getContextClassLoader().getResourceAsStream(storePath), storePasswd.toCharArray());
+        } catch (KeyStoreException e) {
+            e.printStackTrace();
+        } catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+        } catch (CertificateException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return store;
+    }
+
+    /**
+     * Initialize Cluster
+     * @param builder all builder properties required to make connection to a node.
+     * @return Riak Cluster object based on builder properties
+     */
+    private static RiakCluster initializeRiakCluster(RiakNode.Builder builder){
+        RiakCluster cluster = null;
+        try {
+            cluster = new RiakCluster.Builder(builder.build()).build();
+            cluster.start();
+        } catch (UnknownHostException e) {
+            e.printStackTrace();
+        }
+        return cluster;
+    }
+
+    /**
+     * Get Riak Cluster Handle. This is for unsecured connection when Riak security is disabled.
+     * @return Riak Cluster Object
+     */
+    public static RiakCluster getRiakCluster(){
+
+        RiakNode.Builder builder = new RiakNode.Builder();
+        builder.withMinConnections(1);
+        RiakCluster cluster = initializeRiakCluster(builder);
+
+        return cluster;
+    }
+
+    /**
+     * Get Riak Client Handle. This is for unsecured connection when Riak security is disabled.
+     * @return Riak Client Object
+     */
+    public static RiakClient getRiakConnection(){
+        RiakClient client = null;
+        RiakCluster cluster = getRiakCluster();
+        if(cluster!=null){
+            client= new RiakClient(cluster);
+        }
+        return client;
+    }
+
+    /**
+     * Get Riak Cluster Handle. This is for secured connection with user source set to either Trust or Password. Riak security is enabled.
+     * @param username username with which the connection needs to be established
+     * @param password password of the username provided
+     * @return Riak Cluster Object
+     */
+    public static RiakCluster getRiakCluster(String username, String password){
+
+        RiakNode.Builder builder = new RiakNode.Builder();
+        builder.withMinConnections(1);
+        builder.withAuth(username, password, trustStore);
+        RiakCluster cluster = initializeRiakCluster(builder);
+
+        return cluster;
+    }
+
+    /**
+     * Get Riak Client Handle. This is for secured connection with user source set to either Trust or Password. Riak security is enabled.
+     * @param username username with which the connection needs to be established
+     * @param password password of the username provided
+     * @return Riak Client Object
+     */
+    public static RiakClient getRiakConnection(String username, String password){
+        RiakClient client = null;
+        RiakCluster cluster = getRiakCluster(username,password);
+        if(cluster!=null){
+            client= new RiakClient(cluster);
+        }
+        return client;
+    }
+
+    /**
+     * Get Riak Cluster Handle. This is for secured connection with user source set to certificate. Riak security is enabled.
+     * @param username username with which the connection needs to be established
+     * @param password password of the username provided
+     * @param storePath path to the Keystore file containing private and public key of the user.
+     * @param storePasswd passowrd of Keystore file.
+     * @param keyPasswd password of the user's private key/certificate.
+     * @return Riak Cluster Object
+     */
+    public static RiakCluster getRiakCluster(String username, String password, String storePath, String storePasswd, String keyPasswd){
+        KeyStore keyStore = loadKeystore(storePath,storePasswd);
+
+        RiakNode.Builder builder = new RiakNode.Builder();
+        builder.withMinConnections(1);
+        builder.withAuth(username, password, trustStore, keyStore, keyPasswd);
+        RiakCluster cluster = initializeRiakCluster(builder);
+
+        return cluster;
+    }
+
+    /**
+     * Get Riak Client Handle. This is for secured connection with user source set to certificate. Riak security is enabled.
+     * @param username username with which the connection needs to be established
+     * @param password password of the username provided
+     * @param storePath path to the Keystore file containing private and public key of the user.
+     * @param storePasswd passowrd of Keystore file.
+     * @param keyPasswd password of the user's private key/certificate.
+     * @return Riak Client Object
+     */
+    public static RiakClient getRiakConnection(String username, String password, String storePath, String storePasswd, String keyPasswd){
+        RiakClient client = null;
+        RiakCluster cluster = getRiakCluster(username,password,storePath,storePasswd,keyPasswd);
+        if(cluster!=null){
+            client= new RiakClient(cluster);
+        }
+        return client;
+    }
+}

--- a/src/test/java/com/basho/riak/client/core/operations/itest/RiakPemConnection.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/RiakPemConnection.java
@@ -1,0 +1,219 @@
+package com.basho.riak.client.core.operations.itest;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.UnknownHostException;
+import java.security.KeyFactory;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.KeySpec;
+import java.security.spec.PKCS8EncodedKeySpec;
+
+import sun.misc.BASE64Decoder;
+
+import com.basho.riak.client.api.RiakClient;
+import com.basho.riak.client.core.RiakCluster;
+import com.basho.riak.client.core.RiakNode;
+
+public class RiakPemConnection {
+
+    private static final KeyStore trustStore = loadTruststore();
+
+    /**
+     * Load Truststore using Trusted Certificates.
+     * @return a keystore with all trusted certificate entries loaded
+     */
+    private static KeyStore loadTruststore(){
+
+        KeyStore truststore = null;
+        try {
+            CertificateFactory cFactory = CertificateFactory.getInstance("X.509");
+
+            InputStream in = Thread.currentThread().getContextClassLoader().getResourceAsStream("cacert.pem");
+            X509Certificate caCert = (X509Certificate) cFactory.generateCertificate(in);
+            in.close();
+
+            in = Thread.currentThread().getContextClassLoader().getResourceAsStream("cert.pem");
+            X509Certificate serverCert = (X509Certificate) cFactory.generateCertificate(in);
+            in.close();
+
+            truststore = KeyStore.getInstance(KeyStore.getDefaultType());
+            truststore.load(null, "password".toCharArray());
+            truststore.setCertificateEntry("cacert", caCert);
+            truststore.setCertificateEntry("server", serverCert);
+
+        } catch (KeyStoreException e) {
+            e.printStackTrace();
+        } catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+        } catch (CertificateException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return truststore;
+    }
+
+    /**
+     * Load Keystore using the Private Key Pem file and Public Cert Pem file
+     * @param privateKeyPemPath path to the Private Key Pem file
+     * @param publicCertPemPath path to the Public Cert Pem file
+     * @return a keystore with private certificate entry loaded
+     */
+    private static KeyStore loadKeystore(String privateKeyPemPath, String publicCertPemPath) {
+
+        KeyStore keystore = null;
+        try {
+            CertificateFactory cFactory = CertificateFactory.getInstance("X.509");
+            InputStream in = Thread.currentThread().getContextClassLoader().getResourceAsStream(publicCertPemPath);
+            X509Certificate public_cert = (X509Certificate) cFactory.generateCertificate(in);
+            in.close();
+
+            in = Thread.currentThread().getContextClassLoader().getResourceAsStream(privateKeyPemPath);
+            byte[] privKeyBytes = new byte[in.available()];
+            in.read(privKeyBytes, 0, in.available());
+            in.close();
+
+            String key = new String(privKeyBytes);
+            key = key.replace("-----BEGIN PRIVATE KEY-----\n", "").replace("-----END PRIVATE KEY-----\n", "");
+
+            BASE64Decoder base64Decoder = new BASE64Decoder();
+            privKeyBytes = base64Decoder.decodeBuffer(key);
+
+            KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+            KeySpec ks = new PKCS8EncodedKeySpec(privKeyBytes);
+            PrivateKey privKey = (PrivateKey) keyFactory.generatePrivate(ks);
+
+            keystore = KeyStore.getInstance(KeyStore.getDefaultType());
+            keystore.load(null, "password".toCharArray());
+            keystore.setKeyEntry("private-key", privKey,"".toCharArray(),new java.security.cert.Certificate[] { public_cert });
+
+        } catch (KeyStoreException e) {
+            e.printStackTrace();
+        } catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+        } catch (CertificateException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        } catch (InvalidKeySpecException e) {
+            e.printStackTrace();
+        }
+        return keystore;
+    }
+
+    /**
+     * Initialize Cluster
+     * @param builder all builder properties required to make connection to a node.
+     * @return Riak Cluster object based on builder properties
+     */
+    private static RiakCluster initializeRiakCluster(RiakNode.Builder builder){
+        RiakCluster cluster = null;
+        try {
+            cluster = new RiakCluster.Builder(builder.build()).build();
+            cluster.start();
+        } catch (UnknownHostException e) {
+            e.printStackTrace();
+        }
+        return cluster;
+    }
+
+    /**
+     * Get Riak Cluster Handle. This is for unsecured connection when Riak security is disabled.
+     * @return Riak Cluster Object
+     */
+    public static RiakCluster getRiakCluster(){
+
+        RiakNode.Builder builder = new RiakNode.Builder();
+        builder.withMinConnections(1);
+        RiakCluster cluster = initializeRiakCluster(builder);
+
+        return cluster;
+    }
+
+    /**
+     * Get Riak Client Handle. This is for unsecured connection when Riak security is disabled.
+     * @return Riak Client Object
+     */
+    public static RiakClient getRiakConnection(){
+        RiakClient client = null;
+        RiakCluster cluster = getRiakCluster();
+        if(cluster!=null){
+            client= new RiakClient(cluster);
+        }
+        return client;
+    }
+
+    /**
+     * Get Riak Cluster Handle. This is for secured connection with user source set to either Trust or Password. Riak security is enabled.
+     * @param username username with which the connection needs to be established
+     * @param password password of the username provided
+     * @return Riak Cluster Object
+     */
+    public static RiakCluster getRiakCluster(String username, String password){
+
+        RiakNode.Builder builder = new RiakNode.Builder();
+        builder.withMinConnections(1);
+        builder.withAuth(username, password, trustStore);
+        RiakCluster cluster = initializeRiakCluster(builder);
+
+        return cluster;
+    }
+
+    /**
+     * Get Riak Client Handle. This is for secured connection with user source set to either Trust or Password. Riak security is enabled.
+     * @param username username with which the connection needs to be established
+     * @param password password of the username provided
+     * @return Riak Client Object
+     */
+    public static RiakClient getRiakConnection(String username, String password){
+        RiakClient client = null;
+        RiakCluster cluster = getRiakCluster(username,password);
+        if(cluster!=null){
+            client= new RiakClient(cluster);
+        }
+        return client;
+    }
+
+    /**
+     * Get Riak Cluster Handle. This is for secured connection with user source set to certificate. Riak security is enabled.
+     * @param username username with which the connection needs to be established
+     * @param password password of the username provided
+     * @param privateKeyPemPath path to the Private Key Pem file of the user.
+     * @param publicCertPemPath path to the Public Cert Pem file of the Private key provided.
+     * @return Riak Cluster Object
+     */
+    public static RiakCluster getRiakCluster(String username, String password, String privateKeyPemPath, String publicCertPemPath){
+        KeyStore keyStore = loadKeystore(privateKeyPemPath,publicCertPemPath);
+
+        RiakNode.Builder builder = new RiakNode.Builder();
+        builder.withMinConnections(1);
+        builder.withAuth(username, password, trustStore, keyStore, "");
+        RiakCluster cluster = initializeRiakCluster(builder);
+
+        return cluster;
+    }
+
+    /**
+     * Get Riak Client Handle. This is for secured connection with user source set to certificate. Riak security is enabled.
+     * @param username username with which the connection needs to be established
+     * @param password password of the username provided
+     * @param privateKeyPemPath path to the Private Key Pem file of the user.
+     * @param publicCertPemPath path to the Public Cert Pem file of the Private key provided.
+     * @return Riak Client Object
+     */
+    public static RiakClient getRiakConnection(String username, String password, String privateKeyPemPath, String publicCertPemPath){
+        RiakClient client = null;
+        RiakCluster cluster = getRiakCluster(username,password,privateKeyPemPath,publicCertPemPath);
+        if(cluster!=null){
+            client= new RiakClient(cluster);
+        }
+        return client;
+    }
+}


### PR DESCRIPTION
These diffs come from Atul Shivtare of JP Morgan Chase & Co.. They want
to use Oracle's `keytool` for storing certs, which this client
previously didn't support. This patch seems to already have been
tested by Atul and the other engineers at JP Morgan Chase.
Details can be found in Ticket #9735 (link below).

https://docs.oracle.com/javase/6/docs/technotes/tools/solaris/keytool.html

https://basho.zendesk.com/agent/tickets/9735