### PR TITLE
DP-46  GetCoverage operation to obtain either full or key coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -357,7 +357,7 @@
         <dependency>
             <groupId>com.basho.riak.protobuf</groupId>
             <artifactId>riak-pb</artifactId>
-            <version>2.0.0.16</version>
+            <version>2.0.0.17-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/basho/riak/client/api/commands/kv/GetCoverage.java
+++ b/src/main/java/com/basho/riak/client/api/commands/kv/GetCoverage.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2013 Basho Technologies Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.basho.riak.client.api.commands.kv;
+
+import com.basho.riak.client.api.RiakCommand;
+import com.basho.riak.client.api.commands.CoreFutureAdapter;
+import com.basho.riak.client.core.RiakCluster;
+import com.basho.riak.client.core.RiakFuture;
+import com.basho.riak.client.core.operations.GetCoverageOperation;
+import com.basho.riak.client.core.query.Location;
+import com.basho.riak.client.core.query.Namespace;
+import com.basho.riak.client.core.util.BinaryValue;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Command used to get a coverage information from Riak.
+ * <p>
+ * It returns coverage for the specified {@link com.basho.riak.client.core.query.Location} or
+ * {@link com.basho.riak.client.core.query.Namespace}.
+ * if nothing was specified then the full coverage will be returned.
+ * <p>
+ * Coverage is returned as a {@link List} of Riak entry points (Riak nodes), which are defined as a {@link java.util.Map.Entry}:
+ * <ul>
+ *  <li>{@link Map.Entry#getKey()} contains address of the corresponding endpoint</li>
+ *  <li> {@link Map.Entry#getValue()} contains port</li>
+ * </ul>
+ *
+ * <b>Note:</b> The endpoint's address is always returned as IPv4 in dot-decimal notation.
+ *
+ * @author Sergey Galkin <sgalkin at basho dot com>
+ */
+public class GetCoverage extends RiakCommand<GetCoverage.Response, String>{
+    private final Namespace namespace;
+    private final BinaryValue key;
+    private final boolean forceUpdte;
+
+    private GetCoverage(Builder builder){
+        this.namespace = builder.namespace;
+        this.key = builder.key;
+        this.forceUpdte = builder.forceUpdate;
+    }
+
+    @Override
+    protected RiakFuture<GetCoverage.Response, String> executeAsync(RiakCluster cluster) {
+        RiakFuture<GetCoverageOperation.Response , String> coreFuture =
+                cluster.execute(buildCoreOperation());
+
+        CoreFutureAdapter<GetCoverage.Response, String, GetCoverageOperation.Response, String> future =
+                new CoreFutureAdapter<GetCoverage.Response, String, GetCoverageOperation.Response, String>(coreFuture)
+                {
+                    @Override
+                    protected Response convertResponse(GetCoverageOperation.Response coreResponse)
+                    {
+                        return new Response(coreResponse.geEntryPoints());
+                    }
+
+                    @Override
+                    protected String convertQueryInfo(String coreQueryInfo) {
+                        return coreQueryInfo;
+                    }
+                };
+        coreFuture.addListener(future);
+        return future;
+    }
+
+    private GetCoverageOperation buildCoreOperation()
+    {
+        final GetCoverageOperation.Builder coreBuilder;
+        if(key != null)
+        {
+            // Location coverage
+            coreBuilder = new GetCoverageOperation.Builder(new Location(namespace, key));
+        }
+        else if(namespace != null)
+        {
+            // Namespace coverage
+            coreBuilder = new GetCoverageOperation.Builder(namespace);
+        }
+        else
+        {
+            // Full coverage
+            coreBuilder = new GetCoverageOperation.Builder();
+        }
+
+        if(forceUpdte)
+        {
+            coreBuilder.withForcedUpdate();
+        }
+
+        return coreBuilder.build();
+    }
+
+    /**
+     * A response from Riak containing results from a GetCoverage command.
+     */
+    public static class Response implements Iterable<Map.Entry<String,Integer>>{
+        final List<Map.Entry<String,Integer>> entryPoints;
+        public Response(List<Map.Entry<String,Integer>> pairs) {
+            this.entryPoints = pairs;
+        }
+
+        @Override
+        public Iterator<Map.Entry<String,Integer>> iterator() {
+            return entryPoints.iterator();
+        }
+
+        public List<Map.Entry<String,Integer>> entryPoints(){
+            return entryPoints;
+        }
+    }
+
+    /**
+     * Used to construct a GetCoverage command.
+     */
+    public static class Builder{
+        private Namespace namespace;
+        private BinaryValue key;
+        private boolean forceUpdate;
+
+        /**
+         * Set the namespace.
+         * @param namespace The {@link com.basho.riak.client.core.query.Namespace}.
+         * @return a reference to this object.
+         */
+        public Builder withNamespace(Namespace namespace)
+        {
+            this.namespace = namespace;
+            return this;
+        }
+
+        /**
+         * Set the location.
+         * @param location the {@link com.basho.riak.client.core.query.Location}.
+         * @return a reference to this object.
+         */
+        public Builder withLocation(Location location)
+        {
+            this.namespace = location.getNamespace();
+            this.key = location.getKey();
+            return this;
+        }
+
+        /**
+         * Force entry points discovering on the actual nodes (that is costly), even when Riak already has
+         * corresponding result cached from the previous call.
+         * <p>
+         * <b>Note:</b> If you are not sure what it is, use it. Most likely it will prevent you from spending hours
+         * trying to realize what the strange behavior you have got.
+         *
+         * @return a reference to this object.
+         */
+        public Builder withForcedUpdate(){
+            this.forceUpdate = true;
+            return this;
+        }
+
+        /**
+         * Construct the  GetCoverage command.
+         * @return the new GetCoverage command.
+         */
+        public GetCoverage build()
+        {
+            return new  GetCoverage(this);
+        }
+    }
+}

--- a/src/main/java/com/basho/riak/client/api/commands/kv/GetCoverage.java
+++ b/src/main/java/com/basho/riak/client/api/commands/kv/GetCoverage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 Basho Technologies Inc
+ * Copyright 2015 Basho Technologies Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,12 +48,12 @@ import java.util.Map;
 public class GetCoverage extends RiakCommand<GetCoverage.Response, String>{
     private final Namespace namespace;
     private final BinaryValue key;
-    private final boolean forceUpdte;
+    private final boolean forceUpdate;
 
     private GetCoverage(Builder builder){
         this.namespace = builder.namespace;
         this.key = builder.key;
-        this.forceUpdte = builder.forceUpdate;
+        this.forceUpdate = builder.forceUpdate;
     }
 
     @Override
@@ -67,7 +67,7 @@ public class GetCoverage extends RiakCommand<GetCoverage.Response, String>{
                     @Override
                     protected Response convertResponse(GetCoverageOperation.Response coreResponse)
                     {
-                        return new Response(coreResponse.geEntryPoints());
+                        return new Response(coreResponse.getEntryPoints());
                     }
 
                     @Override
@@ -98,7 +98,7 @@ public class GetCoverage extends RiakCommand<GetCoverage.Response, String>{
             coreBuilder = new GetCoverageOperation.Builder();
         }
 
-        if(forceUpdte)
+        if(forceUpdate)
         {
             coreBuilder.withForcedUpdate();
         }

--- a/src/main/java/com/basho/riak/client/core/netty/RiakChannelInitializer.java
+++ b/src/main/java/com/basho/riak/client/core/netty/RiakChannelInitializer.java
@@ -20,6 +20,8 @@ import com.basho.riak.client.core.util.Constants;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
 
 /**
  *
@@ -39,6 +41,7 @@ public class RiakChannelInitializer extends ChannelInitializer<SocketChannel>
     public void initChannel(SocketChannel ch) throws Exception
     {
         ChannelPipeline p = ch.pipeline();
+        p.addLast(new LoggingHandler(LogLevel.DEBUG));
         p.addLast(Constants.MESSAGE_CODEC, new RiakMessageCodec());
         p.addLast(Constants.OPERATION_ENCODER, new RiakOperationEncoder());
         p.addLast(Constants.RESPONSE_HANDLER, new RiakResponseHandler(listener));

--- a/src/main/java/com/basho/riak/client/core/operations/GetCoverageOperation.java
+++ b/src/main/java/com/basho/riak/client/core/operations/GetCoverageOperation.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2013 Basho Technologies Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.basho.riak.client.core.operations;
+
+import com.basho.riak.client.core.FutureOperation;
+import com.basho.riak.client.core.RiakMessage;
+import com.basho.riak.client.core.query.Location;
+import com.basho.riak.client.core.query.Namespace;
+import com.basho.riak.protobuf.RiakKvPB;
+import com.basho.riak.protobuf.RiakMessageCodes;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+
+import java.util.*;
+
+/**
+ * An operation to get a coverage information from Riak.
+ *
+ * @author Sergey Galkin <sgalkin at basho dot com>
+ */
+public class GetCoverageOperation extends FutureOperation<GetCoverageOperation.Response, RiakKvPB.RpbApiEpResp, String> {
+    private final RiakKvPB.RpbApiEpReq.Builder reqBuilder;
+    private final String queryInfo;
+
+    private GetCoverageOperation(Builder builder){
+        this.reqBuilder = builder.reqBuilder;
+        queryInfo = builder.queryInfo;
+    }
+
+    @Override
+    protected Response convert(List<RiakKvPB.RpbApiEpResp> rawResponse) {
+        if (rawResponse.size() != 1)
+        {
+            throw new IllegalStateException("Expecting exactly one response, instead received " + rawResponse.size());
+        }
+
+        RiakKvPB.RpbApiEpResp response = rawResponse.iterator().next();
+        return new Response(response.getEplistList());
+    }
+
+    @Override
+    protected RiakMessage createChannelMessage() {
+        return new RiakMessage(RiakMessageCodes.MSG_ApiEpReq, reqBuilder.build().toByteArray());
+    }
+
+    @Override
+    protected RiakKvPB.RpbApiEpResp decode(RiakMessage rawMessage) {
+        try
+        {
+            Operations.checkMessageType(rawMessage, RiakMessageCodes.MSG_ApiEpResp);
+            return RiakKvPB.RpbApiEpResp.parseFrom(rawMessage.getData());
+        }
+        catch (InvalidProtocolBufferException e)
+        {
+            throw new IllegalArgumentException("Invalid message received", e);
+        }
+    }
+
+    @Override
+    public String getQueryInfo() {
+        return queryInfo;
+    }
+
+    public static class Builder {
+        private final RiakKvPB.RpbApiEpReq.Builder reqBuilder = RiakKvPB.RpbApiEpReq.newBuilder();
+        private String queryInfo = "";
+
+        public Builder(){
+            reqBuilder.setProto(RiakKvPB.RpbApiProto.valueOf(RiakKvPB.RpbApiProto.pbc_VALUE));
+        }
+
+        public Builder(Location location){
+            this();
+
+            if (location == null)
+            {
+                throw new IllegalArgumentException("Location cannot be null");
+            }
+
+            withNamespace(location.getNamespace());
+            reqBuilder.setKey(ByteString.copyFrom(location.getKey().unsafeGetValue()));
+            queryInfo = location.toString();
+        }
+
+        public Builder(Namespace namespace){
+            withNamespace(namespace);
+        }
+
+        private Builder withNamespace(Namespace namespace){
+            if (namespace == null)
+            {
+                throw new IllegalArgumentException("Namespace cannot be null");
+            }
+
+            reqBuilder.setBucket(ByteString.copyFrom(namespace.getBucketName().unsafeGetValue()));
+            queryInfo = "{bucket: " + namespace.getBucketName() + "}";
+            return this;
+        }
+
+        public Builder withForcedUpdate(){
+            reqBuilder.setForceUpdate(true);
+            return this;
+        }
+
+        public GetCoverageOperation build()
+        {
+            return new GetCoverageOperation(this);
+        }
+    }
+
+    public static class Response
+    {
+        private final List<Map.Entry<String,Integer>> entryPoints;
+
+        public Response(List<RiakKvPB.RpbApiEp> epList) {
+            entryPoints = new ArrayList<Map.Entry<String,Integer>>(epList.size());
+            for(RiakKvPB.RpbApiEp ep: epList){
+                entryPoints.add(new AbstractMap.SimpleEntry<String, Integer>(ep.getAddr().toStringUtf8(), ep.getPort()));
+            }
+        }
+
+        public List<Map.Entry<String,Integer>> geEntryPoints() {
+            return entryPoints;
+        }
+    }
+}

--- a/src/main/java/com/basho/riak/client/core/operations/GetCoverageOperation.java
+++ b/src/main/java/com/basho/riak/client/core/operations/GetCoverageOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 Basho Technologies Inc
+ * Copyright 2015 Basho Technologies Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -132,7 +132,7 @@ public class GetCoverageOperation extends FutureOperation<GetCoverageOperation.R
             }
         }
 
-        public List<Map.Entry<String,Integer>> geEntryPoints() {
+        public List<Map.Entry<String,Integer>> getEntryPoints() {
             return entryPoints;
         }
     }

--- a/src/test/java/com/basho/riak/client/api/commands/itest/ITestGetCoverage.java
+++ b/src/test/java/com/basho/riak/client/api/commands/itest/ITestGetCoverage.java
@@ -1,0 +1,104 @@
+package com.basho.riak.client.api.commands.itest;
+
+import com.basho.riak.client.api.RiakClient;
+import com.basho.riak.client.api.commands.kv.GetCoverage;
+import com.basho.riak.client.api.commands.kv.StoreValue;
+import com.basho.riak.client.core.RiakCluster;
+import com.basho.riak.client.core.RiakNode;
+import com.basho.riak.client.core.operations.PingOperation;
+import com.basho.riak.client.core.operations.itest.ITestBase;
+import com.basho.riak.client.core.query.Location;
+import com.basho.riak.client.core.query.RiakObject;
+import com.basho.riak.client.core.util.BinaryValue;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.UnknownHostException;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.Assert.assertTrue;
+
+public class ITestGetCoverage extends ITestBase {
+    private static Logger logger = LoggerFactory.getLogger(ITestGetCoverage.class);
+
+    @Test(timeout = 60000)
+    public void getFullCoverage() throws ExecutionException, InterruptedException, UnknownHostException {
+        logger.info("Retrieve list of EPs...");
+        final RiakClient client = new RiakClient(cluster);
+        final GetCoverage cmd = new GetCoverage.Builder()
+                .withForcedUpdate()
+                .build();
+
+        final GetCoverage.Response response = client.execute(cmd);
+
+        logger.info("Got the following list of EPs: {}", response.entryPoints());
+
+        /**
+         * Since GetCoverage command is the only way to get an information about the number of available Riak nodes
+         * there is no chance to verify count of returned EPs. Therefore we will iterate through the list of the
+         * returned EPs and ping each of them to ensure that at least a valid EP was returned.
+         * */
+        verifyThatAllNodesAreAvailable(response.entryPoints());
+    }
+
+    @Test(timeout = 60000)
+    public void getCoverageForLocation() throws ExecutionException, InterruptedException, UnknownHostException {
+        final RiakClient client = new RiakClient(cluster);
+        final String key = "coverage-4-location";
+
+        // create test value
+        final RiakObject ro = new RiakObject()
+                .setValue(BinaryValue.create("{\"value\": 42}"))
+                .setContentType("application/json");
+
+        final StoreValue request = new StoreValue.Builder(ro)
+                .withLocation(new Location(defaultNamespace(), key))
+                .build();
+
+        client.execute(request);
+
+        // perform test
+        final Location location = new Location(defaultNamespace(), key);
+        logger.info("Retrieve list of EPs for location '{}' ...", location);
+
+        final GetCoverage cmd = new GetCoverage.Builder()
+                .withForcedUpdate()
+                .withLocation(location)
+                .build();
+
+        final GetCoverage.Response response = client.execute(cmd);
+        logger.info("Got the following list of EPs: {}", response.entryPoints());
+
+        /**
+         * Since GetCoverage command is the only way to get an information about the number of available Riak nodes
+         * there is no chance to verify count of returned EPs. Therefore we will iterate through the list of the
+         * returned EPs and ping each of them to ensure that at least a valid EP was returned.
+         * */
+        verifyThatAllNodesAreAvailable(response.entryPoints());
+    }
+
+    private static void verifyThatAllNodesAreAvailable(Collection<Map.Entry<String,Integer>> nodes) throws UnknownHostException, InterruptedException {
+        for(Map.Entry<String,Integer> e: nodes){
+            final RiakNode.Builder builder = new RiakNode.Builder()
+                    .withRemoteAddress(e.getKey())
+                    .withRemotePort(e.getValue())
+                    .withMinConnections(1);
+
+            logger.info("Sending ping to EP {}:{}", e.getKey(), e.getValue());
+
+            final RiakCluster c = new RiakCluster.Builder(builder.build()).build();
+            c.start();
+            try{
+                PingOperation ping = new PingOperation();
+                c.execute(ping).await();
+                assertTrue(ping.isSuccess());
+                logger.info("EP Ping {}:{}: succeeded", e.getKey(), e.getValue());
+            }finally{
+                c.shutdown();
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR utilizes API introduced by DP-6. Therefore **IT might BE MERGED ONLY when** DP-6 will be completed and all the following PRs will be merged:
-  https://github.com/basho/riak_pb/pull/106
-  https://github.com/basho/riak_api/pull/84
-  https://github.com/basho/riak_kv/pull/1087

**NOTE:**  As soon as riak_pb version with the PR mentioned above to be released, **pom.xml should be updated to use  released version of riak_pb**. Currently, since there is no released version with the required functionality, SNAPSHOT dependecy is used.
