### PR TITLE
READY: Settable Default Charset

### DIFF
--- a/src/main/java/com/basho/riak/client/api/commands/indexes/BinIndexQuery.java
+++ b/src/main/java/com/basho/riak/client/api/commands/indexes/BinIndexQuery.java
@@ -24,6 +24,8 @@ import com.basho.riak.client.api.commands.indexes.SecondaryIndexQuery.IndexConve
 import com.basho.riak.client.core.query.Location;
 import com.basho.riak.client.core.query.Namespace;
 import com.basho.riak.client.core.util.BinaryValue;
+import com.basho.riak.client.core.util.DefaultCharset;
+
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
@@ -108,7 +110,7 @@ public class BinIndexQuery extends SecondaryIndexQuery<String, BinIndexQuery.Res
     
     protected static abstract class Init<S, T extends Init<S,T>> extends SecondaryIndexQuery.Init<S,T>
     {
-        private Charset charset = Charset.defaultCharset();
+        private Charset charset = DefaultCharset.get();
 
         public Init(Namespace namespace, String indexName, S start, S end)
         {

--- a/src/main/java/com/basho/riak/client/core/RiakCluster.java
+++ b/src/main/java/com/basho/riak/client/core/RiakCluster.java
@@ -641,6 +641,7 @@ public class  RiakCluster implements OperationRetrier, NodeStateListener
         private NodeManager nodeManager;
         private ScheduledExecutorService executor;
         private Bootstrap bootstrap;
+        private String defaultCharacterSet;
 
 
         /**
@@ -732,6 +733,12 @@ public class  RiakCluster implements OperationRetrier, NodeStateListener
         public Builder withOperationQueueMaxDepth(int operationQueueMaxDepth)
         {
             this.operationQueueMaxDepth = operationQueueMaxDepth;
+            return this;
+        }
+
+        public Builder withDefaultCharacterSet(String contentType)
+        {
+            this.defaultCharacterSet = contentType;
             return this;
         }
 

--- a/src/main/java/com/basho/riak/client/core/RiakCluster.java
+++ b/src/main/java/com/basho/riak/client/core/RiakCluster.java
@@ -641,8 +641,6 @@ public class  RiakCluster implements OperationRetrier, NodeStateListener
         private NodeManager nodeManager;
         private ScheduledExecutorService executor;
         private Bootstrap bootstrap;
-        private String defaultCharacterSet;
-
 
         /**
          * Instantiate a Builder containing the supplied {@link RiakNode}s
@@ -733,12 +731,6 @@ public class  RiakCluster implements OperationRetrier, NodeStateListener
         public Builder withOperationQueueMaxDepth(int operationQueueMaxDepth)
         {
             this.operationQueueMaxDepth = operationQueueMaxDepth;
-            return this;
-        }
-
-        public Builder withDefaultCharacterSet(String contentType)
-        {
-            this.defaultCharacterSet = contentType;
             return this;
         }
 

--- a/src/main/java/com/basho/riak/client/core/query/Location.java
+++ b/src/main/java/com/basho/riak/client/core/query/Location.java
@@ -17,6 +17,8 @@
 package com.basho.riak.client.core.query;
 
 import com.basho.riak.client.core.util.BinaryValue;
+import com.basho.riak.client.core.util.DefaultCharset;
+
 import java.nio.charset.Charset;
 
 /**
@@ -98,7 +100,7 @@ public final class Location
      */
     public Location(Namespace namespace, String key)
     {
-        this(namespace, key, Charset.defaultCharset());
+        this(namespace, key, DefaultCharset.get());
     }
     
     /**

--- a/src/main/java/com/basho/riak/client/core/query/Namespace.java
+++ b/src/main/java/com/basho/riak/client/core/query/Namespace.java
@@ -17,6 +17,8 @@
 package com.basho.riak.client.core.query;
 
 import com.basho.riak.client.core.util.BinaryValue;
+import com.basho.riak.client.core.util.DefaultCharset;
+
 import java.nio.charset.Charset;
 
 /**
@@ -117,7 +119,7 @@ public class Namespace
      */
     public Namespace(String bucketType, String bucketName)
     {
-        this(bucketType, bucketName, Charset.defaultCharset());
+        this(bucketType, bucketName, DefaultCharset.get());
     }
     
     /**
@@ -166,7 +168,7 @@ public class Namespace
      */
     public Namespace(String bucketName)
     {
-        this(bucketName, Charset.defaultCharset());
+        this(bucketName, DefaultCharset.get());
     }
     
     /**

--- a/src/main/java/com/basho/riak/client/core/query/UserMetadata/RiakUserMetadata.java
+++ b/src/main/java/com/basho/riak/client/core/query/UserMetadata/RiakUserMetadata.java
@@ -16,6 +16,8 @@
 package com.basho.riak.client.core.query.UserMetadata;
 
 import com.basho.riak.client.core.util.BinaryValue;
+import com.basho.riak.client.core.util.DefaultCharset;
+
 import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.Map;
@@ -63,7 +65,7 @@ public class RiakUserMetadata
      */
     public boolean containsKey(String key)
     {
-        return containsKey(key, Charset.defaultCharset());
+        return containsKey(key, DefaultCharset.get());
     }
     
     /**
@@ -90,7 +92,7 @@ public class RiakUserMetadata
      */
     public String get(String key)
     {
-        return get(key, Charset.defaultCharset());
+        return get(key, DefaultCharset.get());
     }
     
     /**
@@ -155,7 +157,7 @@ public class RiakUserMetadata
      */
     public void put(String key, String value)
     {
-        put(key, value, Charset.defaultCharset());
+        put(key, value, DefaultCharset.get());
     }
     
     /**
@@ -201,7 +203,7 @@ public class RiakUserMetadata
     
     public void remove (String key)
     {
-        remove(key, Charset.defaultCharset());
+        remove(key, DefaultCharset.get());
     }
     
     // TODO: deal with charset. Should add to annotation

--- a/src/main/java/com/basho/riak/client/core/query/indexes/StringBinIndex.java
+++ b/src/main/java/com/basho/riak/client/core/query/indexes/StringBinIndex.java
@@ -17,6 +17,8 @@ package com.basho.riak.client.core.query.indexes;
 
 import com.basho.riak.client.core.query.RiakObject;
 import com.basho.riak.client.core.util.BinaryValue;
+import com.basho.riak.client.core.util.DefaultCharset;
+
 import java.nio.charset.Charset;
 
 /**
@@ -66,7 +68,7 @@ public class StringBinIndex extends RiakIndex<String>
     
     public static Name named(String name)
     {
-        return named(name, Charset.defaultCharset());
+        return named(name, DefaultCharset.get());
     }
     
     public static Name named(String name, Charset charset)
@@ -88,7 +90,7 @@ public class StringBinIndex extends RiakIndex<String>
          */
         Name(String name)
         {
-            this(name, Charset.defaultCharset());
+            this(name, DefaultCharset.get());
         }
         /**
          * Constructs a RiakIndex.Name to be used with {@link RiakIndexes}

--- a/src/main/java/com/basho/riak/client/core/query/links/RiakLink.java
+++ b/src/main/java/com/basho/riak/client/core/query/links/RiakLink.java
@@ -16,6 +16,8 @@
 package com.basho.riak.client.core.query.links;
 
 import com.basho.riak.client.core.util.BinaryValue;
+import com.basho.riak.client.core.util.DefaultCharset;
+
 import java.nio.charset.Charset;
 
 /**
@@ -53,7 +55,7 @@ public class RiakLink
      */
     public RiakLink(String bucket, String key, String tag)
     {
-        this(bucket, key, tag, Charset.defaultCharset());
+        this(bucket, key, tag, DefaultCharset.get());
     }
 
     /**

--- a/src/main/java/com/basho/riak/client/core/util/BinaryValue.java
+++ b/src/main/java/com/basho/riak/client/core/util/BinaryValue.java
@@ -75,7 +75,7 @@ public final class BinaryValue
      */
     public static BinaryValue create(String data)
     {
-        return create(data, Charset.defaultCharset());
+        return create(data, DefaultCharset.get());
     }
     
     /**
@@ -185,7 +185,7 @@ public final class BinaryValue
     @Override
     public String toString()
     {
-        return toString(Charset.defaultCharset());
+        return toString(DefaultCharset.get());
     }
     
     /**

--- a/src/main/java/com/basho/riak/client/core/util/Constants.java
+++ b/src/main/java/com/basho/riak/client/core/util/Constants.java
@@ -97,5 +97,6 @@ public interface Constants {
     public static final String RESPONSE_HANDLER = "responseHandler";
     public static final String SSL_HANDLER = "sslHandler";
     public static final String HEALTHCHECK_CODEC = "healthCheckCodec";
-    
+
+    public static final String CLIENT_OPTION_CHARSET = "com.basho.riak.client.DefaultCharset";
 }

--- a/src/main/java/com/basho/riak/client/core/util/DefaultCharset.java
+++ b/src/main/java/com/basho/riak/client/core/util/DefaultCharset.java
@@ -8,7 +8,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * <p>
- *     Holds an application-wide default charset, that
+ *     Holds an classloader-wide default charset, that
  *     is then used to encode/decode between Strings and
  *     Byte arrays for Riak's use (see {@link com.basho.riak.client.core.util.BinaryValue}).
  *</p>
@@ -79,8 +79,8 @@ public final class DefaultCharset
     }
 
     /**
-     * Get the current application-wide default Charset for the Riak client.
-     * @return The current application-wide default charset.
+     * Get the current classloader-wide default Charset for the Riak client.
+     * @return The current classloader-wide default charset.
      */
     public static Charset get()
     {
@@ -88,8 +88,8 @@ public final class DefaultCharset
     }
 
     /**
-     * Set the application-wide default Charset for the Riak client.
-     * @param charset The charset to set the application-wide default to.
+     * Set the classloader-wide default Charset for the Riak client.
+     * @param charset The charset to set the classloader-wide default to.
      */
     public static void set(Charset charset)
     {

--- a/src/main/java/com/basho/riak/client/core/util/DefaultCharset.java
+++ b/src/main/java/com/basho/riak/client/core/util/DefaultCharset.java
@@ -1,0 +1,43 @@
+package com.basho.riak.client.core.util;
+
+import java.nio.charset.Charset;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ *
+ */
+public final class DefaultCharset
+{
+    private final AtomicReference<Charset> currentCharset;
+    private static DefaultCharset instance = initializeDefaultCharsetSingleton();
+
+    private static DefaultCharset initializeDefaultCharsetSingleton()
+    {
+        Charset charset = Charset.defaultCharset();
+
+        String declaredCharsetName = System.getProperty(Constants.CLIENT_OPTION_CHARSET);
+        if(declaredCharsetName != null && !declaredCharsetName.isEmpty())
+        {
+            Charset declaredCharset = Charset.forName(declaredCharsetName);
+            charset = declaredCharset;
+        }
+
+        return new DefaultCharset(charset);
+    }
+
+    private DefaultCharset(Charset c)
+    {
+        this.currentCharset = new AtomicReference<Charset>(c);
+    }
+
+
+    public static Charset get()
+    {
+        return instance.currentCharset.get();
+    }
+
+    public static void set(Charset charset)
+    {
+        instance.currentCharset.set(charset);
+    }
+}

--- a/src/main/java/com/basho/riak/client/core/util/DefaultCharset.java
+++ b/src/main/java/com/basho/riak/client/core/util/DefaultCharset.java
@@ -1,5 +1,8 @@
 package com.basho.riak.client.core.util;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.nio.charset.Charset;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -8,8 +11,16 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public final class DefaultCharset
 {
+    private static final Logger logger = LoggerFactory.getLogger(DefaultCharset.class);
+    private final static DefaultCharset instance = initializeDefaultCharsetSingleton();
+
     private final AtomicReference<Charset> currentCharset;
-    private static DefaultCharset instance = initializeDefaultCharsetSingleton();
+
+    private DefaultCharset(Charset c)
+    {
+        LogCharsetChange(c);
+        this.currentCharset = new AtomicReference<Charset>(c);
+    }
 
     private static DefaultCharset initializeDefaultCharsetSingleton()
     {
@@ -25,11 +36,10 @@ public final class DefaultCharset
         return new DefaultCharset(charset);
     }
 
-    private DefaultCharset(Charset c)
+    private static void LogCharsetChange(Charset charset)
     {
-        this.currentCharset = new AtomicReference<Charset>(c);
+        logger.info("Setting client charset to: {}", charset.name());
     }
-
 
     public static Charset get()
     {
@@ -38,6 +48,7 @@ public final class DefaultCharset
 
     public static void set(Charset charset)
     {
+        LogCharsetChange(charset);
         instance.currentCharset.set(charset);
     }
 }

--- a/src/main/java/com/basho/riak/client/core/util/DefaultCharset.java
+++ b/src/main/java/com/basho/riak/client/core/util/DefaultCharset.java
@@ -8,41 +8,42 @@ import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * <p>
- *     Holds an classloader-wide default charset, that
- *     is then used to encode/decode between Strings and
- *     Byte arrays for Riak's use (see {@link com.basho.riak.client.core.util.BinaryValue}).
- *</p>
- *
+ * Holds an classloader-wide default charset, that
+ * is then used to encode/decode between Strings and
+ * Byte arrays for Riak's use (see {@link com.basho.riak.client.core.util.BinaryValue}).
+ * </p>
+ * <p/>
  * <p>
- *     Before 2.0.3, the system used the JRE's default Charset from the
- *     {@link Charset#defaultCharset()} property.
- *</p>
- *
+ * Before 2.0.3, the system used the JRE's default Charset from the
+ * {@link Charset#defaultCharset()} property.
+ * </p>
+ * <p/>
  * <p>
- *     With this class you may change the Riak client to use a different default.
- *     You can set it at startup by providing the desired Charset name with the vm argument
- *     {@code -Dcom.basho.riak.client.DefaultCharset="UTF-8"}, or at runtime
- *     with the static method (see {@link #set(Charset)}).
+ * With this class you may change the Riak client to use a different default.
+ * You can set it at startup by providing the desired Charset name with the vm argument
+ * {@code -Dcom.basho.riak.client.DefaultCharset="UTF-8"}, or at runtime
+ * with the static method (see {@link #set(Charset)}).
+ * </p>
+ * <p/>
+ * <p>
+ * As of 2.0.3 it still defaults to the value provided by
+ * {@link Charset#defaultCharset()},
+ * but the default is planned to change to "UTF-8" with 2.1.0.
+ * </p>
+ * <p/>
+ * <p>
+ * If your JRE default charset is one of "<b>US-ASCII</b>",
+ * "<b>UTF-8</b>", or "<b>ISO-8859-1</b>",
+ * this change should <b>not</b> affect you.
+ * </p>
+ * <p/>
+ * <p>
+ * If your JRE default charset is one of "<b>UTF-16</b>",
+ * "<b>UTF-16BE</b>", or "<b>UTF-16LE</b>",
+ * <b>you will need to set that default on the command line or
+ * after application startup once you upgrade</b>.
  * </p>
  *
- * <p>
- *     As of 2.0.3 it still defaults to the value provided by
- *     {@link Charset#defaultCharset()},
- *     but the default is planned to change to "UTF-8" with 2.1.0.
- * </p>
- *
- * <p>
- *     If your JRE default charset is one of "<b>US-ASCII</b>",
- *     "<b>UTF-8</b>", or "<b>ISO-8859-1</b>",
- *     this change should <b>not</b> affect you.
- * </p>
- *
- * <p>
- *     If your JRE default charset is one of "<b>UTF-16</b>",
- *     "<b>UTF-16BE</b>", or "<b>UTF-16LE</b>",
- *     <b>you will need to set that default on the command line or
- *     after application startup once you upgrade</b>.
- * </p>
  * @author Alex Moore <amoore AT basho dot com>
  * @since 2.0.3
  */
@@ -66,7 +67,7 @@ public final class DefaultCharset
         final Charset systemDefault = Charset.defaultCharset();
         final String declaredCharsetName = System.getProperty(Constants.CLIENT_OPTION_CHARSET);
 
-        if(declaredCharsetName != null && !declaredCharsetName.isEmpty())
+        if (declaredCharsetName != null && !declaredCharsetName.isEmpty())
         {
             try
             {
@@ -82,7 +83,8 @@ public final class DefaultCharset
         }
         else
         {
-            logger.info("No declared charset found, the default charset '{}' will be used", systemDefault.name());
+            logger.info("No desired charset found in system properties, the default charset '{}' will be used",
+                        systemDefault.name());
             charset = systemDefault;
         }
 
@@ -91,6 +93,7 @@ public final class DefaultCharset
 
     /**
      * Get the current classloader-wide default Charset for the Riak client.
+     *
      * @return The current classloader-wide default charset.
      */
     public static Charset get()
@@ -100,6 +103,7 @@ public final class DefaultCharset
 
     /**
      * Set the classloader-wide default Charset for the Riak client.
+     *
      * @param charset The charset to set the classloader-wide default to.
      */
     public static void set(Charset charset)

--- a/src/main/java/com/basho/riak/client/core/util/DefaultCharset.java
+++ b/src/main/java/com/basho/riak/client/core/util/DefaultCharset.java
@@ -7,8 +7,46 @@ import java.nio.charset.Charset;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
+ * <p>
+ *     Holds an application-wide default charset, that
+ *     is then used to encode/decode between Strings and
+ *     Byte arrays for Riak's use (see {@link com.basho.riak.client.core.util.BinaryValue}).
+ *</p>
  *
+ * <p>
+ *     Before 2.0.3, the system used the JRE's default Charset from the
+ *     {@link Charset#defaultCharset()} property.
+ *</p>
+ *
+ * <p>
+ *     With this class you may change the Riak client to use a different default.
+ *     You can set it at startup by providing the desired Charset name with the vm argument
+ *     {@code -Dcom.basho.riak.client.DefaultCharset="UTF-8"}, or at runtime
+ *     with the static method (see {@link #set(Charset)}).
+ * </p>
+ *
+ * <p>
+ *     As of 2.0.3 it still defaults to the value provided by
+ *     {@link Charset#defaultCharset()},
+ *     but the default is planned to change to "UTF-8" with 2.1.0.
+ * </p>
+ *
+ * <p>
+ *     If your JRE default charset is one of "<b>US-ASCII</b>",
+ *     "<b>UTF-8</b>", or "<b>ISO-8859-1</b>",
+ *     this change should <b>not</b> affect you.
+ * </p>
+ *
+ * <p>
+ *     If your JRE default charset is one of "<b>UTF-16</b>",
+ *     "<b>UTF-16BE</b>", or "<b>UTF-16LE</b>",
+ *     <b>you will need to set that default on the command line or
+ *     after application startup once you upgrade</b>.
+ * </p>
+ * @author Alex Moore <amoore AT basho dot com>
+ * @since 2.0.3
  */
+
 public final class DefaultCharset
 {
     private static final Logger logger = LoggerFactory.getLogger(DefaultCharset.class);
@@ -29,8 +67,7 @@ public final class DefaultCharset
         String declaredCharsetName = System.getProperty(Constants.CLIENT_OPTION_CHARSET);
         if(declaredCharsetName != null && !declaredCharsetName.isEmpty())
         {
-            Charset declaredCharset = Charset.forName(declaredCharsetName);
-            charset = declaredCharset;
+            charset = Charset.forName(declaredCharsetName);
         }
 
         return new DefaultCharset(charset);
@@ -41,11 +78,19 @@ public final class DefaultCharset
         logger.info("Setting client charset to: {}", charset.name());
     }
 
+    /**
+     * Get the current application-wide default Charset for the Riak client.
+     * @return The current application-wide default charset.
+     */
     public static Charset get()
     {
         return instance.currentCharset.get();
     }
 
+    /**
+     * Set the application-wide default Charset for the Riak client.
+     * @param charset The charset to set the application-wide default to.
+     */
     public static void set(Charset charset)
     {
         LogCharsetChange(charset);

--- a/src/test/java/com/basho/riak/client/core/util/DefaultCharsetTest.java
+++ b/src/test/java/com/basho/riak/client/core/util/DefaultCharsetTest.java
@@ -80,6 +80,10 @@ public class DefaultCharsetTest
             {
                 System.setProperty(Constants.CLIENT_OPTION_CHARSET, definedCharsetName);
             }
+            else
+            {
+                System.clearProperty(Constants.CLIENT_OPTION_CHARSET);
+            }
         }
     }
 
@@ -117,6 +121,10 @@ public class DefaultCharsetTest
             if (definedCharsetName != null)
             {
                 System.setProperty(Constants.CLIENT_OPTION_CHARSET, definedCharsetName);
+            }
+            else
+            {
+                System.clearProperty(Constants.CLIENT_OPTION_CHARSET);
             }
         }
     }

--- a/src/test/java/com/basho/riak/client/core/util/DefaultCharsetTest.java
+++ b/src/test/java/com/basho/riak/client/core/util/DefaultCharsetTest.java
@@ -1,0 +1,49 @@
+package com.basho.riak.client.core.util;
+
+import java.nio.charset.Charset;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class DefaultCharsetTest
+{
+    @Test
+    public void testDefaults()
+    {
+        Charset systemDefault = Charset.defaultCharset();
+        Charset clientDefault = DefaultCharset.get();
+
+        String definedCharsetName = System.getProperty(Constants.CLIENT_OPTION_CHARSET);
+
+        if(definedCharsetName == null || definedCharsetName.isEmpty())
+        {
+            assertEquals(systemDefault, clientDefault);
+        }
+        else
+        {
+            Charset definedCharset = Charset.forName(definedCharsetName);
+            assertEquals(definedCharset, clientDefault);
+        }
+    }
+
+    @Test
+    public void testRuntimeSetCharset()
+    {
+        Charset systemDefault = Charset.defaultCharset();
+        Charset ascii = Charset.forName("US-ASCII");
+        Charset utf8 = Charset.forName("UTF-8");
+
+        if(systemDefault != utf8)
+        {
+            DefaultCharset.set(utf8);
+            Charset clientCharset = DefaultCharset.get();
+            assertEquals(utf8, clientCharset);
+        }
+        else
+        {
+            DefaultCharset.set(ascii);
+            Charset clientCharset = DefaultCharset.get();
+            assertEquals(ascii, clientCharset);
+        }
+    }
+}

--- a/src/test/java/com/basho/riak/client/core/util/DefaultCharsetTest.java
+++ b/src/test/java/com/basho/riak/client/core/util/DefaultCharsetTest.java
@@ -1,28 +1,123 @@
 package com.basho.riak.client.core.util;
 
-import java.nio.charset.Charset;
-
+import org.junit.Assume;
 import org.junit.Test;
-import static org.junit.Assert.*;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.charset.Charset;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
 
 public class DefaultCharsetTest
 {
     @Test
-    public void testDefaults()
+    public void testDefaultIfNoPropertyDefined()
     {
         Charset systemDefault = Charset.defaultCharset();
         Charset clientDefault = DefaultCharset.get();
 
         String definedCharsetName = System.getProperty(Constants.CLIENT_OPTION_CHARSET);
 
-        if(definedCharsetName == null || definedCharsetName.isEmpty())
+        Boolean noCharsetPropertyDefined = definedCharsetName == null;
+        Assume.assumeTrue(noCharsetPropertyDefined);
+
+        assertEquals(systemDefault, clientDefault);
+    }
+
+    @Test
+    public void testDefinedCharset()
+    {
+        Charset clientDefault = DefaultCharset.get();
+
+        String definedCharsetName = System.getProperty(Constants.CLIENT_OPTION_CHARSET);
+
+        Boolean charsetPropertyDefined = definedCharsetName != null && !definedCharsetName.isEmpty();
+
+        Assume.assumeTrue(charsetPropertyDefined);
+
+        Charset definedCharset = Charset.forName(definedCharsetName);
+        assertEquals(definedCharset, clientDefault);
+    }
+
+    @Test
+    public void testStaticInitializerValidDefinedCharset()
+            throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, NoSuchFieldException
+    {
+        String definedCharsetName = System.getProperty(Constants.CLIENT_OPTION_CHARSET);
+        Charset systemDefault = Charset.defaultCharset();
+        String goodCharsetName = "UTF-16";
+
+        try
         {
-            assertEquals(systemDefault, clientDefault);
+            Charset goodCharset = Charset.forName(goodCharsetName);
+
+            // Open up the private static initializer
+            Method staticInitializer = DefaultCharset.class.getDeclaredMethod("initializeDefaultCharsetSingleton",
+                                                                              null);
+            staticInitializer.setAccessible(true);
+
+            // Set system property for client charset to bad value
+            System.setProperty(Constants.CLIENT_OPTION_CHARSET, goodCharsetName);
+
+            // Run static initializer to test good charset handling
+            DefaultCharset initializedDefaultCharset = (DefaultCharset) staticInitializer.invoke(null);
+
+            // Get initialized charset
+            Field currentCharsetField = DefaultCharset.class.getDeclaredField("currentCharset");
+            currentCharsetField.setAccessible(true);
+            AtomicReference<Charset> initializedCharset =
+                    (AtomicReference<Charset>)currentCharsetField.get(initializedDefaultCharset);
+
+            assertEquals(goodCharset.name(), initializedCharset.get().name());
         }
-        else
+        finally
         {
-            Charset definedCharset = Charset.forName(definedCharsetName);
-            assertEquals(definedCharset, clientDefault);
+            // Cleanup
+            if (definedCharsetName != null)
+            {
+                System.setProperty(Constants.CLIENT_OPTION_CHARSET, definedCharsetName);
+            }
+        }
+    }
+
+    @Test
+    public void testStaticInitializerInvalidDefinedCharset()
+            throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, NoSuchFieldException
+    {
+        String definedCharsetName = System.getProperty(Constants.CLIENT_OPTION_CHARSET);
+        Charset systemDefault = Charset.defaultCharset();
+        String badCharsetName = "Foobar-16NE";
+
+        try
+        {
+            // Open up the private static initializer
+            Method staticInitializer = DefaultCharset.class.getDeclaredMethod("initializeDefaultCharsetSingleton",
+                                                                              null);
+            staticInitializer.setAccessible(true);
+
+            // Set system property for client charset to bad value
+            System.setProperty(Constants.CLIENT_OPTION_CHARSET, badCharsetName);
+
+            // Run static initializer to test bad charset handling
+            DefaultCharset initializedDefaultCharset = (DefaultCharset) staticInitializer.invoke(null);
+
+            Field currentCharsetField = DefaultCharset.class.getDeclaredField("currentCharset");
+            currentCharsetField.setAccessible(true);
+            AtomicReference<Charset> initializedCharset =
+                    (AtomicReference<Charset>)currentCharsetField.get(initializedDefaultCharset);
+
+            assertEquals(systemDefault.name(), initializedCharset.get().name());
+        }
+        finally
+        {
+            // Cleanup
+            if (definedCharsetName != null)
+            {
+                System.setProperty(Constants.CLIENT_OPTION_CHARSET, definedCharsetName);
+            }
         }
     }
 
@@ -33,7 +128,7 @@ public class DefaultCharsetTest
         Charset ascii = Charset.forName("US-ASCII");
         Charset utf8 = Charset.forName("UTF-8");
 
-        if(systemDefault != utf8)
+        if (systemDefault != utf8)
         {
             DefaultCharset.set(utf8);
             Charset clientCharset = DefaultCharset.get();


### PR DESCRIPTION
This is from a customer request (JIRA CLIENTS-547), to have a settable default charset. Currently it's set to the JRE's default, which can change from machine to machine.   

You can set it from the static [`set()`](https://github.com/basho/riak-java-client/pull/550/files#diff-4a31b593bfc4aa074e9f6cb60083dc5eR94) method on the `DefaultCharset` class, or from the command line by providing the charset name with the arg `com.basho.riak.client.DefaultCharset`. (e.g. `java -Dcom.basho.riak.client.DefaultCharset="UTF-8" ...`)

Rendered Javadocs:
![defaultcharset__riak_client_for_java_2_0_3-snapshot_api_](https://cloud.githubusercontent.com/assets/1438/10051772/40355cf8-61f1-11e5-97b0-7ccf0ec404ec.jpg)
