### PR TITLE
Gh484 pom option pb shading

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -3,41 +3,36 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.basho.riak</groupId>
   <artifactId>riak-client</artifactId>
-  <packaging>bundle</packaging>
   <name>Riak Client for Java</name>
-  <version>1.4.1</version>
-  <description>HttpClient-based client for Riak</description>
+  <version>2.0.1-SNAPSHOT</version>
+  <description>Java client for Riak 2.0</description>
   <url>https://github.com/basho/riak-java-client</url>
   <developers>
     <developer>
-      <name>Jonathan Lee</name>
-      <email>jonjlee@gmail.com</email>
-    </developer>
-    <developer>
-      <name>Andy Gross</name>
-      <email>andy@basho.com</email>
-    </developer>
-    <developer>
-      <name>Dave Smith</name>
-      <email>dizzyd@basho.com</email>
-    </developer>
-    <developer>
-      <name>Russell Brown</name>
-      <email>russelldb@basho.com</email>
-    </developer>
-    <developer>
       <name>Brian Roach</name>
       <email>roach@basho.com</email>
+      <organization>Basho Technologies, Inc</organization>
+      <organizationUrl>http://www.basho.com</organizationUrl>
     </developer>
     <developer>
-      <name>Dave Rusek</name>
+      <name>David Rusek</name>
       <email>drusek@basho.com</email>
+      <organization>Basho Technologies, Inc</organization>
+      <organizationUrl>http://www.basho.com</organizationUrl>
+    </developer>
+    <developer>
+      <name>Alex Moore</name>
+      <email>amoore@basho.com</email>
+      <organization>Basho Technologies, Inc</organization>
+      <organizationUrl>http://www.basho.com</organizationUrl>
     </developer>
   </developers>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+      <comments>A business-friendly OSS license</comments>
     </license>
   </licenses>
   <scm>
@@ -47,63 +42,6 @@
   </scm>
   <build>
     <plugins>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
