### PR TITLE
The RiakIndex annotation should not have a default value [JIRA: CLIENTS-559]

### DIFF
--- a/src/main/java/com/basho/riak/client/api/annotations/RiakIndex.java
+++ b/src/main/java/com/basho/riak/client/api/annotations/RiakIndex.java
@@ -75,5 +75,5 @@ import java.lang.annotation.Target;
     /**
      * @return the index name
      */
-    String name() default "";
+    String name();
 }

--- a/src/test/java/com/basho/riak/client/api/convert/reflection/AnnotationUtilTest.java
+++ b/src/test/java/com/basho/riak/client/api/convert/reflection/AnnotationUtilTest.java
@@ -1248,11 +1248,11 @@ public class AnnotationUtilTest
         
         Object o = new Object()
         {
-            @RiakIndex
+            @RiakIndex(name = "")
             public void setIndex(Set<String> index)
             {}
             
-            @RiakIndex
+            @RiakIndex(name = "")
             public Set<String> getIndex() 
             {
                 return null;
@@ -1272,7 +1272,7 @@ public class AnnotationUtilTest
         
         o = new Object()
         {
-            @RiakIndex
+            @RiakIndex(name = "")
             private String index = null;
 
         };


### PR DESCRIPTION
Removed the default value from the RiakIndex annotation because it requires a value. Updated the unit tests accordingly to test if a value provided by the user is not an empty string.
