### PR TITLE
Gh481 response options

### DIFF
--- a/src/main/java/com/basho/riak/client/api/commands/indexes/SecondaryIndexQuery.java
+++ b/src/main/java/com/basho/riak/client/api/commands/indexes/SecondaryIndexQuery.java
@@ -39,7 +39,7 @@ public abstract class SecondaryIndexQuery<T,S,U> extends RiakCommand<S, U>
 {
     public enum Type
     {
-        _INT("_int"), _BIN("_bin");
+        _INT("_int"), _BIN("_bin"), _BUCKET(""), _KEY("");
         
         private String suffix;
         

--- a/src/main/java/com/basho/riak/client/core/operations/SecondaryIndexQueryOperation.java
+++ b/src/main/java/com/basho/riak/client/core/operations/SecondaryIndexQueryOperation.java
@@ -61,9 +61,11 @@ public class SecondaryIndexQueryOperation extends FutureOperation<SecondaryIndex
              * list of object keys and you have to have
              * preserved the index key if you want to return it to the user
              * with the results. 
+             * 
+             * Also, the $key index queries just ignore return_terms altogether.
              */
             
-            if (pbReq.getReturnTerms())
+            if (pbReq.getReturnTerms() && !query.indexName.toString().equalsIgnoreCase("$key"))
             {
                 if (pbReq.hasRangeMin())
                 {

--- a/src/main/java/com/basho/riak/client/core/query/indexes/IndexType.java
+++ b/src/main/java/com/basho/riak/client/core/query/indexes/IndexType.java
@@ -35,7 +35,15 @@ public enum IndexType
     /**
      * Encapsulates the {@code "_bin"} suffix for Riak index names.
      */
-    BIN("_bin");
+    BIN("_bin"),
+    /**
+     * Used for the special $bucket index
+     */
+    BUCKET(""),
+    /**
+     * Used for the special $key index
+     */
+    KEY("");
     
     private final String suffix;
     
@@ -68,19 +76,30 @@ public enum IndexType
      */
     public static IndexType typeFromFullname(String fullname)
     {
-        int i = fullname.lastIndexOf('_');
-        if (i != -1)
+        if (fullname.equalsIgnoreCase("$bucket"))
         {
-            String suffix = fullname.substring(i);
-            for (IndexType t : IndexType.values())
+            return IndexType.BUCKET;
+        }
+        else if (fullname.equalsIgnoreCase("$key"))
+        {
+            return IndexType.KEY;
+        }
+        else
+        {
+            int i = fullname.lastIndexOf('_');
+            if (i != -1)
             {
-                if (t.suffix().equalsIgnoreCase(suffix))
+                String suffix = fullname.substring(i);
+                for (IndexType t : IndexType.values())
                 {
-                    return t;
+                    if (t.suffix().equalsIgnoreCase(suffix))
+                    {
+                        return t;
+                    }
                 }
             }
-        }
 
-        throw new IllegalArgumentException("Indexname does not end with valid suffix");
+            throw new IllegalArgumentException("Indexname does not end with valid suffix");
+        }
     }
 }

--- a/src/main/java/com/basho/riak/client/core/query/indexes/RiakIndex.java
+++ b/src/main/java/com/basho/riak/client/core/query/indexes/RiakIndex.java
@@ -360,6 +360,7 @@ public abstract class RiakIndex<T> implements Iterable<T>
         
         protected Name(String name, IndexType type)
         {
+            name = name.toLowerCase();
             this.name = stripSuffix(name, type);
             this.type = type;
         }

--- a/src/test/java/com/basho/riak/client/api/commands/itest/ITestFetchValue.java
+++ b/src/test/java/com/basho/riak/client/api/commands/itest/ITestFetchValue.java
@@ -24,9 +24,11 @@ import com.basho.riak.client.api.commands.kv.FetchValue.Option;
 import com.basho.riak.client.api.commands.kv.FetchValue;
 import com.basho.riak.client.api.RiakClient;
 import com.basho.riak.client.api.annotations.RiakVClock;
+import com.basho.riak.client.api.cap.DefaultResolver;
 import com.basho.riak.client.api.cap.VClock;
 import com.basho.riak.client.core.operations.StoreBucketPropsOperation;
 import com.basho.riak.client.api.commands.kv.StoreValue;
+import com.basho.riak.client.api.convert.JSONConverter;
 import com.basho.riak.client.core.query.Location;
 import com.basho.riak.client.core.query.Namespace;
 import com.basho.riak.client.core.query.RiakObject;
@@ -205,8 +207,13 @@ public class ITestFetchValue extends ITestBase
         FetchValue.Response fResp = client.execute(fv);
          
         assertEquals(pojo.value, fResp.getValue(Pojo.class).value);
-
         
+        JSONConverter<Pojo> converter = new JSONConverter<Pojo>(Pojo.class);
+        ConflictResolver<Pojo> resolver = new DefaultResolver<Pojo>();
+        
+        assertEquals(pojo.value, fResp.getValues(converter).get(0).value);
+        assertEquals(pojo.value, fResp.getValue(converter, resolver).value);
+
     }
     
     @Test

--- a/src/test/java/com/basho/riak/client/core/query/indexes/IndexTest.java
+++ b/src/test/java/com/basho/riak/client/core/query/indexes/IndexTest.java
@@ -43,6 +43,8 @@ public class IndexTest
     {
         Assert.assertEquals(IndexType.BIN.suffix(), "_bin");
         Assert.assertEquals(IndexType.INT.suffix(), "_int");
+        Assert.assertEquals(IndexType.BUCKET.suffix(), "");
+        Assert.assertEquals(IndexType.KEY.suffix(), "");
     }
     
     @Test
@@ -53,6 +55,12 @@ public class IndexTest
 
         IndexType indexType1 = IndexType.typeFromFullname("indexname_bin");
         Assert.assertTrue(indexType1.equals(IndexType.BIN));
+        
+        IndexType indexType2 = IndexType.typeFromFullname("$bucket");
+        Assert.assertTrue(indexType2.equals(IndexType.BUCKET));
+        
+        IndexType indexType3 = IndexType.typeFromFullname("$key");
+        Assert.assertTrue(indexType3.equals(IndexType.KEY));
 
     }
 }


### PR DESCRIPTION
You can now explicitly supply a `Converter<T>` and `ConflictResolver<T>`
rather than being required to register them with the associated
factories.

Addresses #481 (CLIENTS-35) 