### PR TITLE
Fixing messagecode output in exception to match PB spec

### DIFF
--- a/src/main/java/com/basho/riak/client/core/operations/Operations.java
+++ b/src/main/java/com/basho/riak/client/core/operations/Operations.java
@@ -21,17 +21,29 @@ import com.basho.riak.client.core.RiakMessage;
 public class Operations
 {
 
-	public static void checkMessageType(RiakMessage msg, byte expected)
-	{
-		byte pbMessageCode = msg.getCode();
-		if (pbMessageCode != expected)
-		{
-			throw new IllegalStateException("Wrong response; expected "
-				+ expected
-				+ " received " + pbMessageCode);
-		}
+    public static void checkMessageType(RiakMessage msg, byte expected)
+    {
+        byte pbMessageCode = msg.getCode();
+        if (pbMessageCode != expected)
+        {
+            final short unsignedBytePbMessageCode = getUnsignedByteValue(pbMessageCode);
+            throw new IllegalStateException("Wrong response; expected "
+                + expected
+                + " received " + unsignedBytePbMessageCode);
+        }
 
-	}
+    }
+
+    /**
+     * Convert a Java signed byte to unsigned.
+     * Returns the unsigned value as a (signed) short.
+     * @param b a java signed byte
+     * @return a short containing the converted value.
+     */
+    public static short getUnsignedByteValue(byte b)
+    {
+        return (short)(b & 0xFF);
+    }
 
     /**
      * Convert a Java signed int to unsigned.

--- a/src/test/java/com/basho/riak/client/core/operations/OperationsTest.java
+++ b/src/test/java/com/basho/riak/client/core/operations/OperationsTest.java
@@ -1,0 +1,42 @@
+package com.basho.riak.client.core.operations;
+
+import com.basho.riak.client.core.RiakMessage;
+import com.basho.riak.protobuf.RiakMessageCodes;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Operations Class Unit Tests
+
+ * @author Alex Moore <amoore at basho dot com>
+ * @since 2.0.3
+ */
+public class OperationsTest
+{
+    @Test
+    public void testThatMessageCodesAreWrittenCorrectlyInErrorMessages()
+    {
+        // MSG_StartTls = 255
+        RiakMessage msg = new RiakMessage(RiakMessageCodes.MSG_StartTls, new byte[0]);
+
+        try
+        {
+            Operations.checkMessageType(msg, RiakMessageCodes.MSG_GetReq);
+        }
+        catch (IllegalStateException ex)
+        {
+            assertTrue(ex.getMessage().indexOf("255") > 0);
+        }
+    }
+
+    @Test
+    public void testThatSingedToUnsignedConversionIsCorrect()
+    {
+        assertEquals(Operations.getUnsignedByteValue((byte)0x00), 0);
+        assertEquals(Operations.getUnsignedByteValue((byte)0xFF), 255);
+        assertEquals(Operations.getUnsignedIntValue(0x00000000), 0l);
+        assertEquals(Operations.getUnsignedIntValue(0xffffffff), 4294967295l);
+    }
+}


### PR DESCRIPTION
Java's bytes are signed, our PB message code byte is not. This fix correctly outputs the correct message code value when creating a "wrong message received" exception:

"Wrong response; expected 93 received -1"  
should be 
"Wrong response; expected 93 received 255"
