### PR TITLE
RiakObject equals(), hashCode() and toString()

### DIFF
--- a/src/main/java/com/basho/riak/client/api/commands/indexes/SecondaryIndexQuery.java
+++ b/src/main/java/com/basho/riak/client/api/commands/indexes/SecondaryIndexQuery.java
@@ -230,7 +230,87 @@ public abstract class SecondaryIndexQuery<T,S,U> extends RiakCommand<S, U>
         
         return cluster.execute(builder.build());
     }
-                        
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof SecondaryIndexQuery)) {
+            return false;
+        }
+
+        SecondaryIndexQuery<?, ?, ?> that = (SecondaryIndexQuery<?, ?, ?>) o;
+
+        if (returnTerms != that.returnTerms) {
+            return false;
+        }
+        if (paginationSort != that.paginationSort) {
+            return false;
+        }
+        if (namespace != null ? !namespace.equals(that.namespace) : that.namespace != null) {
+            return false;
+        }
+        if (indexName != null ? !indexName.equals(that.indexName) : that.indexName != null) {
+            return false;
+        }
+        if (continuation != null ? !continuation.equals(that.continuation) : that.continuation != null) {
+            return false;
+        }
+        if (match != null ? !match.equals(that.match) : that.match != null) {
+            return false;
+        }
+        if (start != null ? !start.equals(that.start) : that.start != null) {
+            return false;
+        }
+        if (end != null ? !end.equals(that.end) : that.end != null) {
+            return false;
+        }
+        if (maxResults != null ? !maxResults.equals(that.maxResults) : that.maxResults != null) {
+            return false;
+        }
+        if (termFilter != null ? !termFilter.equals(that.termFilter) : that.termFilter != null) {
+            return false;
+        }
+        return !(timeout != null ? !timeout.equals(that.timeout) : that.timeout != null);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = namespace != null ? namespace.hashCode() : 0;
+        result = 31 * result + (indexName != null ? indexName.hashCode() : 0);
+        result = 31 * result + (continuation != null ? continuation.hashCode() : 0);
+        result = 31 * result + (match != null ? match.hashCode() : 0);
+        result = 31 * result + (start != null ? start.hashCode() : 0);
+        result = 31 * result + (end != null ? end.hashCode() : 0);
+        result = 31 * result + (maxResults != null ? maxResults.hashCode() : 0);
+        result = 31 * result + (returnTerms ? 1 : 0);
+        result = 31 * result + (paginationSort ? 1 : 0);
+        result = 31 * result + (termFilter != null ? termFilter.hashCode() : 0);
+        result = 31 * result + (timeout != null ? timeout.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "SecondaryIndexQuery{" +
+                ", continuation: " + continuation +
+                ", namespace: " + namespace +
+                ", indexName: " + indexName +
+                ", match: " + match +
+                ", start: " + start +
+                ", end: " + end +
+                ", maxResults: " + maxResults +
+                ", returnTerms: " + returnTerms +
+                ", paginationSort: " + paginationSort +
+                ", termFilter: '" + termFilter + '\'' +
+                ", timeout: " + timeout +
+                '}';
+    }
+
     protected interface IndexConverter<T>
     {
         T convert(BinaryValue input);

--- a/src/main/java/com/basho/riak/client/core/query/RiakObject.java
+++ b/src/main/java/com/basho/riak/client/core/query/RiakObject.java
@@ -386,4 +386,76 @@ public final class RiakObject
     {
         return isDeleted;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        RiakObject that = (RiakObject) o;
+
+        if (isDeleted != that.isDeleted) {
+            return false;
+        }
+        if (isModified != that.isModified) {
+            return false;
+        }
+        if (lastModified != that.lastModified) {
+            return false;
+        }
+        if (value != null ? !value.equals(that.value) : that.value != null) {
+            return false;
+        }
+        if (riakIndexes != null ? !riakIndexes.equals(that.riakIndexes) : that.riakIndexes != null) {
+            return false;
+        }
+        if (links != null ? !links.equals(that.links) : that.links != null) {
+            return false;
+        }
+        if (userMeta != null ? !userMeta.equals(that.userMeta) : that.userMeta != null) {
+            return false;
+        }
+        if (contentType != null ? !contentType.equals(that.contentType) : that.contentType != null) {
+            return false;
+        }
+        if (vtag != null ? !vtag.equals(that.vtag) : that.vtag != null) {
+            return false;
+        }
+        return !(vclock != null ? !vclock.equals(that.vclock) : that.vclock != null);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = value != null ? value.hashCode() : 0;
+        result = 31 * result + (riakIndexes != null ? riakIndexes.hashCode() : 0);
+        result = 31 * result + (links != null ? links.hashCode() : 0);
+        result = 31 * result + (userMeta != null ? userMeta.hashCode() : 0);
+        result = 31 * result + (contentType != null ? contentType.hashCode() : 0);
+        result = 31 * result + (vtag != null ? vtag.hashCode() : 0);
+        result = 31 * result + (isDeleted ? 1 : 0);
+        result = 31 * result + (isModified ? 1 : 0);
+        result = 31 * result + (vclock != null ? vclock.hashCode() : 0);
+        result = 31 * result + (int) (lastModified ^ (lastModified >>> 32));
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "RiakObject{" +
+                "contentType: " + contentType +
+                ", value: " + value +
+                ", riakIndexes: " + riakIndexes +
+                ", links: " + links +
+                ", userMeta: " + userMeta +
+                ", vtag: " + vtag +
+                ", isDeleted: " + isDeleted +
+                ", isModified: " + isModified +
+                ", vclock: " + vclock +
+                ", lastModified: " + lastModified +
+                '}';
+    }
 }

