### PR TITLE
Use RiakUserMetadata.containsKey() charset parameter

### DIFF
--- a/src/main/java/com/basho/riak/client/core/query/UserMetadata/RiakUserMetadata.java
+++ b/src/main/java/com/basho/riak/client/core/query/UserMetadata/RiakUserMetadata.java
@@ -78,7 +78,7 @@ public class RiakUserMetadata
      */
     public boolean containsKey(String key, Charset charset)
     {
-        return meta.containsKey(BinaryValue.unsafeCreate(key.getBytes()));
+        return meta.containsKey(BinaryValue.unsafeCreate(key.getBytes(charset)));
     }
     
     /**


### PR DESCRIPTION
In RiakUserMetadata.containsKey(), use the charset method parameter when encoding the key.
