### PR TITLE
Declare constants as final - use double-checked locking for lazy init

### DIFF
--- a/src/main/java/com/basho/riak/client/core/query/RiakObject.java
+++ b/src/main/java/com/basho/riak/client/core/query/RiakObject.java
@@ -298,14 +298,22 @@ public final class RiakObject
      * @return the {@link RiakIndexes} that encapsulates any/all indexes for this RiakObject
      * @see <a href="http://docs.basho.com/riak/latest/dev/advanced/2i/">Riak Secondary Indexes</a>
      */
-    public synchronized RiakIndexes getIndexes()
+    public RiakIndexes getIndexes()
     {
         // Lazy initialization of the internal container.
-        if (null == riakIndexes)
+        RiakIndexes result = this.riakIndexes;
+        if (null == result)
         {
-            riakIndexes = new RiakIndexes();
+            synchronized(this)
+            {
+                result = this.riakIndexes;
+                if(null == result)
+                {
+                    this.riakIndexes = result = new RiakIndexes();
+                }
+            }
         }
-        return riakIndexes;
+        return result;
     }
     
     // Links
@@ -325,15 +333,23 @@ public final class RiakObject
      * are directly applied to this <code>RiakObject</code>.
      * @return the {@link RiakIndexes} that encapsulates all/any links for this {@code RiakObject}
      */
-    public synchronized RiakLinks getLinks()
+    public RiakLinks getLinks()
     {
-        // Lazy initialization of container
-        if (null == links)
+        // Lazy initialization of comtainer
+        RiakLinks result = this.links;
+        if (null == result)
         {
-            links = new RiakLinks();
+            synchronized (this)
+            {
+                result = this.links;
+                if(null == result)
+                {
+                    this.links = result = new RiakLinks();
+                }
+            }
         }
         
-        return links;
+        return result;
     }
     
     // User Meta
@@ -355,15 +371,21 @@ public final class RiakObject
      * are directly applied to this <code>RiakObject</code>.
      * @return the {@code RiakUserMetadata} that containsKeyKey any/all User Meta entries for this {@code RiakObject}
      */