-        <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>cobertura-maven-plugin</artifactId>
-        <version>${cobertura.version}</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>clean</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <instrumentation>
-            <excludes>
-              <exclude>org/json/*.class</exclude>
-              <exclude>com/basho/riak/pbc/RPB*</exclude>
-            </excludes>
-          </instrumentation>
-        </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-release-plugin</artifactId>
-        <version>2.1</version>
-      </plugin>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>2.4</version>
-        <executions>
-          <execution>
-            <id>test-jar</id>
-            <phase>package</phase>
-            <goals>
-              <goal>test-jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <version>2.3.7</version>
-        <extensions>true</extensions>
-        <configuration>
-          <instructions>
-            <Import-Package>org.apache.commons.codec.binary;version="[1.4,2)",
-                            *;resolution:=optional</Import-Package>
-          </instructions>
-        </configuration>
-      </plugin>
       <plugin>
         <artifactId>maven-shade-plugin</artifactId>
         <version>2.1</version>
@@ -136,17 +74,123 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <artifactId>maven-release-plugin</artifactId>
+        <version>2.1</version>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.6.3.201306030806</version>
+        <executions>
+          <execution>
+            <id>jacoco-initialize</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>jacoco-site</id>
+            <phase>package</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>1.6</source>
+          <target>1.6</target>
+          <compilerArgument>-Xlint:unchecked</compilerArgument>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>animal-sniffer-maven-plugin</artifactId>
+        <version>1.9</version>
+        <executions>
+          <execution>
+            <phase>test</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <signature>
+            <groupId>org.codehaus.mojo.signature</groupId>
+            <artifactId>java16</artifactId>
+            <version>1.1</version>
+          </signature>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.14</version>
+        <configuration>
+          <systemPropertyVariables>
+            <org.slf4j.simpleLogger.defaultLogLevel>debug</org.slf4j.simpleLogger.defaultLogLevel>
+            <org.slf4j.simpleLogger.showDateTime>true</org.slf4j.simpleLogger.showDateTime>
+            <org.slf4j.simpleLogger.dateTimeFormat>yyyy-MM-dd HH:mm:ss</org.slf4j.simpleLogger.dateTimeFormat>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.9.1</version>
+        <configuration>
+          <taglets>
+            <taglet>
+              <tagletClass>com.basho.riak.client.javadoc.RiakThreadSafetyTaglet</tagletClass>
+              <tagletArtifact>
+                <groupId>com.basho.riak</groupId>
+                <artifactId>riak-client</artifactId>
+                <version>2.0.0-SNAPSHOT</version>
+              </tagletArtifact>
+            </taglet>
+          </taglets>
+          <doclet>com.basho.riak.client.javadoc.JavadocFilter</doclet>
+          <docletArtifact>
+            <groupId>com.basho.riak</groupId>
+            <artifactId>riak-client</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+          </docletArtifact>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
   <profiles>
+    <profile>
+      <dependencies>
+        <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-nop</artifactId>
+          <version>1.7.5</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>test-debug-logging</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-simple</artifactId>
+          <version>1.7.5</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
     <profile>
       <id>itest</id>
       <build>
         <plugins>
           <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>failsafe-maven-plugin</artifactId>
-            <version>2.4.3-alpha-1</version>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <version>2.16</version>
             <executions>
               <execution>
                 <goals>
@@ -155,6 +199,32 @@
                 </goals>
               </execution>
             </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>jar-with-dependencies</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-assembly-plugin</artifactId>
+            <version>2.4</version>
+            <executions>
+              <execution>
+                <id>make-assembly</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>single</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <descriptors>
+                <descriptor>src/main/assembly/jar-with-dependencies.xml</descriptor>
+              </descriptors>
+              <archive />
+            </configuration>
           </plugin>
         </plugins>
       </build>
@@ -180,85 +250,9 @@
       </build>
     </profile>
     <profile>
-      <id>githubUpload</id>
+      <id>shaded_pb</id>
       <build>
         <plugins>
-          <plugin>
-            <groupId>com.github.github</groupId>
-            <artifactId>downloads-maven-plugin</artifactId>
-            <version>0.4</version>
-            <executions>
-              <execution>
-                <phase>install</phase>
-                <goals>
-                  <goal>upload</goal>
-                </goals>
-              </execution>
-            </executions>
-            <configuration>
-              <description>${project.version} release of ${project.name}</description>
-              <override>false</override>
-              <includeAttached>true</includeAttached>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>dependencyArchive</id>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-assembly-plugin</artifactId>
-            <version>2.2.1</version>
-            <executions>
-              <execution>
-                <id>make-assembly</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>single</goal>
-                </goals>
-              </execution>
-            </executions>
-            <configuration>
-              <descriptors>
-                <descriptor>src/main/assembly/rjc-deps.xml</descriptor>
-              </descriptors>
-              <archive />
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>depsAndTests</id>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-assembly-plugin</artifactId>
-            <version>2.2.1</version>
-            <executions>
-              <execution>
-                <id>make-assembly</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>single</goal>
-                </goals>
-                <configuration>
-                  <descriptors>
-                    <descriptor>src/main/assembly/rjc-be-fat.xml</descriptor>
-                  </descriptors>
-                  <archive />
-                </configuration>
-              </execution>
-            </executions>
-            <configuration>
-              <descriptors>
-                <descriptor>src/main/assembly/rjc-be-fat.xml</descriptor>
-              </descriptors>
-              <archive />
-            </configuration>
-          </plugin>
           <plugin>
             <artifactId>maven-shade-plugin</artifactId>
             <version>2.1</version>
@@ -269,7 +263,7 @@
                   <goal>shade</goal>
                 </goals>
                 <configuration>
-                  <shadedArtifactAttached>false</shadedArtifactAttached>
+                  <shadedArtifactAttached>true</shadedArtifactAttached>
                   <createDependencyReducedPom>true</createDependencyReducedPom>
                   <artifactSet>
                     <includes>
@@ -294,69 +288,80 @@
         </plugins>
       </build>
     </profile>
-    <profile>
-      <id>fat_jar</id>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-assembly-plugin</artifactId>
-            <version>2.2.1</version>
-            <executions>
-              <execution>
-                <id>make-assembly</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>single</goal>
-                </goals>
-              </execution>
-            </executions>
-            <configuration>
-              <descriptorRefs>
-                <descriptorRef>jar-with-dependencies</descriptorRef>
-              </descriptorRefs>
-              <archive />
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
   </profiles>
   <dependencies>
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <version>4.2.5</version>
+      <groupId>com.sun</groupId>
+      <artifactId>tools</artifactId>
+      <version>1.4.2</version>
+      <scope>system</scope>
+      <systemPath>/Library/Java/JavaVirtualMachines/jdk1.7.0_25.jdk/Contents/Home/jre/../lib/tools.jar</systemPath>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.2</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.8.0</version>
+      <artifactId>mockito-core</artifactId>
+      <version>1.9.5</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>objenesis</artifactId>
+          <groupId>org.objenesis</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.4</version>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <version>1.5</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>mockito-all</artifactId>
+          <groupId>org.mockito</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>powermock-api-support</artifactId>
+          <groupId>org.powermock</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.json</groupId>
-      <artifactId>json</artifactId>
-      <version>20090211</version>
-      <scope>compile</scope>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>1.5</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>powermock-module-junit4-common</artifactId>
+          <groupId>org.powermock</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-annotations</artifactId>
-      <version>2.2.2</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-      <version>2.2.2</version>
-      <scope>compile</scope>
+      <groupId>com.jayway.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>1.3.5</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>hamcrest-library</artifactId>
+          <groupId>org.hamcrest</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>cglib-nodep</artifactId>
+          <groupId>cglib</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>objenesis</artifactId>
+          <groupId>org.objenesis</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -370,32 +375,34 @@
       <version>2.2.2</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-all</artifactId>
+      <version>4.0.17.Final</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-nop</artifactId>
+      <version>1.7.5</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
-  <reporting>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>cobertura-maven-plugin</artifactId>
-        <version>${cobertura.version}</version>
-      </plugin>
-    </plugins>
-  </reporting>
   <distributionManagement>
     <repository>
       <id>sonatype-nexus-staging</id>
       <name>Nexus Release Repository</name>
-      <url>http://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
     </repository>
     <snapshotRepository>
       <id>sonatype-nexus-snapshots</id>
       <name>Sonatype Nexus Snapshots</name>
-      <url>http://oss.sonatype.org/content/repositories/snapshots</url>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
     </snapshotRepository>
   </distributionManagement>
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <cobertura.version>2.4</cobertura.version>
-    <jackson.version>2.2.2</jackson.version>
+    <powermock.version>1.5</powermock.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,39 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadedArtifactAttached>false</shadedArtifactAttached>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                            <artifactSet>
+                                <includes>
+                                    <include>com.google.protobuf:protobuf-java</include>
+                                    <include>com.basho.riak.protobuf:riak-pb</include>
+                                </includes>
+                            </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.google.protobuf</pattern>
+                                    <shadedPattern>shaded.com.google.protobuf</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.basho.riak.protobuf</pattern>
+                                    <shadedPattern>shaded.com.bash.riak.protobuf</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>maven-release-plugin</artifactId>
                 <version>2.1</version>
             </plugin>

--- a/src/main/java/com/basho/riak/client/api/commands/indexes/SecondaryIndexQuery.java
+++ b/src/main/java/com/basho/riak/client/api/commands/indexes/SecondaryIndexQuery.java
@@ -39,7 +39,7 @@ public abstract class SecondaryIndexQuery<T,S,U> extends RiakCommand<S, U>
 {
     public enum Type
     {
-        _INT("_int"), _BIN("_bin");
+        _INT("_int"), _BIN("_bin"), _BUCKET(""), _KEY("");
         
         private String suffix;
         

--- a/src/main/java/com/basho/riak/client/api/commands/kv/DeleteValue.java
+++ b/src/main/java/com/basho/riak/client/api/commands/kv/DeleteValue.java
@@ -37,7 +37,7 @@ import java.util.Map;
  * </p>
  * <p>
  * Note that this operation returns a {@code Void} type upon success. Any failure
- * will be thrown as an exception when calling {@DeleteValue} synchronously or
+ * will be thrown as an exception when calling {@code DeleteValue} synchronously or
  * when calling the future's get methods. 
  * </p>
  * <pre class="prettyprint">

--- a/src/main/java/com/basho/riak/client/api/commands/kv/DeleteValue.java
+++ b/src/main/java/com/basho/riak/client/api/commands/kv/DeleteValue.java
@@ -34,19 +34,25 @@ import java.util.Map;
  * <p>
  * Deleting an object from Riak is a simple matter of supplying a {@link com.basho.riak.client.core.query.Location}
  * and executing the operation.
+ * </p>
+ * <p>
+ * Note that this operation returns a {@code Void} type upon success. Any failure
+ * will be thrown as an exception when calling {@DeleteValue} synchronously or
+ * when calling the future's get methods. 
+ * </p>
  * <pre class="prettyprint">
  * {@code
  * Namespace ns = new Namespace("my_type", "my_bucket");
  * Location loc = new Location(ns, "my_key");
  * DeleteValue dv = new DeleteValue.Builder(loc).build();
- * DeleteValue.Response resp = client.execute(dv);}</pre>
+ * client.execute(dv);}</pre>
  * </p>
  * <p>
  * All operations can called async as well.
  * <pre class="prettyprint">
  * {@code
  * ...
- * RiakFuture<DeleveValue.Response, Location> future = client.executeAsync(dv);
+ * RiakFuture<Void, Location> future = client.executeAsync(dv);
  * ...
  * future.await();
  * if (future.isSuccess())

--- a/src/main/java/com/basho/riak/client/api/commands/kv/UpdateValue.java
+++ b/src/main/java/com/basho/riak/client/api/commands/kv/UpdateValue.java
@@ -49,6 +49,10 @@ import java.util.concurrent.TimeUnit;
  * object is then passed to your {@link com.basho.riak.client.api.commands.kv.UpdateValue.Update}
  * and the result stored back into Riak.
  * </p>
+ * <p>
+ * To create the mutation you wish to perform, you extend the 
+ * {@link com.basho.riak.client.api.commands.kv.UpdateValue.Update} class:
+ * </p>
  * <pre class="prettyprint">
  * {@code
  * class AppendUpdate extends UpdateValue.Update<MyPojo>
@@ -316,50 +320,8 @@ public final class UpdateValue extends RiakCommand<UpdateValue.Response, Locatio
             return modified;
         }
 
-        /**
-         * Returns a no-op Update instance.
-         * <p>
-         * This can be used to simply resolve siblings that exist 
-         * in Riak without modifying the resolved object.
-         * <p>
-         * 
-         * @return An {@code Update} instance the does not modify anything.
-         */
-        public static <T> Update<T> noopUpdate()
-        {
-            return new Update<T>()
-            {
-                @Override
-                public T apply(T original)
-                {
-                    return original;
-                }
-            };
-        }
-        
-        /**
-         * Returns an Update that replaces whatever is in Riak.
-         * <p>
-         * This Update simply returns the supplied value, thus replacing 
-         * anything currently in Riak with that value.
-         * </p>
-         * @param newValue the obj to store in Riak.
-         * @return an Update instance.
-         */
-        public static <T> Update<T> clobberUpdate(final T newValue)
-        {
-            return new Update<T>()
-            {
-                @Override
-                public T apply(T original)
-                {
-                    return newValue;
-                }
-                
-            };
-        }
     }
