### PR TITLE
Gh429 annotations

### DIFF
--- a/src/main/java/com/basho/riak/client/api/commands/indexes/SecondaryIndexQuery.java
+++ b/src/main/java/com/basho/riak/client/api/commands/indexes/SecondaryIndexQuery.java
@@ -39,7 +39,7 @@ public abstract class SecondaryIndexQuery<T,S,U> extends RiakCommand<S, U>
 {
     public enum Type
     {
-        _INT("_int"), _BIN("_bin");
+        _INT("_int"), _BIN("_bin"), _BUCKET(""), _KEY("");
         
         private String suffix;
         

--- a/src/main/java/com/basho/riak/client/api/commands/kv/ListKeys.java
+++ b/src/main/java/com/basho/riak/client/api/commands/kv/ListKeys.java
@@ -36,7 +36,7 @@ import java.util.List;
  * <pre class="prettyprint">
  * {@code
  * Namespace ns = new Namespace("my_type", "my_bucket");
- * ListKeys lk = ListKeys.Builder(ns).build();
+ * ListKeys lk = new ListKeys.Builder(ns).build();
  * ListKeys.Response response = client.execute(lk);
  * for (Location l : response)
  * {

--- a/src/main/java/com/basho/riak/client/api/commands/kv/UpdateValue.java
+++ b/src/main/java/com/basho/riak/client/api/commands/kv/UpdateValue.java
@@ -49,6 +49,10 @@ import java.util.concurrent.TimeUnit;
  * object is then passed to your {@link com.basho.riak.client.api.commands.kv.UpdateValue.Update}
  * and the result stored back into Riak.
  * </p>
+ * <p>
+ * To create the mutation you wish to perform, you extend the 
+ * {@link com.basho.riak.client.api.commands.kv.UpdateValue.Update} class:
+ * </p>
  * <pre class="prettyprint">
  * {@code
  * class AppendUpdate extends UpdateValue.Update<MyPojo>
@@ -316,50 +320,8 @@ public final class UpdateValue extends RiakCommand<UpdateValue.Response, Locatio
             return modified;
         }
 
-        /**
-         * Returns a no-op Update instance.
-         * <p>
-         * This can be used to simply resolve siblings that exist 
-         * in Riak without modifying the resolved object.
-         * <p>
-         * 
-         * @return An {@code Update} instance the does not modify anything.
-         */
-        public static <T> Update<T> noopUpdate()
-        {
-            return new Update<T>()
-            {
-                @Override
-                public T apply(T original)
-                {
-                    return original;
-                }
-            };
-        }
-        
-        /**
-         * Returns an Update that replaces whatever is in Riak.
-         * <p>
-         * This Update simply returns the supplied value, thus replacing 
-         * anything currently in Riak with that value.
-         * </p>
-         * @param newValue the obj to store in Riak.
-         * @return an Update instance.
-         */
-        public static <T> Update<T> clobberUpdate(final T newValue)
-        {
-            return new Update<T>()
-            {
-                @Override
-                public T apply(T original)
-                {
-                    return newValue;
-                }
-                
-            };
-        }
     }
-
+    
     /**
      * Used to construct an UpdateValue command.
      */

--- a/src/main/java/com/basho/riak/client/api/convert/reflection/AnnotationInfo.java
+++ b/src/main/java/com/basho/riak/client/api/convert/reflection/AnnotationInfo.java
@@ -1311,7 +1311,7 @@ public class AnnotationInfo
 
         private void validateRiakLinksMethod(Method m)
         {
-            if (m.getReturnType().equals(Void.TYPE))
+            if (m.getParameterTypes().length == 1)
             {
                 // it's a setter, check the arg type
                 Type[] genericParameterTypes = m.getGenericParameterTypes();
@@ -1331,7 +1331,7 @@ public class AnnotationInfo
 
                 throw new IllegalArgumentException("@RiakLinks setter must take Collection<RiakLink>");
             }
-            else
+            else if (m.getParameterTypes().length == 0)
             {
                 // it's a getter, check return type
                 Type t = m.getGenericReturnType();
@@ -1363,7 +1363,7 @@ public class AnnotationInfo
 
         private void validateVClockMethod(Method m)
         {
-            if (m.getReturnType().equals(Void.TYPE))
+            if (m.getParameterTypes().length == 1)
             {
                 // It's a setter
                 Class<?> pType = m.getParameterTypes()[0];
@@ -1373,7 +1373,7 @@ public class AnnotationInfo
                     throw new IllegalArgumentException("@RiakVClock setter must take VClock or byte[]");
                 }
             }
-            else
+            else if (m.getParameterTypes().length == 0)
             {
                 Class<?> rType = m.getReturnType();
                 if (!(rType.isArray() && rType.getComponentType().equals(byte.class))
@@ -1395,7 +1395,7 @@ public class AnnotationInfo
 
         private void validateTombstoneMethod(Method m)
         {
-            if (m.getReturnType().equals(Void.TYPE))
+            if (m.getParameterTypes().length == 1)
             {
                 Class<?> pType = m.getParameterTypes()[0];
                 if (!pType.equals(Boolean.class) && !pType.equals(boolean.class))
@@ -1403,7 +1403,7 @@ public class AnnotationInfo
                     throw new IllegalArgumentException("@RiakTombstone setter must take boolean or Boolean");
                 }
             }
-            else
+            else if (m.getParameterTypes().length == 0)
             {
                 Class<?> rType = m.getReturnType();
                 if (!rType.equals(Boolean.class) && !rType.equals(boolean.class))
@@ -1423,14 +1423,14 @@ public class AnnotationInfo
         
         private void validateContentTypeMethod(Method m)
         {
-            if (m.getReturnType().equals(Void.TYPE))
+            if (m.getParameterTypes().length == 1)
             { 
                 if (!String.class.equals(m.getParameterTypes()[0]))
                 {
                     throw new IllegalArgumentException("@RiakContentType setter must take a String.");
                 }
             }
-            else
+            else if (m.getParameterTypes().length == 0)
             {
                 if (!m.getReturnType().equals(String.class))
                 {
@@ -1449,11 +1449,11 @@ public class AnnotationInfo
         
         private void validateLastModifiedMethod(Method m)
         {
-            if (!m.getReturnType().equals(Void.TYPE))
+            if (m.getParameterTypes().length == 0)
             {
                 throw new IllegalArgumentException("@RiakLastModified can only be applied to a setter method.");
             }
-            else
+            else if (m.getParameterTypes().length == 1)
             {
                 Class<?> pType = m.getParameterTypes()[0];
                 if (!pType.equals(Long.class) && !pType.equals(long.class))
@@ -1473,11 +1473,11 @@ public class AnnotationInfo
         
         private void validateVTagMethod(Method m)
         {
-            if (!m.getReturnType().equals(Void.TYPE))
+            if (m.getParameterTypes().length == 0)
             {
                 throw new IllegalArgumentException("@RiakVTag can only be applied to a setter method.");
             }
-            else
+            else if (m.getParameterTypes().length == 1)
             {
                 Class<?> pType = m.getParameterTypes()[0];
                 if (!pType.equals(String.class))
@@ -1498,7 +1498,7 @@ public class AnnotationInfo
         
         private void validateStringOrByteMethod(Method m, String annotation)
         {
-            if (m.getReturnType().equals(Void.TYPE))
+            if (m.getParameterTypes().length == 1)
             {
                 // It's a setter
                 Class<?> pType = m.getParameterTypes()[0];
@@ -1508,7 +1508,7 @@ public class AnnotationInfo
                     throw new IllegalArgumentException(annotation + " setter must take String or byte[]");
                 }
             }
-            else
+            else if (m.getParameterTypes().length == 0)
             {
                 Class<?> rType = m.getReturnType();
                 if (!(rType.isArray() && rType.getComponentType().equals(byte.class))

--- a/src/main/java/com/basho/riak/client/api/convert/reflection/AnnotationInfo.java
+++ b/src/main/java/com/basho/riak/client/api/convert/reflection/AnnotationInfo.java
@@ -131,26 +131,7 @@ public class AnnotationInfo
     {
         // TODO: charset
         BinaryValue key = null;
-        if (riakKeyField != null)
-        {
-            if (riakKeyField.getType().equals(String.class))
-            {
-                Object o = getFieldValue(riakKeyField, obj);
-                if (o != null)
-                {
-                    key = BinaryValue.create((String) o);
-                }
-            }
-            else
-            {
-                Object o = getFieldValue(riakKeyField, obj);
-                if (o != null)
-                {
-                    key = BinaryValue.create((byte[]) o);
-                }
-            }
-        }
-        else if (riakKeyGetter != null)
+        if (riakKeyGetter != null)
         {
             if (riakKeyGetter.getReturnType().isArray())
             {
@@ -169,24 +150,33 @@ public class AnnotationInfo
                 }
             }
         }
+        else if (riakKeyField != null)
+        {
+            if (riakKeyField.getType().equals(String.class))
+            {
+                Object o = getFieldValue(riakKeyField, obj);
+                if (o != null)
+                {
+                    key = BinaryValue.create((String) o);
+                }
+            }
+            else
+            {
+                Object o = getFieldValue(riakKeyField, obj);
+                if (o != null)
+                {
+                    key = BinaryValue.create((byte[]) o);
+                }
+            }
+        }
+        
         return key;
     }
 
     // TODO: charset
     public <T> void setRiakKey(T obj, BinaryValue key)
     {
-        if (riakKeyField != null)
-        {
-            if (riakKeyField.getType().equals(String.class))
-            {
-                setFieldValue(riakKeyField, obj, key.toString());
-            }
-            else
-            {
-                setFieldValue(riakKeyField, obj, key.unsafeGetValue());
-            }
-        }
-        else if (riakKeySetter != null)
+        if (riakKeySetter != null)
         {
             if (riakKeySetter.getParameterTypes()[0].isArray())
             {
@@ -197,6 +187,18 @@ public class AnnotationInfo
                 setMethodValue(riakKeySetter, obj, key.toString());
             }
         }
+        else if (riakKeyField != null)
+        {
+            if (riakKeyField.getType().equals(String.class))
+            {
+                setFieldValue(riakKeyField, obj, key.toString());
+            }
+            else
+            {
+                setFieldValue(riakKeyField, obj, key.unsafeGetValue());
+            }
+        }
+         
     }
 
     // TODO: charset in annotation
@@ -204,26 +206,7 @@ public class AnnotationInfo
     {
         BinaryValue bucketName = null;
         
-        if (riakBucketNameField != null)
-        {
-            if (riakBucketNameField.getType().equals(String.class))
-            {
-                Object o = getFieldValue(riakBucketNameField, obj);
-                if (o != null)
-                {
-                    bucketName = BinaryValue.create((String) o);
-                }
-            }
-            else
-            {
-                Object o = getFieldValue(riakBucketNameField, obj);
-                if (o != null)
-                {
-                    bucketName = BinaryValue.create((byte[]) o);
-                }
-            }
-        }
-        else if (riakBucketNameGetter != null)
+        if (riakBucketNameGetter != null)
         {
             if (riakBucketNameGetter.getReturnType().isArray())
             {
@@ -242,24 +225,33 @@ public class AnnotationInfo
                 }
             }
         }
+        else if (riakBucketNameField != null)
+        {
+            if (riakBucketNameField.getType().equals(String.class))
+            {
+                Object o = getFieldValue(riakBucketNameField, obj);
+                if (o != null)
+                {
+                    bucketName = BinaryValue.create((String) o);
+                }
+            }
+            else
+            {
+                Object o = getFieldValue(riakBucketNameField, obj);
+                if (o != null)
+                {
+                    bucketName = BinaryValue.create((byte[]) o);
+                }
+            }
+        }
+         
         return bucketName;
     }
     
     // TODO: charset in annotation
     public <T> void setRiakBucketName(T obj, BinaryValue bucketName)
     {
-        if (riakBucketNameField != null)
-        {
-            if (riakBucketNameField.getType().equals(String.class))
-            {
-                setFieldValue(riakBucketNameField, obj, bucketName.toString());
-            }
-            else
-            {
-                setFieldValue(riakBucketNameField, obj, bucketName.unsafeGetValue());
-            }
-        }
-        else if (riakBucketNameSetter != null)
+        if (riakBucketNameSetter != null)
         {
             if (riakBucketNameSetter.getParameterTypes()[0].isArray())
             {
@@ -270,6 +262,17 @@ public class AnnotationInfo
                 setMethodValue(riakBucketNameSetter, obj, bucketName.toString());
             }
         }
+        else if (riakBucketNameField != null)
+        {
+            if (riakBucketNameField.getType().equals(String.class))
+            {
+                setFieldValue(riakBucketNameField, obj, bucketName.toString());
+            }
+            else
+            {
+                setFieldValue(riakBucketNameField, obj, bucketName.unsafeGetValue());
+            }
+        }
     }
     
     // TODO: charset in annotation
@@ -277,26 +280,7 @@ public class AnnotationInfo
     {
         BinaryValue bucketType = null;
         
-        if (riakBucketTypeField != null)
-        {
-            if (riakBucketTypeField.getType().equals(String.class))
-            {
-                Object o = getFieldValue(riakBucketTypeField, obj);
-                if (o != null)
-                {
-                    bucketType = BinaryValue.create((String) o);
-                }
-            }
-            else
-            {
-                Object o = getFieldValue(riakBucketTypeField, obj);
-                if (o != null)
-                {
-                    bucketType = BinaryValue.create((byte[]) o);
-                }
-            }
-        }
-        else if (riakBucketTypeGetter != null)
+        if (riakBucketTypeGetter != null)
         {
             if (riakBucketTypeGetter.getReturnType().isArray())
             {
@@ -315,24 +299,32 @@ public class AnnotationInfo
                 }
             }
         }
+        else if (riakBucketTypeField != null)
+        {
+            if (riakBucketTypeField.getType().equals(String.class))
+            {
+                Object o = getFieldValue(riakBucketTypeField, obj);
+                if (o != null)
+                {
+                    bucketType = BinaryValue.create((String) o);
+                }
+            }
+            else
+            {
+                Object o = getFieldValue(riakBucketTypeField, obj);
+                if (o != null)
+                {
+                    bucketType = BinaryValue.create((byte[]) o);
+                }
+            }
+        }
         return bucketType;
     }
     
     // TODO: charset in annotation
     public <T> void setRiakBucketType(T obj, BinaryValue bucketType)
     {
-        if (riakBucketTypeField != null)
-        {
-            if (riakBucketTypeField.getType().equals(String.class))
-            {
-                setFieldValue(riakBucketTypeField, obj, bucketType.toString());
-            }
-            else
-            {
-                setFieldValue(riakBucketTypeField, obj, bucketType.unsafeGetValue());
-            }
-        }
-        else if (riakBucketTypeSetter != null)
+        if (riakBucketTypeSetter != null)
         {
             if (riakBucketTypeSetter.getParameterTypes()[0].isArray())
             {
@@ -341,6 +333,17 @@ public class AnnotationInfo
             else
             {
                 setMethodValue(riakBucketTypeSetter, obj, bucketType.toString());
+            }
+        }
+        else if (riakBucketTypeField != null)
+        {
+            if (riakBucketTypeField.getType().equals(String.class))
+            {
+                setFieldValue(riakBucketTypeField, obj, bucketType.toString());
+            }
+            else
+            {
+                setFieldValue(riakBucketTypeField, obj, bucketType.unsafeGetValue());
             }
         }
     }
@@ -357,18 +360,7 @@ public class AnnotationInfo
 
         // We allow the annotated field to be either an actual VClock, or
         // a byte array.
-        if (riakVClockField != null)
-        {
-            if (riakVClockField.getType().isAssignableFrom(VClock.class))
-            {
-                vclock = (VClock) getFieldValue(riakVClockField, obj);
-            }
-            else
-            {
-                vclock = new BasicVClock((byte[]) getFieldValue(riakVClockField, obj));
-            }
-        }
-        else if (riakVClockGetter != null)
+        if (riakVClockGetter != null)
         {
             if (riakVClockGetter.getReturnType().isArray())
             {
@@ -379,7 +371,18 @@ public class AnnotationInfo
                 vclock = (VClock) getMethodValue(riakVClockGetter, obj);
             }
         }
-
+        else if (riakVClockField != null)
+        {
+            if (riakVClockField.getType().isAssignableFrom(VClock.class))
+            {
+                vclock = (VClock) getFieldValue(riakVClockField, obj);
+            }
+            else
+            {
+                vclock = new BasicVClock((byte[]) getFieldValue(riakVClockField, obj));
+            }
+        }
+        
         return vclock;
     }
 
@@ -388,19 +391,7 @@ public class AnnotationInfo
 
         // We allow the annotated field to be either an actual VClock, or
         // a byte array. This is enforced in the AnnotationScanner
-        if (riakVClockField != null)
-        {
-
-            if (riakVClockField.getType().isAssignableFrom(VClock.class))
-            {
-                setFieldValue(riakVClockField, obj, vclock);
-            }
-            else
-            {
-                setFieldValue(riakVClockField, obj, vclock.getBytes());
-            }
-        }
-        else if (riakVClockSetter != null)
+        if (riakVClockSetter != null)
         {
             Class<?> pType = riakVClockSetter.getParameterTypes()[0];
             if (pType.isArray())
@@ -412,83 +403,95 @@ public class AnnotationInfo
                 setMethodValue(riakVClockSetter, obj, vclock);
             }
         }
+        else if (riakVClockField != null)
+        {
+
+            if (riakVClockField.getType().isAssignableFrom(VClock.class))
+            {
+                setFieldValue(riakVClockField, obj, vclock);
+            }
+            else
+            {
+                setFieldValue(riakVClockField, obj, vclock.getBytes());
+            }
+        }
     }
 
     public <T> Boolean getRiakTombstone(T obj)
     {
         Boolean tombstone = null;
-        if (riakTombstoneField != null)
-        {
-            tombstone = (Boolean) getFieldValue(riakTombstoneField, obj);
-        }
-        else if (riakTombstoneGetter != null)
+        if (riakTombstoneGetter != null)
         {
             tombstone = (Boolean) getMethodValue(riakTombstoneGetter, obj);
         }
-
+        else if (riakTombstoneField != null)
+        {
+            tombstone = (Boolean) getFieldValue(riakTombstoneField, obj);
+        }
+        
         return tombstone;
     }
 
     public <T> void setRiakTombstone(T obj, Boolean isDeleted)
     {
 
-        if (riakTombstoneField != null)
-        {
-            setFieldValue(riakTombstoneField, obj, isDeleted);
-        }
-        else if (riakTombstoneSetter != null)
+        if (riakTombstoneSetter != null)
         {
             setMethodValue(riakTombstoneSetter, obj, isDeleted);
+        }
+        else if (riakTombstoneField != null)
+        {
+            setFieldValue(riakTombstoneField, obj, isDeleted);
         }
     }
 
     public <T> String getRiakContentType(T obj)
     {
         String contentType = null;
-        if (riakContentTypeField != null)
-        {
-            contentType = (String) getFieldValue(riakContentTypeField, obj);
-        }
-        else if (riakContentTypeGetter != null)
+        if (riakContentTypeGetter != null)
         {
             contentType = (String) getMethodValue(riakContentTypeGetter, obj);
+        }
+        else if (riakContentTypeField != null)
+        {
+            contentType = (String) getFieldValue(riakContentTypeField, obj);
         }
         return contentType;
     }
     
     public <T> void setRiakContentType(T obj, String contentType)
     {
-        if (riakContentTypeField != null)
-        {
-            setFieldValue(riakContentTypeField, obj, contentType);
-        } 
-        else if (riakContentTypeSetter != null)
+        if (riakContentTypeSetter != null)
         {
             setMethodValue(riakContentTypeSetter, obj, contentType);
         }
+        else if (riakContentTypeField != null)
+        {
+            setFieldValue(riakContentTypeField, obj, contentType);
+        } 
     }
     
     public <T> void setRiakLastModified(T obj, Long lastModified)
     {
-        if (riakLastModifiedField != null)
-        {
-            setFieldValue(riakLastModifiedField, obj, lastModified);
-        }
-        else if (riakLastModifiedSetter != null)
+        if (riakLastModifiedSetter != null)
         {
             setMethodValue(riakLastModifiedSetter, obj, lastModified);
+        }
+        else if (riakLastModifiedField != null)
+        {
+            setFieldValue(riakLastModifiedField, obj, lastModified);
         }
     }
     
     public <T> void setRiakVTag(T obj, String vtag)
     {
-        if (riakVTagField != null)
-        {
-            setFieldValue(riakVTagField, obj, vtag);
-        }
-        else if (riakVTagSetter != null)
+        if (riakVTagSetter != null)
         {
             setMethodValue(riakVTagSetter, obj, vtag);
+        }
+        else if (riakVTagField != null)
+        {
+            setFieldValue(riakVTagField, obj, vtag);
         }
     }
     
@@ -916,15 +919,15 @@ public class AnnotationInfo
     public <T> RiakLinks getLinks(RiakLinks container, T obj)
     {
         Object o = null;
-        if (riakLinksField != null)
-        {
-            o = getFieldValue(riakLinksField, obj);
-        }
-        else if (riakLinksGetter != null)
+        if (riakLinksGetter != null)
         {
             o = getMethodValue(riakLinksGetter, obj);
         }
-
+        else if (riakLinksField != null)
+        {
+            o = getFieldValue(riakLinksField, obj);
+        }
+        
         if (o != null)
         {
             container.addLinks((Collection<RiakLink>) o);
@@ -935,15 +938,15 @@ public class AnnotationInfo
 
     public <T> void setLinks(RiakLinks links, T obj)
     {
-        if (riakLinksField != null)
-        {
-            setFieldValue(riakLinksField, obj, links.getLinks());
-        }
-        else if (riakLinksSetter != null)
+        if (riakLinksSetter != null)
         {
             setMethodValue(riakLinksSetter, obj, links.getLinks());
         }
-
+        else if (riakLinksField != null)
+        {
+            setFieldValue(riakLinksField, obj, links.getLinks());
+        }
+        
     }
 
     public static class Builder
@@ -1003,7 +1006,7 @@ public class AnnotationInfo
          */
         public Builder withRiakKeyField(Field f)
         {
-            validateStringOrByteField(f, riakKeyGetter, riakKeySetter, "@RiakKey");
+            validateStringOrByteField(f, "@RiakKey");
             this.riakKeyField = ClassUtil.checkAndFixAccess(f);
             return this;
         }
@@ -1016,7 +1019,7 @@ public class AnnotationInfo
          */
         public Builder withRiakKeyGetter(Method m)
         {
-            validateStringOrByteMethod(m, riakKeyField, "@RiakKey");
+            validateStringOrByteMethod(m, "@RiakKey");
             this.riakKeyGetter = ClassUtil.checkAndFixAccess(m);
             return this;
         }
@@ -1029,7 +1032,7 @@ public class AnnotationInfo
          */
         public Builder withRiakKeySetter(Method m)
         {
-            validateStringOrByteMethod(m, riakKeyField, "@RiakKey");
+            validateStringOrByteMethod(m, "@RiakKey");
             this.riakKeySetter = ClassUtil.checkAndFixAccess(m);
             return this;
         }
@@ -1233,44 +1236,42 @@ public class AnnotationInfo
         
         public Builder withRiakBucketNameField(Field f)
         {
-            validateStringOrByteField(f, riakBucketNameGetter, 
-                                         riakBucketNameSetter, "@RiakBucketName");
+            validateStringOrByteField(f, "@RiakBucketName");
             this.riakBucketNameField = ClassUtil.checkAndFixAccess(f);
             return this;
         }
         
         public Builder withRiakBucketNameSetter(Method m)
         {
-            validateStringOrByteMethod(m, riakBucketNameField, "@RiakBucketName");
+            validateStringOrByteMethod(m, "@RiakBucketName");
             this.riakBucketNameSetter = ClassUtil.checkAndFixAccess(m);
             return this;
         }
         
         public Builder withRiakBucketNameGetter(Method m)
         {
-            validateStringOrByteMethod(m, riakBucketNameField, "@RiakBucketName");            
+            validateStringOrByteMethod(m, "@RiakBucketName");            
             this.riakBucketNameGetter = ClassUtil.checkAndFixAccess(m);
             return this;
         }
         
         public Builder withRiakBucketTypeField(Field f)
         {
-            validateStringOrByteField(f, riakBucketTypeGetter, 
-                                         riakBucketTypeSetter, "@RiakBucketType");
+            validateStringOrByteField(f, "@RiakBucketType");
             this.riakBucketTypeField = ClassUtil.checkAndFixAccess(f);
             return this;
         }
         
         public Builder withRiakBucketTypeSetter(Method m)
         {
-            validateStringOrByteMethod(m,riakBucketTypeField, "@RiakBucketType");
+            validateStringOrByteMethod(m, "@RiakBucketType");
             this.riakBucketTypeSetter = ClassUtil.checkAndFixAccess(m);
             return this;
         }
         
         public Builder withRiakBucketTypeGetter(Method m)
         {
-            validateStringOrByteMethod(m,riakBucketTypeField, "@RiakBucketType");
+            validateStringOrByteMethod(m, "@RiakBucketType");
             this.riakBucketTypeGetter = ClassUtil.checkAndFixAccess(m);
             return this;
         }
@@ -1278,47 +1279,11 @@ public class AnnotationInfo
         
         public AnnotationInfo build()
         {
-            validateAnnotatedSet(riakVClockField, riakVClockGetter,
-                                 riakVClockSetter, "@RiakVClock");
-            validateAnnotatedSet(riakTombstoneField, riakTombstoneGetter,
-                                 riakTombstoneSetter, "@RiakTombstone");
-            validateAnnotatedSet(riakLinksField, riakLinksGetter,
-                                 riakLinksSetter, "@RiakLinks");
-            validateAnnotatedSet(riakKeyField, riakKeyGetter,
-                                 riakKeySetter, "@RiakKey");
-            validateAnnotatedSet(riakContentTypeField, riakContentTypeGetter,
-                                 riakContentTypeSetter, "@RiakContentType");
-            validateAnnotatedSet(riakBucketNameField, riakBucketNameGetter,
-                                 riakBucketNameSetter, "@RiakBucketName");
-            validateAnnotatedSet(riakBucketTypeField, riakBucketTypeGetter,
-                                 riakBucketTypeSetter, "@RiakBucketType");
-            
-
             return new AnnotationInfo(this);
-        }
-
-        private void validateAnnotatedSet(Field f, Method getter, Method setter, String annotation)
-        {
-            if (f == null && (getter == null || setter == null))
-            {
-                if (getter != null && setter == null)
-                {
-                    throw new IllegalStateException("Getter present for " + annotation + " without setter.");
-                }
-                else if (setter != null && getter == null)
-                {
-                    throw new IllegalStateException("Setter present for " + annotation + " without getter.");
-                }
-            }
         }
 
         private void validateRiakLinksField(Field riakLinksField)
         {
-
-            if (riakLinksGetter != null || riakLinksSetter != null)
-            {
-                throw new IllegalArgumentException("@RiakLinks annotated method already set");
-            }
 
             if (Collection.class.isAssignableFrom(riakLinksField.getType()))
             {
@@ -1346,10 +1311,6 @@ public class AnnotationInfo
 
         private void validateRiakLinksMethod(Method m)
         {
-            if (riakLinksField != null)
-            {
-                throw new IllegalArgumentException("@RiakLinks annotated field already set.");
-            }
             if (m.getReturnType().equals(Void.TYPE))
             {
                 // it's a setter, check the arg type
@@ -1393,11 +1354,7 @@ public class AnnotationInfo
 
         private void validateVClockField(Field f)
         {
-            if (riakVClockGetter != null || riakVClockSetter != null)
-            {
-                throw new IllegalArgumentException("@RiakVClock annotated method already set.");
-            }
-            else if (!(f.getType().isArray() && f.getType().getComponentType().equals(byte.class))
+            if (!(f.getType().isArray() && f.getType().getComponentType().equals(byte.class))
                 && !f.getType().isAssignableFrom(VClock.class))
             {
                 throw new IllegalArgumentException("@RiakVClock field must be a VClock or byte[]");
@@ -1406,11 +1363,7 @@ public class AnnotationInfo
 
         private void validateVClockMethod(Method m)
         {
-            if (riakVClockField != null)
-            {
-                throw new IllegalArgumentException("@RiakVClock annotated field already set.");
-            }
-            else if (m.getReturnType().equals(Void.TYPE))
+            if (m.getReturnType().equals(Void.TYPE))
             {
                 // It's a setter
                 Class<?> pType = m.getParameterTypes()[0];
@@ -1434,11 +1387,7 @@ public class AnnotationInfo
 
         private void validateTombstoneField(Field f)
         {
-            if (riakTombstoneGetter != null || riakTombstoneSetter != null)
-            {
-                throw new IllegalArgumentException("@RiakTombstone annotated method already set.");
-            }
-            else if (!f.getType().equals(Boolean.class) && !f.getType().equals(boolean.class))
+            if (!f.getType().equals(Boolean.class) && !f.getType().equals(boolean.class))
             {
                 throw new IllegalArgumentException("@RiakTombstone field must be Boolean or boolean");
             }
@@ -1446,11 +1395,7 @@ public class AnnotationInfo
 
         private void validateTombstoneMethod(Method m)
         {
-            if (riakTombstoneField != null)
-            {
-                throw new IllegalArgumentException("@RiakTombstone annotated field already set");
-            }
-            else if (m.getReturnType().equals(Void.TYPE))
+            if (m.getReturnType().equals(Void.TYPE))
             {
                 Class<?> pType = m.getParameterTypes()[0];
                 if (!pType.equals(Boolean.class) && !pType.equals(boolean.class))
@@ -1470,11 +1415,7 @@ public class AnnotationInfo
         
         private void validateContentTypeField(Field f)
         {
-            if (riakContentTypeGetter != null || riakContentTypeSetter != null)
-            {
-                throw new IllegalArgumentException("@RiakContentType annotated method already set.");
-            }
-            else if (!f.getType().equals(String.class))
+            if (!f.getType().equals(String.class))
             {
                 throw new IllegalArgumentException("@RiakContentType field must be a String.");
             }
@@ -1482,11 +1423,7 @@ public class AnnotationInfo
         
         private void validateContentTypeMethod(Method m)
         {
-            if (riakContentTypeField != null)
-            {
-                throw new IllegalArgumentException("@RiakContentType annotated field already set");
-            }
-            else if (m.getReturnType().equals(Void.TYPE))
+            if (m.getReturnType().equals(Void.TYPE))
             { 
                 if (!String.class.equals(m.getParameterTypes()[0]))
                 {
@@ -1504,11 +1441,7 @@ public class AnnotationInfo
         
         private void validateLastModifiedField(Field f)
         {
-            if (riakLastModified != null)
-            {
-                throw new IllegalArgumentException("@RiakLastModified annotated method already set.");
-            }
-            else if (!f.getType().equals(Long.class) && !f.getType().equals(long.class))
+            if (!f.getType().equals(Long.class) && !f.getType().equals(long.class))
             {
                 throw new IllegalArgumentException("@RiakLastModified field must be a Long or long.");
             }
@@ -1516,34 +1449,23 @@ public class AnnotationInfo
         
         private void validateLastModifiedMethod(Method m)
         {
-            if (riakLastModifiedField != null)
+            if (!m.getReturnType().equals(Void.TYPE))
             {
-                throw new IllegalArgumentException("@RiakLastModified annotated field already set.");
+                throw new IllegalArgumentException("@RiakLastModified can only be applied to a setter method.");
             }
             else
             {
-                if (!m.getReturnType().equals(Void.TYPE))
+                Class<?> pType = m.getParameterTypes()[0];
+                if (!pType.equals(Long.class) && !pType.equals(long.class))
                 {
-                    throw new IllegalArgumentException("@RiakLastModified can only be applied to a setter method.");
-                }
-                else
-                {
-                    Class<?> pType = m.getParameterTypes()[0];
-                    if (!pType.equals(Long.class) && !pType.equals(long.class))
-                    {
-                        throw new IllegalArgumentException("@RiakLastModified setter must take a long or Long.");
-                    }
+                    throw new IllegalArgumentException("@RiakLastModified setter must take a long or Long.");
                 }
             }
         }
         
         private void validateVTagField(Field f)
         {
-            if (riakVTagSetter != null)
-            {
-                throw new IllegalArgumentException("@RiakVTag annotated method already set.");
-            }
-            else if (!f.getType().equals(String.class))
+            if (!f.getType().equals(String.class))
             {
                 throw new IllegalArgumentException("@RiakVTag field must be a String.");
             }
@@ -1551,47 +1473,32 @@ public class AnnotationInfo
         
         private void validateVTagMethod(Method m)
         {
-            if (riakVTagField != null)
+            if (!m.getReturnType().equals(Void.TYPE))
             {
-                throw new IllegalArgumentException("@RiakVTag annotated field already set.");
+                throw new IllegalArgumentException("@RiakVTag can only be applied to a setter method.");
             }
             else
             {
-                if (!m.getReturnType().equals(Void.TYPE))
+                Class<?> pType = m.getParameterTypes()[0];
+                if (!pType.equals(String.class))
                 {
-                    throw new IllegalArgumentException("@RiakVTag can only be applied to a setter method.");
-                }
-                else
-                {
-                    Class<?> pType = m.getParameterTypes()[0];
-                    if (!pType.equals(String.class))
-                    {
-                        throw new IllegalArgumentException("@RiakVTag setter must take a String.");
-                    }
+                    throw new IllegalArgumentException("@RiakVTag setter must take a String.");
                 }
             }
         }
         
-        private void validateStringOrByteField(Field f, Method getter, Method setter, String annotation)
+        private void validateStringOrByteField(Field f, String annotation)
         {
-            if (getter != null || setter != null)
-            {
-                throw new IllegalArgumentException(annotation + " annotated method already set.");
-            }
-            else if (!(f.getType().isArray() && f.getType().getComponentType().equals(byte.class))
+            if (!(f.getType().isArray() && f.getType().getComponentType().equals(byte.class))
                 && !f.getType().isAssignableFrom(String.class))
             {
                 throw new IllegalArgumentException(annotation + " field must be a String or byte[].");
             }
         }
         
-        private void validateStringOrByteMethod(Method m, Field field, String annotation)
+        private void validateStringOrByteMethod(Method m, String annotation)
         {
-            if (field != null)
-            {
-                throw new IllegalArgumentException(annotation + " annotated field already set.");
-            }
-            else if (m.getReturnType().equals(Void.TYPE))
+            if (m.getReturnType().equals(Void.TYPE))
             {
                 // It's a setter
                 Class<?> pType = m.getParameterTypes()[0];

--- a/src/main/java/com/basho/riak/client/core/operations/SecondaryIndexQueryOperation.java
+++ b/src/main/java/com/basho/riak/client/core/operations/SecondaryIndexQueryOperation.java
@@ -61,9 +61,11 @@ public class SecondaryIndexQueryOperation extends FutureOperation<SecondaryIndex
              * list of object keys and you have to have
              * preserved the index key if you want to return it to the user
              * with the results. 
+             * 
+             * Also, the $key index queries just ignore return_terms altogether.
              */
             
-            if (pbReq.getReturnTerms())
+            if (pbReq.getReturnTerms() && !query.indexName.toString().equalsIgnoreCase("$key"))
             {
                 if (pbReq.hasRangeMin())
                 {

--- a/src/main/java/com/basho/riak/client/core/query/indexes/IndexType.java
+++ b/src/main/java/com/basho/riak/client/core/query/indexes/IndexType.java
@@ -35,7 +35,15 @@ public enum IndexType
     /**
      * Encapsulates the {@code "_bin"} suffix for Riak index names.
      */
-    BIN("_bin");
+    BIN("_bin"),
+    /**
+     * Used for the special $bucket index
+     */
+    BUCKET(""),
+    /**
+     * Used for the special $key index
+     */
+    KEY("");
     
     private final String suffix;
     
@@ -68,19 +76,30 @@ public enum IndexType
      */
     public static IndexType typeFromFullname(String fullname)
     {
-        int i = fullname.lastIndexOf('_');
-        if (i != -1)
+        if (fullname.equalsIgnoreCase("$bucket"))
         {
-            String suffix = fullname.substring(i);
-            for (IndexType t : IndexType.values())
+            return IndexType.BUCKET;
+        }
+        else if (fullname.equalsIgnoreCase("$key"))
+        {
+            return IndexType.KEY;
+        }
+        else
+        {
+            int i = fullname.lastIndexOf('_');
+            if (i != -1)
             {
-                if (t.suffix().equalsIgnoreCase(suffix))
+                String suffix = fullname.substring(i);
+                for (IndexType t : IndexType.values())
                 {
-                    return t;
+                    if (t.suffix().equalsIgnoreCase(suffix))
+                    {
+                        return t;
+                    }
                 }
             }
-        }
 
-        throw new IllegalArgumentException("Indexname does not end with valid suffix");
+            throw new IllegalArgumentException("Indexname does not end with valid suffix");
+        }
     }
 }

--- a/src/main/java/com/basho/riak/client/core/query/indexes/RiakIndex.java
+++ b/src/main/java/com/basho/riak/client/core/query/indexes/RiakIndex.java
@@ -360,6 +360,7 @@ public abstract class RiakIndex<T> implements Iterable<T>
         
         protected Name(String name, IndexType type)
         {
+            name = name.toLowerCase();
             this.name = stripSuffix(name, type);
             this.type = type;
         }

--- a/src/test/java/com/basho/riak/client/api/commands/itest/ITestFetchValue.java
+++ b/src/test/java/com/basho/riak/client/api/commands/itest/ITestFetchValue.java
@@ -24,9 +24,11 @@ import com.basho.riak.client.api.commands.kv.FetchValue.Option;
 import com.basho.riak.client.api.commands.kv.FetchValue;
 import com.basho.riak.client.api.RiakClient;
 import com.basho.riak.client.api.annotations.RiakVClock;
+import com.basho.riak.client.api.cap.DefaultResolver;
 import com.basho.riak.client.api.cap.VClock;
 import com.basho.riak.client.core.operations.StoreBucketPropsOperation;
 import com.basho.riak.client.api.commands.kv.StoreValue;
+import com.basho.riak.client.api.convert.JSONConverter;
 import com.basho.riak.client.core.query.Location;
 import com.basho.riak.client.core.query.Namespace;
 import com.basho.riak.client.core.query.RiakObject;
@@ -205,8 +207,13 @@ public class ITestFetchValue extends ITestBase
         FetchValue.Response fResp = client.execute(fv);
          
         assertEquals(pojo.value, fResp.getValue(Pojo.class).value);
-
         
+        JSONConverter<Pojo> converter = new JSONConverter<Pojo>(Pojo.class);
+        ConflictResolver<Pojo> resolver = new DefaultResolver<Pojo>();
+        
+        assertEquals(pojo.value, fResp.getValues(converter).get(0).value);
+        assertEquals(pojo.value, fResp.getValue(converter, resolver).value);
+
     }
     
     @Test

--- a/src/test/java/com/basho/riak/client/core/query/indexes/IndexTest.java
+++ b/src/test/java/com/basho/riak/client/core/query/indexes/IndexTest.java
@@ -43,6 +43,8 @@ public class IndexTest
     {
         Assert.assertEquals(IndexType.BIN.suffix(), "_bin");
         Assert.assertEquals(IndexType.INT.suffix(), "_int");
+        Assert.assertEquals(IndexType.BUCKET.suffix(), "");
+        Assert.assertEquals(IndexType.KEY.suffix(), "");
     }
     
     @Test
@@ -53,6 +55,12 @@ public class IndexTest
 
         IndexType indexType1 = IndexType.typeFromFullname("indexname_bin");
         Assert.assertTrue(indexType1.equals(IndexType.BIN));
+        
+        IndexType indexType2 = IndexType.typeFromFullname("$bucket");
+        Assert.assertTrue(indexType2.equals(IndexType.BUCKET));
+        
+        IndexType indexType3 = IndexType.typeFromFullname("$key");
+        Assert.assertTrue(indexType3.equals(IndexType.KEY));
 
     }
 }


### PR DESCRIPTION
Slightly revamped annotation scanning.

Getters/Setters no longer are required as pairs; you can have only one of them. In addition, Setter/Getter methods now take precedent over annotated fields rather than being mutually exclusive. 

Addresses #429 (CLIENTS-36) 

Also we now look at the number of parameters and parameter type to determine if getter or setter. Allows users to have fluent APIs in their objects (old way required setters to return `void`) 

Addresses #413 (CLIENTS-37) 