-    public synchronized RiakUserMetadata getUserMeta()
+    public RiakUserMetadata getUserMeta()
     {
-        // Lazy initialization of container. 
-        if (null == userMeta)
+        // Lazy initialization of container.
+        RiakUserMetadata result = this.userMeta;
+        if (null == result)
         {
-            userMeta = new RiakUserMetadata();
+            synchronized (this)
+            {
+                result = this.userMeta;
+                if(null == result) {
+                    this.userMeta = result = new RiakUserMetadata();
+                }
+            }
         }
-        
-        return userMeta;
+        return result;
     }
     
     /**

--- a/src/main/java/com/basho/riak/client/core/util/Constants.java
+++ b/src/main/java/com/basho/riak/client/core/util/Constants.java
@@ -25,71 +25,71 @@ import com.basho.riak.client.core.netty.RiakResponseHandler;
 public interface Constants {
 
     // JSON fields used by Riak
-    public static String FL_NAME = "name";
-    public static String FL_KEYS = "keys";
-    public static String FL_SCHEMA = "props";
-    public static String FL_SCHEMA_ALLOW_MULT = "allow_mult";
-    public static String FL_SCHEMA_CHASHFUN = "chash_keyfun";
-    public static String FL_SCHEMA_CHASHFUN_MOD = "mod";
-    public static String FL_SCHEMA_CHASHFUN_FUN = "fun";
-    public static String FL_SCHEMA_LINKFUN = "linkfun";
-    public static String FL_SCHEMA_LINKFUN_MOD = "mod";
-    public static String FL_SCHEMA_LINKFUN_FUN = "fun";
-    public static String FL_SCHEMA_NVAL = "n_val";
-    public static String FL_SCHEMA_FUN_MOD = "mod";
-    public static String FL_SCHEMA_FUN_FUN = "fun";
-    public static String FL_SCHEMA_FUN_NAME = "name";
-    public static String FL_SCHEMA_LAST_WRITE_WINS = "last_write_wins";
-    public static String FL_SCHEMA_BACKEND = "backend";
-    public static String FL_SCHEMA_SMALL_VCLOCK = "small_vclock";
-    public static String FL_SCHEMA_BIG_VCLOCK = "big_vclock";
-    public static String FL_SCHEMA_YOUNG_VCLOCK = "young_vclock";
-    public static String FL_SCHEMA_OLD_VCLOCK = "old_vclock";
-    public static String FL_SCHEMA_R = "r";
-    public static String FL_SCHEMA_W = "w";
-    public static String FL_SCHEMA_DW = "dw";
-    public static String FL_SCHEMA_RW = "rw";
-    public static String FL_SCHEMA_PR = "pr";
-    public static String FL_SCHEMA_PW = "pw";
-    public static String FL_SCHEMA_BASIC_QUORUM = "basic_quorum";
-    public static String FL_SCHEMA_NOT_FOUND_OK = "notfound_ok";
-    public static String FL_SCHEMA_POSTCOMMIT = "postcommit";
-    public static String FL_SCHEMA_PRECOMMIT = "precommit";
-    public static String FL_SCHEMA_SEARCH = "search";
-    public static String FL_BUCKETS = "buckets";
+    public static final String FL_NAME = "name";
+    public static final String FL_KEYS = "keys";
+    public static final String FL_SCHEMA = "props";
+    public static final String FL_SCHEMA_ALLOW_MULT = "allow_mult";
+    public static final String FL_SCHEMA_CHASHFUN = "chash_keyfun";
+    public static final String FL_SCHEMA_CHASHFUN_MOD = "mod";
+    public static final String FL_SCHEMA_CHASHFUN_FUN = "fun";
+    public static final String FL_SCHEMA_LINKFUN = "linkfun";
+    public static final String FL_SCHEMA_LINKFUN_MOD = "mod";
+    public static final String FL_SCHEMA_LINKFUN_FUN = "fun";
+    public static final String FL_SCHEMA_NVAL = "n_val";
+    public static final String FL_SCHEMA_FUN_MOD = "mod";
+    public static final String FL_SCHEMA_FUN_FUN = "fun";
+    public static final String FL_SCHEMA_FUN_NAME = "name";
+    public static final String FL_SCHEMA_LAST_WRITE_WINS = "last_write_wins";
+    public static final String FL_SCHEMA_BACKEND = "backend";
+    public static final String FL_SCHEMA_SMALL_VCLOCK = "small_vclock";
+    public static final String FL_SCHEMA_BIG_VCLOCK = "big_vclock";
+    public static final String FL_SCHEMA_YOUNG_VCLOCK = "young_vclock";
+    public static final String FL_SCHEMA_OLD_VCLOCK = "old_vclock";
+    public static final String FL_SCHEMA_R = "r";
+    public static final String FL_SCHEMA_W = "w";
+    public static final String FL_SCHEMA_DW = "dw";
+    public static final String FL_SCHEMA_RW = "rw";
+    public static final String FL_SCHEMA_PR = "pr";
+    public static final String FL_SCHEMA_PW = "pw";
+    public static final String FL_SCHEMA_BASIC_QUORUM = "basic_quorum";
+    public static final String FL_SCHEMA_NOT_FOUND_OK = "notfound_ok";
+    public static final String FL_SCHEMA_POSTCOMMIT = "postcommit";
+    public static final String FL_SCHEMA_PRECOMMIT = "precommit";
+    public static final String FL_SCHEMA_SEARCH = "search";
+    public static final String FL_BUCKETS = "buckets";
 
     // Header directives used by Riak
-    public static String LINK_TAG = "riaktag";
+    public static final String LINK_TAG = "riaktag";
 
     // Content types used in Riak
-    public static String CTYPE_ANY = "*/*";
-    public static String CTYPE_JSON = "application/json";
-    public static String CTYPE_JSON_UTF8 = "application/json; charset=UTF-8";
-    public static String CTYPE_OCTET_STREAM = "application/octet-stream";
-    public static String CTYPE_MULTIPART_MIXED = "multipart/mixed";
-    public static String CTYPE_TEXT = "text/plain";
-    public static String CTYPE_TEXT_UTF8 = "text/plain; charset=UTF-8";
+    public static final String CTYPE_ANY = "*/*";
+    public static final String CTYPE_JSON = "application/json";
+    public static final String CTYPE_JSON_UTF8 = "application/json; charset=UTF-8";
+    public static final String CTYPE_OCTET_STREAM = "application/octet-stream";
+    public static final String CTYPE_MULTIPART_MIXED = "multipart/mixed";
+    public static final String CTYPE_TEXT = "text/plain";
+    public static final String CTYPE_TEXT_UTF8 = "text/plain; charset=UTF-8";
 
     // Values for the "keys" query parameter
-    public static String NO_KEYS = "false";
-    public static String INCLUDE_KEYS = "true";
-    public static String STREAM_KEYS = "stream";
+    public static final String NO_KEYS = "false";
+    public static final String INCLUDE_KEYS = "true";
+    public static final String STREAM_KEYS = "stream";
 
     // Query parameters used in Riak
-    public static String QP_RETURN_BODY = "returnbody";
-    public static String QP_R = "r";
-    public static String QP_W = "w";
-    public static String QP_DW = "dw";
-    public static String QP_RW = "rw";
-    public static String QP_KEYS = "keys";
-    public static String QP_BUCKETS = "buckets";
-    public static String QP_PR = "pr";
-    public static String QP_PW = "pw";
-    public static String QP_NOT_FOUND_OK = "notfound_ok";
-    public static String QP_BASIC_QUORUM = "basic_quorum";
+    public static final String QP_RETURN_BODY = "returnbody";
+    public static final String QP_R = "r";
+    public static final String QP_W = "w";
+    public static final String QP_DW = "dw";
+    public static final String QP_RW = "rw";
+    public static final String QP_KEYS = "keys";
+    public static final String QP_BUCKETS = "buckets";
+    public static final String QP_PR = "pr";
+    public static final String QP_PW = "pw";
+    public static final String QP_NOT_FOUND_OK = "notfound_ok";
+    public static final String QP_BASIC_QUORUM = "basic_quorum";
 
     // List bucket operation parameters
-    public static String LIST_BUCKETS = "true";
+    public static final String LIST_BUCKETS = "true";
     
     // Netty Channel handler constants
     public static final String MESSAGE_CODEC = "codec";


### PR DESCRIPTION
For performance consideration,it is possible to remove the synchronized keyword for 3 methods inside RiakObject class without compromising thread safety.
See for reference: http://stackoverflow.com/questions/17164454/why-double-checked-locking-is-25-faster-in-joshua-bloch-effective-java-example?rq=1