-
+    
     /**
      * Used to construct an UpdateValue command.
      */

--- a/src/main/java/com/basho/riak/client/core/operations/SecondaryIndexQueryOperation.java
+++ b/src/main/java/com/basho/riak/client/core/operations/SecondaryIndexQueryOperation.java
@@ -61,9 +61,11 @@ public class SecondaryIndexQueryOperation extends FutureOperation<SecondaryIndex
              * list of object keys and you have to have
              * preserved the index key if you want to return it to the user
              * with the results. 
+             * 
+             * Also, the $key index queries just ignore return_terms altogether.
              */
             
-            if (pbReq.getReturnTerms())
+            if (pbReq.getReturnTerms() && !query.indexName.toString().equalsIgnoreCase("$key"))
             {
                 if (pbReq.hasRangeMin())
                 {

--- a/src/main/java/com/basho/riak/client/core/query/indexes/IndexType.java
+++ b/src/main/java/com/basho/riak/client/core/query/indexes/IndexType.java
@@ -35,7 +35,15 @@ public enum IndexType
     /**
      * Encapsulates the {@code "_bin"} suffix for Riak index names.
      */
-    BIN("_bin");
+    BIN("_bin"),
+    /**
+     * Used for the special $bucket index
+     */
+    BUCKET(""),
+    /**
+     * Used for the special $key index
+     */
+    KEY("");
     
     private final String suffix;
     
@@ -68,19 +76,30 @@ public enum IndexType
      */
     public static IndexType typeFromFullname(String fullname)
     {
-        int i = fullname.lastIndexOf('_');
-        if (i != -1)
+        if (fullname.equalsIgnoreCase("$bucket"))
         {
-            String suffix = fullname.substring(i);
-            for (IndexType t : IndexType.values())
+            return IndexType.BUCKET;
+        }
+        else if (fullname.equalsIgnoreCase("$key"))
+        {
+            return IndexType.KEY;
+        }
+        else
+        {
+            int i = fullname.lastIndexOf('_');
+            if (i != -1)
             {
-                if (t.suffix().equalsIgnoreCase(suffix))
+                String suffix = fullname.substring(i);
+                for (IndexType t : IndexType.values())
                 {
-                    return t;
+                    if (t.suffix().equalsIgnoreCase(suffix))
+                    {
+                        return t;
+                    }
                 }
             }
-        }
 
-        throw new IllegalArgumentException("Indexname does not end with valid suffix");
+            throw new IllegalArgumentException("Indexname does not end with valid suffix");
+        }
     }
 }

