### PR TITLE
Add a custom ReadTimehandler to work with pooled channels

### DIFF
--- a/src/main/java/com/basho/riak/client/core/netty/RiakChannelInitializer.java
+++ b/src/main/java/com/basho/riak/client/core/netty/RiakChannelInitializer.java
@@ -28,11 +28,15 @@ import io.netty.channel.socket.SocketChannel;
  */
 public class RiakChannelInitializer extends ChannelInitializer<SocketChannel>
 {
+
     private final RiakResponseListener listener;
-    public RiakChannelInitializer(RiakResponseListener listener)
+    private final long readTimeout;
+
+    public RiakChannelInitializer(RiakResponseListener listener, long readTimeout)
     {
         super();
         this.listener = listener;
+        this.readTimeout = readTimeout;
     }
 
     @Override
@@ -41,7 +45,11 @@ public class RiakChannelInitializer extends ChannelInitializer<SocketChannel>
         ChannelPipeline p = ch.pipeline();
         p.addLast(Constants.MESSAGE_CODEC, new RiakMessageCodec());
         p.addLast(Constants.OPERATION_ENCODER, new RiakOperationEncoder());
+        if (readTimeout > 0)
+        {
+            p.addLast(Constants.READTIMEOUT_HANDLER, new RiakReadTimeoutHandler(readTimeout));
+        }
         p.addLast(Constants.RESPONSE_HANDLER, new RiakResponseHandler(listener));
     }
-    
+
 }

--- a/src/main/java/com/basho/riak/client/core/netty/RiakReadTimeoutHandler.java
+++ b/src/main/java/com/basho/riak/client/core/netty/RiakReadTimeoutHandler.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2015 Basho Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.basho.riak.client.core.netty;
+
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.timeout.ReadTimeoutException;
+
+public class RiakReadTimeoutHandler extends ChannelDuplexHandler
+{
+    private final Logger logger = LoggerFactory.getLogger(RiakReadTimeoutHandler.class);
+    private final long timeout;
+    private volatile ScheduledFuture<?> timer;
+
+    public RiakReadTimeoutHandler(long timeout)
+    {
+        this.timeout = timeout;
+    }
+
+    @Override
+    public void flush(final ChannelHandlerContext ctx) throws Exception
+    {
+        super.flush(ctx);
+        logger.debug("Scheduled Read Timeout hander. id: {}", ctx.channel().hashCode());
+        timer = ctx.executor().schedule(new RiakReadTimeoutTask(ctx), timeout, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void channelReadComplete(ChannelHandlerContext ctx) throws Exception
+    {
+        cancelTimeoutTimer();
+        logger.debug("Canceled Read Timeout hander. id: {}", ctx.channel().hashCode());
+        super.channelReadComplete(ctx);
+    }
+
+    @Override
+    public void close(ChannelHandlerContext ctx, ChannelPromise future) throws Exception
+    {
+        super.close(ctx, future);
+        cancelTimeoutTimer();
+    }
+
+    private void cancelTimeoutTimer()
+    {
+        if (timer != null && !timer.isDone())
+        {
+            timer.cancel(false);
+        }
+    }
+}
+
+class RiakReadTimeoutTask implements Runnable
+{
+    private ChannelHandlerContext ctx;
+
+    RiakReadTimeoutTask(ChannelHandlerContext ctx)
+    {
+        this.ctx = ctx;
+    }
+
+    @Override
+    public void run()
+    {
+        if (ctx.channel().isOpen())
+        {
+            ctx.fireExceptionCaught(ReadTimeoutException.INSTANCE);
+            ctx.close();
+        }
+    }
+}

--- a/src/main/java/com/basho/riak/client/core/util/Constants.java
+++ b/src/main/java/com/basho/riak/client/core/util/Constants.java
@@ -95,6 +95,7 @@ public interface Constants {
     public static final String MESSAGE_CODEC = "codec";
     public static final String OPERATION_ENCODER = "operationEncoder";
     public static final String RESPONSE_HANDLER = "responseHandler";
+    public static final String READTIMEOUT_HANDLER = "readTimeoutHandler";
     public static final String SSL_HANDLER = "sslHandler";
     public static final String HEALTHCHECK_CODEC = "healthCheckCodec";
 

--- a/src/test/java/com/basho/riak/client/core/RiakNodeTest.java
+++ b/src/test/java/com/basho/riak/client/core/RiakNodeTest.java
@@ -91,6 +91,7 @@ public class RiakNodeTest
         RiakNode node = new RiakNode.Builder()
             .withIdleTimeout(IDLE_TIMEOUT)
             .withConnectionTimeout(CONNECTION_TIMEOUT)
+            .withReadTimeout(READ_TIMEOUT)
             .withMinConnections(MIN_CONNECTIONS)
             .withMaxConnections(MAX_CONNECTIONS)
             .withRemotePort(PORT)
@@ -104,6 +105,7 @@ public class RiakNodeTest
         assertEquals(node.getNodeState(), RiakNode.State.CREATED);
         assertEquals(node.getMaxConnections(), MAX_CONNECTIONS);
         assertEquals(node.getConnectionTimeout(), CONNECTION_TIMEOUT);
+        assertEquals(node.getReadTimeout(), READ_TIMEOUT);
         assertEquals(node.getIdleTimeout(), IDLE_TIMEOUT);
         assertEquals(node.getMinConnections(), MIN_CONNECTIONS);
         assertEquals(node.getRemoteAddress(), REMOTE_ADDRESS);


### PR DESCRIPTION
This introduce a custom read-timeout handler which is inserted into [channel pipeline](http://netty.io/4.0/api/io/netty/channel/ChannelPipeline.html) if read timeout is specified.

ReadTimeoutHandler of Netty is not intended to work with pooled channels.
Instead, this custom hander measures a duration between a flush
event and a channelReadComplete event. After a specified period, it invokes
fireExceptionCaught with ReadTimeoutException of Netty. If a sever responds in the time period, a timer which measures time is canceled in each request.