--- a/src/main/java/com/basho/riak/client/core/query/UserMetadata/RiakUserMetadata.java
+++ b/src/main/java/com/basho/riak/client/core/query/UserMetadata/RiakUserMetadata.java
@@ -234,7 +234,30 @@ public class RiakUserMetadata
     {
         return meta.size();
     }
-    
-    
-    
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        RiakUserMetadata that = (RiakUserMetadata) o;
+        return meta.equals(that.meta);
+    }
+
+    @Override
+    public int hashCode() {
+        return meta.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "RiakUserMetadata{" +
+                "meta: " + meta +
+                '}';
+    }
 }

--- a/src/main/java/com/basho/riak/client/core/query/indexes/RiakIndexes.java
+++ b/src/main/java/com/basho/riak/client/core/query/indexes/RiakIndexes.java
@@ -197,4 +197,29 @@ public class RiakIndexes implements Iterable<RiakIndex<?>>
 		{
 				return indexes.values().iterator();
 		}
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        RiakIndexes that = (RiakIndexes) o;
+        return indexes.equals(that.indexes);
+    }
+
+    @Override
+    public int hashCode() {
+        return indexes.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "RiakIndexes{" +
+                "indexes: " + indexes +
+                '}';
+    }
 }

--- a/src/main/java/com/basho/riak/client/core/query/links/RiakLinks.java
+++ b/src/main/java/com/basho/riak/client/core/query/links/RiakLinks.java
@@ -125,6 +125,28 @@ public class RiakLinks implements Iterable<RiakLink>
         return links.iterator();
     }
 
-    
-    
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        RiakLinks riakLinks = (RiakLinks) o;
+        return links.equals(riakLinks.links);
+    }
+
+    @Override
+    public int hashCode() {
+        return links.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "RiakLinks{" +
+                "links: " + links +
+                '}';
+    }
 }


### PR DESCRIPTION
Added equals(), hashCode() and toString() methods to RiakObject.

Dependent classes RiakLinks, RiakUserMetadata and RiakObject also got those methods added to allow sensible comparison of any RiakObject. This allows checking parameters for equality in unit tests when mocking out RiakClient.