--- a/src/main/java/com/basho/riak/client/core/query/indexes/RiakIndex.java
+++ b/src/main/java/com/basho/riak/client/core/query/indexes/RiakIndex.java
@@ -360,6 +360,7 @@ public abstract class RiakIndex<T> implements Iterable<T>
         
         protected Name(String name, IndexType type)
         {
+            name = name.toLowerCase();
             this.name = stripSuffix(name, type);
             this.type = type;
         }

--- a/src/test/java/com/basho/riak/client/api/commands/itest/ITestFetchValue.java
+++ b/src/test/java/com/basho/riak/client/api/commands/itest/ITestFetchValue.java
@@ -24,9 +24,11 @@ import com.basho.riak.client.api.commands.kv.FetchValue.Option;
 import com.basho.riak.client.api.commands.kv.FetchValue;
 import com.basho.riak.client.api.RiakClient;
 import com.basho.riak.client.api.annotations.RiakVClock;
+import com.basho.riak.client.api.cap.DefaultResolver;
 import com.basho.riak.client.api.cap.VClock;
 import com.basho.riak.client.core.operations.StoreBucketPropsOperation;
 import com.basho.riak.client.api.commands.kv.StoreValue;
+import com.basho.riak.client.api.convert.JSONConverter;
 import com.basho.riak.client.core.query.Location;
 import com.basho.riak.client.core.query.Namespace;
 import com.basho.riak.client.core.query.RiakObject;
