### PR TITLE
Fixing call to JDK7+ method to maintain JDK6 Runtime compatibility

### DIFF
--- a/src/main/java/com/basho/riak/client/api/RiakClient.java
+++ b/src/main/java/com/basho/riak/client/api/RiakClient.java
@@ -262,7 +262,7 @@ public class RiakClient
         List<RiakNode> nodes = new LinkedList<RiakNode>();
         for (InetSocketAddress addy : addresses)
         {
-            builder.withRemoteAddress(addy.getHostString())
+            builder.withRemoteAddress(addy.getHostName())
                    .withRemotePort(addy.getPort());
             nodes.add(builder.build());
         }


### PR DESCRIPTION
Fix for #527 (CLIENTS-521).
- Switched out https://github.com/basho/riak-java-client/blob/develop/src/main/java/com/basho/riak/client/api/RiakClient.java#L265 - `getHostString()` for `getHostName()`, which should be in JRE6.
- https://github.com/basho/riak-java-client/blob/develop/src/test/java/com/basho/riak/client/core/fixture/NetworkTestFixture.java#L20 - `java.net.StandardSocketOptions` was introduced in JDK7, and remains as it's within a test and shouldn't be a runtime issue.
