### PR TITLE
CLIENTS-614: Removed superfluous declarations of UnknownHostException.

### DIFF
--- a/src/main/java/com/basho/riak/client/core/RiakCluster.java
+++ b/src/main/java/com/basho/riak/client/core/RiakCluster.java
@@ -71,7 +71,7 @@ public class  RiakCluster implements OperationRetrier, NodeStateListener
     private volatile State state;
     private final CountDownLatch shutdownLatch = new CountDownLatch(1);
 
-    private RiakCluster(Builder builder) throws UnknownHostException
+    private RiakCluster(Builder builder)
     {
         this.executionAttempts = builder.executionAttempts;
         this.queueOperations =  builder.operationQueueMaxDepth > 0;
@@ -737,9 +737,8 @@ public class  RiakCluster implements OperationRetrier, NodeStateListener
         /**
          * Instantiates the {@link RiakCluster}
          * @return a new RiakCluster
-         * @throws UnknownHostException if a node fails to start due to a DNS lookup
          */
-        public RiakCluster build() throws UnknownHostException
+        public RiakCluster build()
         {
             return new RiakCluster(this);
         }

--- a/src/main/java/com/basho/riak/client/core/RiakNode.java
+++ b/src/main/java/com/basho/riak/client/core/RiakNode.java
@@ -169,7 +169,7 @@ public class RiakNode implements RiakResponseListener
 
     private final CountDownLatch shutdownLatch = new CountDownLatch(1);
 
-    private RiakNode(Builder builder) throws UnknownHostException
+    private RiakNode(Builder builder)
     {
         this.executor = builder.executor;
         this.connectionTimeout = builder.connectionTimeout;
@@ -1476,9 +1476,8 @@ public class RiakNode implements RiakResponseListener
          * will be created.
          *
          * @return a new Riaknode
-         * @throws UnknownHostException if the DNS lookup fails for the supplied hostname
          */
-        public RiakNode build() throws UnknownHostException
+        public RiakNode build()
         {
             return new RiakNode(this);
         }
@@ -1492,10 +1491,8 @@ public class RiakNode implements RiakResponseListener
          * @param builder         a configured builder
          * @param remoteAddresses a list of IP addresses or FQDN
          * @return a list of constructed RiakNodes
-         * @throws UnknownHostException if a supplied FQDN can not be resolved.
          */
         public static List<RiakNode> buildNodes(Builder builder, List<String> remoteAddresses)
-            throws UnknownHostException
         {
             List<RiakNode> nodes = new ArrayList<RiakNode>(remoteAddresses.size());
             for (String remoteAddress : remoteAddresses)

--- a/src/test/java/com/basho/riak/client/core/RiakClusterTest.java
+++ b/src/test/java/com/basho/riak/client/core/RiakClusterTest.java
@@ -18,7 +18,6 @@ package com.basho.riak.client.core;
 import com.google.protobuf.Message;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.verification.VerificationMode;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -26,7 +25,6 @@ import org.powermock.reflect.Whitebox;
 
 import java.net.UnknownHostException;
 import java.util.List;
-import java.util.Random;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.LinkedBlockingQueue;
 
@@ -45,7 +43,7 @@ import static org.mockito.Mockito.*;
 public class RiakClusterTest
 {
     @Test
-    public void builderCreatesCluster() throws UnknownHostException
+    public void builderCreatesCluster()
     {
         RiakNode.Builder nodeBuilder = new RiakNode.Builder();
         RiakCluster cluster = new RiakCluster.Builder(nodeBuilder.build()).build();
@@ -67,7 +65,7 @@ public class RiakClusterTest
     }
     
     @Test
-    public void removeNodeFromCluster() throws UnknownHostException
+    public void removeNodeFromCluster()
     {
         NodeManager nodeManager = mock(NodeManager.class);
         RiakNode node = mock(RiakNode.class);
@@ -82,7 +80,7 @@ public class RiakClusterTest
     }
     
     @Test
-    public void allNodesShutdownStopsCluster() throws UnknownHostException
+    public void allNodesShutdownStopsCluster()
     {
         NodeManager nodeManager = mock(NodeManager.class);
         RiakNode node = mock(RiakNode.class);
@@ -98,7 +96,7 @@ public class RiakClusterTest
     
     @Test
     @SuppressWarnings("unchecked")
-    public void clusterExecutesOperation() throws UnknownHostException
+    public void clusterExecutesOperation()
     {
         NodeManager nodeManager = mock(NodeManager.class);
         FutureOperation operation = PowerMockito.mock(FutureOperation.class);

--- a/src/test/java/com/basho/riak/client/core/RiakNodeFixtureTest.java
+++ b/src/test/java/com/basho/riak/client/core/RiakNodeFixtureTest.java
@@ -49,7 +49,7 @@ public class RiakNodeFixtureTest extends FixtureTest
 {
     
     @Test
-    public void closedConnectionsTriggerHealthCheck() throws UnknownHostException, InterruptedException, Exception
+    public void closedConnectionsTriggerHealthCheck() throws InterruptedException, Exception
     {
         RiakNode node = new RiakNode.Builder()
                                .withRemotePort(startingPort + NetworkTestFixture.ACCEPT_THEN_CLOSE)
@@ -65,7 +65,7 @@ public class RiakNodeFixtureTest extends FixtureTest
     }
     
     @Test
-    public void failedConnectionsTriggerHealthCheck() throws UnknownHostException, InterruptedException, Exception
+    public void failedConnectionsTriggerHealthCheck() throws InterruptedException, Exception
     {
         RiakNode node = new RiakNode.Builder()
                                .withRemotePort(startingPort + NetworkTestFixture.NO_LISTENER)
@@ -81,7 +81,7 @@ public class RiakNodeFixtureTest extends FixtureTest
     }
         
     @Test
-    public void operationFailuresTriggerHealthCheck() throws UnknownHostException, InterruptedException, Exception
+    public void operationFailuresTriggerHealthCheck() throws InterruptedException, Exception
     {
         RiakNode node = 
             new RiakNode.Builder()
@@ -113,7 +113,7 @@ public class RiakNodeFixtureTest extends FixtureTest
     }
     
     @Test
-    public void idleConnectionsAreRemoved() throws UnknownHostException, InterruptedException, Exception
+    public void idleConnectionsAreRemoved() throws InterruptedException, Exception
     {
         RiakNode node = new RiakNode.Builder()
                                .withRemotePort(startingPort + NetworkTestFixture.PB_FULL_WRITE_STAY_OPEN)
@@ -150,7 +150,7 @@ public class RiakNodeFixtureTest extends FixtureTest
     }
     
     @Test
-    public void nodeGoingDown() throws UnknownHostException, IOException, InterruptedException, ExecutionException
+    public void nodeGoingDown() throws IOException, InterruptedException, ExecutionException
     {
         RiakNode node = new RiakNode.Builder()
                                .withRemotePort(startingPort + NetworkTestFixture.PB_FULL_WRITE_STAY_OPEN)
@@ -178,7 +178,7 @@ public class RiakNodeFixtureTest extends FixtureTest
     }
     
     @Test
-    public void nodeRecovery() throws UnknownHostException, IOException, InterruptedException, ExecutionException
+    public void nodeRecovery() throws IOException, InterruptedException, ExecutionException
     {
         RiakNode node = new RiakNode.Builder()
                                .withRemotePort(startingPort + NetworkTestFixture.PB_FULL_WRITE_STAY_OPEN)
@@ -262,7 +262,7 @@ public class RiakNodeFixtureTest extends FixtureTest
     }
 
     @Test
-    public void nodeChangesStateOnPoolState() throws UnknownHostException, IOException, InterruptedException, ExecutionException
+    public void nodeChangesStateOnPoolState() throws IOException, InterruptedException, ExecutionException
     {
         RiakNode node = 
             new RiakNode.Builder()

--- a/src/test/java/com/basho/riak/client/core/RiakNodeTest.java
+++ b/src/test/java/com/basho/riak/client/core/RiakNodeTest.java
@@ -15,22 +15,13 @@
  */
 package com.basho.riak.client.core;
 
-import static com.jayway.awaitility.Awaitility.await;
-import static com.jayway.awaitility.Awaitility.fieldIn;
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import com.basho.riak.client.core.RiakNode.State;
+import com.google.protobuf.Message;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelPipeline;
-
 import java.net.UnknownHostException;
 import java.util.Deque;
 import java.util.List;
@@ -38,16 +29,17 @@ import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
-
-import com.basho.riak.client.core.RiakNode.State;
-import com.google.protobuf.Message;
+import static com.jayway.awaitility.Awaitility.await;
+import static com.jayway.awaitility.Awaitility.fieldIn;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 
 /**
@@ -59,7 +51,7 @@ import com.google.protobuf.Message;
 public class RiakNodeTest
 {
     @Test
-    public void builderProducesDefaultNode() throws UnknownHostException
+    public void builderProducesDefaultNode()
     {
         RiakNode node = new RiakNode.Builder().build();
 
@@ -74,7 +66,7 @@ public class RiakNodeTest
     }
 
     @Test
-    public void builderProducesCorrectNode() throws UnknownHostException
+    public void builderProducesCorrectNode()
     {
         final int IDLE_TIMEOUT = 2000;
         final int CONNECTION_TIMEOUT = 2001;
@@ -113,7 +105,7 @@ public class RiakNodeTest
     }
 
     @Test
-    public void nodeRegistersListeners() throws UnknownHostException
+    public void nodeRegistersListeners()
     {
         RiakNode node = new RiakNode.Builder().build();
         NodeStateListener listener = mock(NodeStateListener.class);
@@ -124,7 +116,7 @@ public class RiakNodeTest
 
 
     @Test
-    public void nodeNotifiesListeners() throws UnknownHostException, Exception
+    public void nodeNotifiesListeners() throws Exception
     {
         RiakNode node = new RiakNode.Builder().build();
         NodeStateListener listener = mock(NodeStateListener.class);
@@ -161,7 +153,7 @@ public class RiakNodeTest
     }
 
     @Test
-    public void NodeRespectsMax() throws InterruptedException, UnknownHostException, Exception
+    public void NodeRespectsMax() throws InterruptedException, Exception
     {
         final int MAX_CONNECTIONS = 2;
 
@@ -197,7 +189,7 @@ public class RiakNodeTest
     }
 
     @Test
-    public void channelsReturnedCorrectly() throws InterruptedException, UnknownHostException, Exception
+    public void channelsReturnedCorrectly() throws InterruptedException, Exception
     {
         final int MAX_CONNECTIONS = 1;
 
@@ -229,7 +221,7 @@ public class RiakNodeTest
 
     @Test
     public void healthCheckChangesState()
-        throws InterruptedException, UnknownHostException, Exception
+        throws InterruptedException, Exception
     {
         ChannelFuture future = mock(ChannelFuture.class);
         Channel c = mock(Channel.class);
@@ -262,7 +254,7 @@ public class RiakNodeTest
     }
 
     @Test
-    public void idleReaperTest() throws InterruptedException, UnknownHostException, Exception
+    public void idleReaperTest() throws InterruptedException, Exception
     {
 
         ChannelFuture future = mock(ChannelFuture.class);

--- a/src/test/java/com/basho/riak/client/core/operations/itest/ITestBase.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/ITestBase.java
@@ -31,7 +31,6 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.UnknownHostException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -42,7 +41,6 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Semaphore;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -71,7 +69,7 @@ public abstract class ITestBase
     protected static final int NUMBER_OF_PARALLEL_REQUESTS = 10;
 
     @BeforeClass
-    public static void setUp() throws UnknownHostException, FileNotFoundException, CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException
+    public static void setUp() throws FileNotFoundException, CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException
     {
         bucketName = BinaryValue.unsafeCreate("ITestBase".getBytes());
         

--- a/src/test/java/com/basho/riak/client/core/operations/itest/RiakJKSConnection.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/RiakJKSConnection.java
@@ -1,7 +1,6 @@
 package com.basho.riak.client.core.operations.itest;
 
 import java.io.IOException;
-import java.net.UnknownHostException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -46,13 +45,8 @@ public class RiakJKSConnection {
      * @return Riak Cluster object based on builder properties
      */
     private static RiakCluster initializeRiakCluster(RiakNode.Builder builder){
-        RiakCluster cluster = null;
-        try {
-            cluster = new RiakCluster.Builder(builder.build()).build();
-            cluster.start();
-        } catch (UnknownHostException e) {
-            e.printStackTrace();
-        }
+        RiakCluster cluster = new RiakCluster.Builder(builder.build()).build();
+        cluster.start();
         return cluster;
     }
 

--- a/src/test/java/com/basho/riak/client/core/operations/itest/RiakPemConnection.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/RiakPemConnection.java
@@ -1,8 +1,10 @@
 package com.basho.riak.client.core.operations.itest;
 
+import com.basho.riak.client.api.RiakClient;
+import com.basho.riak.client.core.RiakCluster;
+import com.basho.riak.client.core.RiakNode;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.UnknownHostException;
 import java.security.KeyFactory;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -14,12 +16,7 @@ import java.security.cert.X509Certificate;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.KeySpec;
 import java.security.spec.PKCS8EncodedKeySpec;
-
 import sun.misc.BASE64Decoder;
-
-import com.basho.riak.client.api.RiakClient;
-import com.basho.riak.client.core.RiakCluster;
-import com.basho.riak.client.core.RiakNode;
 
 public class RiakPemConnection {
 
@@ -114,13 +111,8 @@ public class RiakPemConnection {
      * @return Riak Cluster object based on builder properties
      */
     private static RiakCluster initializeRiakCluster(RiakNode.Builder builder){
-        RiakCluster cluster = null;
-        try {
-            cluster = new RiakCluster.Builder(builder.build()).build();
-            cluster.start();
-        } catch (UnknownHostException e) {
-            e.printStackTrace();
-        }
+        RiakCluster cluster = new RiakCluster.Builder(builder.build()).build();
+        cluster.start();
         return cluster;
     }
 


### PR DESCRIPTION
Fix for https://github.com/basho/riak-java-client/issues/552.