@@ -205,8 +207,13 @@ public class ITestFetchValue extends ITestBase
         FetchValue.Response fResp = client.execute(fv);
          
         assertEquals(pojo.value, fResp.getValue(Pojo.class).value);
-
         
+        JSONConverter<Pojo> converter = new JSONConverter<Pojo>(Pojo.class);
+        ConflictResolver<Pojo> resolver = new DefaultResolver<Pojo>();
+        
+        assertEquals(pojo.value, fResp.getValues(converter).get(0).value);
+        assertEquals(pojo.value, fResp.getValue(converter, resolver).value);
+
     }
     
     @Test

--- a/src/test/java/com/basho/riak/client/core/query/indexes/IndexTest.java
+++ b/src/test/java/com/basho/riak/client/core/query/indexes/IndexTest.java
@@ -43,6 +43,8 @@ public class IndexTest
     {
         Assert.assertEquals(IndexType.BIN.suffix(), "_bin");
         Assert.assertEquals(IndexType.INT.suffix(), "_int");
+        Assert.assertEquals(IndexType.BUCKET.suffix(), "");
+        Assert.assertEquals(IndexType.KEY.suffix(), "");
     }
     
     @Test
@@ -53,6 +55,12 @@ public class IndexTest
 
         IndexType indexType1 = IndexType.typeFromFullname("indexname_bin");
         Assert.assertTrue(indexType1.equals(IndexType.BIN));
+        
+        IndexType indexType2 = IndexType.typeFromFullname("$bucket");
+        Assert.assertTrue(indexType2.equals(IndexType.BUCKET));
+        
+        IndexType indexType3 = IndexType.typeFromFullname("$key");
+        Assert.assertTrue(indexType3.equals(IndexType.KEY));
 
     }
 }


### PR DESCRIPTION
We will now include a repackaged riak-pb (and thus protocol
buffers 2.5.x+) inside the riak client jar. This eliminates
conflicts were a user is using pb 2.4.x in their project
(still a reported issue, even though pb 2.5.x has been out
for 1.5 years)

Addresses #484 (CLIENTS-40) 

Also doc change to DeleteValue

Addresses #497 (CLIENTS-185) 