### PR TITLE
Review submitted PR [JIRA: CLIENTS-677]

### DIFF
--- a/src/main/java/com/basho/riak/client/api/commands/timeseries/Query.java
+++ b/src/main/java/com/basho/riak/client/api/commands/timeseries/Query.java
@@ -4,6 +4,7 @@ import com.basho.riak.client.api.RiakCommand;
 import com.basho.riak.client.core.RiakCluster;
 import com.basho.riak.client.core.RiakFuture;
 import com.basho.riak.client.core.operations.ts.QueryOperation;
+import com.basho.riak.client.core.query.timeseries.IQueryResult;
 import com.basho.riak.client.core.query.timeseries.QueryResult;
 import com.basho.riak.client.core.util.BinaryValue;
 import org.slf4j.Logger;
@@ -18,9 +19,10 @@ import java.util.regex.Pattern;
  * Allows you to query a Time Series table, with the given query string.
  *
  * @author Alex Moore <amoore at basho dot com>
+ * @author Sergey Galkin <srggal at gmail dot com>
  * @since 2.0.3
  */
-public class Query extends RiakCommand<QueryResult, BinaryValue>
+public class Query extends RiakCommand<IQueryResult, BinaryValue>
 {
     private static final Logger logger = LoggerFactory.getLogger(Query.class);
 
@@ -32,11 +34,8 @@ public class Query extends RiakCommand<QueryResult, BinaryValue>
     }
 
     @Override
-    protected RiakFuture<QueryResult, BinaryValue> executeAsync(RiakCluster cluster) {
-        RiakFuture<QueryResult, BinaryValue> future =
-                cluster.execute(buildCoreOperation());
-
-        return future;
+    protected RiakFuture<IQueryResult, BinaryValue> executeAsync(RiakCluster cluster) {
+        return cluster.execute(buildCoreOperation());
     }
 
     private QueryOperation buildCoreOperation()

--- a/src/main/java/com/basho/riak/client/core/converters/TimeSeriesPBConverter.java
+++ b/src/main/java/com/basho/riak/client/core/converters/TimeSeriesPBConverter.java
@@ -121,12 +121,11 @@ public final class TimeSeriesPBConverter
         {
             final int numCells = pbRow.getCellsCount();
             final List<Cell> cells = new ArrayList<Cell>(numCells);
-            final List<RiakTsPB.TsCell> pbCells = pbRow.getCellsList();
 
-            for (int i = 0; i < numCells; i++)
+            for (int i = 0; i < numCells; ++i)
             {
                 final ColumnDescription.ColumnType columnType = columnDescriptions.get(i).getType();
-                final RiakTsPB.TsCell pbCell = pbCells.get(i);
+                final RiakTsPB.TsCell pbCell = pbRow.getCells(i);
                 cells.add(convertPbCell(pbCell, columnType));
             }
 
@@ -168,7 +167,7 @@ public final class TimeSeriesPBConverter
         return cell;
     }
 
-    private static List<ColumnDescription> convertPBColumnDescriptions(List<RiakTsPB.TsColumnDescription> pbColumns)
+    public static List<ColumnDescription> convertPBColumnDescriptions(List<RiakTsPB.TsColumnDescription> pbColumns)
     {
         if (pbColumns == null)
         {

--- a/src/main/java/com/basho/riak/client/core/converters/TimeSeriesPBConverter.java
+++ b/src/main/java/com/basho/riak/client/core/converters/TimeSeriesPBConverter.java
@@ -24,7 +24,7 @@ public final class TimeSeriesPBConverter
     {
         if (response == null)
         {
-            return QueryResult.emptyResult();
+            return QueryResult.EMPTY;
         }
 
         final List<ColumnDescription> columnDescriptions = convertPBColumnDescriptions(response.getColumnsList());
@@ -37,7 +37,7 @@ public final class TimeSeriesPBConverter
     {
         if (response == null)
         {
-            return QueryResult.emptyResult();
+            return QueryResult.EMPTY;
         }
 
         final List<ColumnDescription> columnDescriptions = convertPBColumnDescriptions(response.getColumnsList());

--- a/src/main/java/com/basho/riak/client/core/converters/TimeSeriesPBConverter.java
+++ b/src/main/java/com/basho/riak/client/core/converters/TimeSeriesPBConverter.java
@@ -63,7 +63,7 @@ public final class TimeSeriesPBConverter
         final RiakTsPB.TsColumnDescription.Builder columnBuilder = RiakTsPB.TsColumnDescription.newBuilder();
         columnBuilder.setName(ByteString.copyFromUtf8(column.getName()));
 
-        columnBuilder.setType(RiakTsPB.TsColumnType.valueOf(column.getType().getId()));
+        columnBuilder.setType(RiakTsPB.TsColumnType.valueOf(column.getType().ordinal()));
 
         return columnBuilder.build();
     }
@@ -190,7 +190,7 @@ public final class TimeSeriesPBConverter
     {
         final String name = pbColumn.getName().toStringUtf8();
 
-        final ColumnDescription.ColumnType type = ColumnDescription.ColumnType.valueOf(pbColumn.getType().getNumber());
+        final ColumnDescription.ColumnType type = ColumnDescription.ColumnType.values()[pbColumn.getType().getNumber()];
 
         return new ColumnDescription(name, type);
     }

--- a/src/main/java/com/basho/riak/client/core/converters/TimeSeriesPBConverter.java
+++ b/src/main/java/com/basho/riak/client/core/converters/TimeSeriesPBConverter.java
@@ -14,6 +14,7 @@ import java.util.*;
  * Converts Time Series Protobuff message types to Java Client entity objects, and back.
  *
  * @author Alex Moore <amoore at basho dot com>
+ * @author Sergey Galkin <srggal at gmail dot com>
  * @since 2.0.3
  */
 public final class TimeSeriesPBConverter
@@ -90,7 +91,12 @@ public final class TimeSeriesPBConverter
         return pbRows;
     }
 
-    public static List<RiakTsPB.TsCell> convertCellsToPb(RiakTsPB.TsCell.Builder cellBuilder, Collection<Cell> cells)
+    public static List<RiakTsPB.TsCell> convertCellsToPb(Collection<Cell> cells)
+    {
+        return convertCellsToPb(RiakTsPB.TsCell.newBuilder(), cells);
+    }
+
+    private static List<RiakTsPB.TsCell> convertCellsToPb(RiakTsPB.TsCell.Builder cellBuilder, Collection<Cell> cells)
     {
         final ArrayList<RiakTsPB.TsCell> pbCells = new ArrayList<RiakTsPB.TsCell>(cells.size());
 
@@ -100,11 +106,6 @@ public final class TimeSeriesPBConverter
         }
 
         return pbCells;
-    }
-
-    public static List<RiakTsPB.TsCell> convertCellsToPb(Collection<Cell> cells)
-    {
-        return convertCellsToPb(RiakTsPB.TsCell.newBuilder(), cells);
     }
 
     private static List<Row> convertPbRows(List<RiakTsPB.TsRow> pbRows, List<ColumnDescription> columnDescriptions)
@@ -200,7 +201,8 @@ public final class TimeSeriesPBConverter
 
         if (cell == null) {
             return cellBuilder;
-        } else if (cell.hasVarcharValue())
+        }
+        else if (cell.hasVarcharValue())
         {
             cellBuilder.setVarcharValue(ByteString.copyFrom(cell.getVarcharValue().unsafeGetValue()));
         }

--- a/src/main/java/com/basho/riak/client/core/operations/ts/QueryOperation.java
+++ b/src/main/java/com/basho/riak/client/core/operations/ts/QueryOperation.java
@@ -2,11 +2,11 @@ package com.basho.riak.client.core.operations.ts;
 
 import com.basho.riak.client.core.converters.TimeSeriesPBConverter;
 import com.basho.riak.client.core.operations.PBFutureOperation;
-import com.basho.riak.client.core.query.timeseries.QueryResult;
+import com.basho.riak.client.core.query.timeseries.IQueryResult;
+import com.basho.riak.client.core.query.timeseries.immutable.TimeSeriesPBLightConverter;
 import com.basho.riak.client.core.util.BinaryValue;
 import com.basho.riak.protobuf.RiakTsPB;
 import com.basho.riak.protobuf.RiakMessageCodes;
-import com.basho.riak.protobuf.RiakTsPB;
 import com.google.protobuf.ByteString;
 
 import java.util.List;
@@ -15,11 +15,13 @@ import java.util.List;
  * An operation to query data from a Riak Time Series table.
  *
  * @author Alex Moore <amoore at basho dot com>
+ * @author Sergey Galkin <srggal at gmail dot com>
  * @since 2.0.3
  */
-public class QueryOperation extends PBFutureOperation<QueryResult, RiakTsPB.TsQueryResp, BinaryValue>
+public class QueryOperation extends PBFutureOperation<IQueryResult, RiakTsPB.TsQueryResp, BinaryValue>
 {
     private final BinaryValue queryText;
+    private final boolean shouldReturnImmutableResults;
 
     private QueryOperation(Builder builder)
     {
@@ -29,15 +31,23 @@ public class QueryOperation extends PBFutureOperation<QueryResult, RiakTsPB.TsQu
               RiakTsPB.TsQueryResp.PARSER);
 
         this.queryText = builder.queryText;
+        this.shouldReturnImmutableResults = builder.shouldReturnImmutableResults;
     }
 
     @Override
-    protected QueryResult convert(List<RiakTsPB.TsQueryResp> responses)
+    protected IQueryResult convert(List<RiakTsPB.TsQueryResp> responses)
     {
         // This is not a streaming op, there will only be one response
         final RiakTsPB.TsQueryResp response = checkAndGetSingleResponse(responses);
 
-        return TimeSeriesPBConverter.convertPbGetResp(response);
+        if (shouldReturnImmutableResults)
+        {
+            return TimeSeriesPBLightConverter.convertPbGetResp(response);
+        }
+        else
+        {
+            return TimeSeriesPBConverter.convertPbGetResp(response);
+        }
     }
     @Override
     public BinaryValue getQueryInfo()
@@ -48,8 +58,11 @@ public class QueryOperation extends PBFutureOperation<QueryResult, RiakTsPB.TsQu
     public static class Builder
     {
         private final BinaryValue queryText;
+        private boolean shouldReturnImmutableResults = RETURN_IMMUTABLE_RESULTS;
         private final RiakTsPB.TsInterpolation.Builder interpolationBuilder =
                 RiakTsPB.TsInterpolation.newBuilder();
+
+        public static boolean RETURN_IMMUTABLE_RESULTS = false;
 
         public Builder(BinaryValue queryText)
         {
@@ -59,6 +72,12 @@ public class QueryOperation extends PBFutureOperation<QueryResult, RiakTsPB.TsQu
             }
             this.queryText = queryText;
             this.interpolationBuilder.setBase(ByteString.copyFrom(queryText.unsafeGetValue()));
+        }
+
+        public Builder returnImmutableResults(boolean shouldReturnImmutableResults)
+        {
+            this.shouldReturnImmutableResults = shouldReturnImmutableResults;
+            return this;
         }
 
         public QueryOperation build()

--- a/src/main/java/com/basho/riak/client/core/operations/ts/QueryOperation.java
+++ b/src/main/java/com/basho/riak/client/core/operations/ts/QueryOperation.java
@@ -42,7 +42,7 @@ public class QueryOperation extends PBFutureOperation<IQueryResult, RiakTsPB.TsQ
 
         if (shouldReturnImmutableResults)
         {
-            return TimeSeriesPBLightConverter.convertPbGetResp(response);
+            return TimeSeriesPBLightConverter.convertPbQueryResp(response);
         }
         else
         {

--- a/src/main/java/com/basho/riak/client/core/query/timeseries/Cell.java
+++ b/src/main/java/com/basho/riak/client/core/query/timeseries/Cell.java
@@ -17,9 +17,10 @@ import java.util.Date;
  * </ol>
  *
  * @author Alex Moore <amoore at basho dot com>
+ * @author Sergey Galkin <srggal at gmail dot com>
  * @since 2.0.3
  */
-public class Cell
+public class Cell implements ICell
 {
     Cell() {}
 
@@ -106,6 +107,7 @@ public class Cell
      * Indicates whether this Cell contains a Varchar value.
      * @return true if it contains a Varchar value, false otherwise.
      */
+    @Override
     public boolean hasVarcharValue()
     {
         return this.varcharValue != null;
@@ -115,6 +117,7 @@ public class Cell
      * Indicates whether this Cell contains a valid signed 64-bit long integer value ({@link Long}).
      * @return true if it contains a java @{link Long} value, false otherwise.
      */
+    @Override
     public boolean hasLong()
     {
         return this.isIntegerCell;
@@ -127,6 +130,7 @@ public class Cell
      * Please use @{link #hasLong()} instead of @{link #hasTimestamp()} to check if a value exists until further notice.
      * @return true if it contains a Timestamp value, false otherwise.
      */
+    @Override
     public boolean hasTimestamp()
     {
         return this.isTimestampCell;
@@ -136,6 +140,7 @@ public class Cell
      * Indicates whether this Cell contains a Boolean value.
      * @return true if it contains a Boolean value, false otherwise.
      */
+    @Override
     public boolean hasBoolean()
     {
         return this.isBooleanCell;
@@ -145,12 +150,14 @@ public class Cell
      * Indicates whether this Cell contains a Double value.
      * @return true if it contains a Double value, false otherwise.
      */
+    @Override
     public boolean hasDouble() { return this.isDoubleCell; }
 
     /**
      * Returns the Varchar value, decoded to a UTF8 String.
      * @return The Varchar value, decoded to a UTF8 String.
      */
+    @Override
     public String getVarcharAsUTF8String()
     {
         return this.varcharValue.toStringUtf8();
@@ -160,6 +167,7 @@ public class Cell
      * Returns the raw Varchar value as a BinaryValue object.
      * @return The raw Varchar value as a BinaryValue object.
      */
+    @Override
     public BinaryValue getVarcharValue()
     {
         return this.varcharValue;
@@ -169,6 +177,7 @@ public class Cell
      * Returns the "Integer" value, as a Long.
      * @return The integer value, as a Java long.
      */
+    @Override
     public long getLong()
     {
         return this.integerValue;
@@ -178,6 +187,7 @@ public class Cell
      * Returns the the "Double" value.
      * @return The double value.
      */
+    @Override
     public double getDouble()
     {
         return this.doubleValue;
@@ -191,6 +201,7 @@ public class Cell
      * @see #getLong()
      * @return The timestamp value.
      */
+    @Override
     public long getTimestamp()
     {
         return timestampValue;
@@ -200,6 +211,7 @@ public class Cell
      * Returns the raw "Boolean" value.
      * @return The boolean value.
      */
+    @Override
     public boolean getBoolean()
     {
         return booleanValue;

--- a/src/main/java/com/basho/riak/client/core/query/timeseries/ColumnDescription.java
+++ b/src/main/java/com/basho/riak/client/core/query/timeseries/ColumnDescription.java
@@ -8,9 +8,10 @@ import java.util.Map;
  * Contains a column name and column type.
  *
  * @author Alex Moore <amoore at basho dot com>
+ * @author Sergey Galkin <srggal at gmail dot com>
  * @since 2.0.3
  */
-public class ColumnDescription
+public class ColumnDescription implements IColumnDescription
 {
     private final String name;
     private final ColumnType type;
@@ -21,26 +22,15 @@ public class ColumnDescription
         this.type = type;
     }
 
+    @Override
     public String getName()
     {
         return name;
     }
 
+    @Override
     public ColumnType getType()
     {
         return type;
-    }
-
-
-    public enum ColumnType
-    {
-        /**
-         * Values MUST BE IN THE SAME ORDER AS in the RiakTsPB.TsColumnType
-         */
-        VARCHAR,
-        SINT64,
-        DOUBLE,
-        TIMESTAMP,
-        BOOLEAN
     }
 }

--- a/src/main/java/com/basho/riak/client/core/query/timeseries/ColumnDescription.java
+++ b/src/main/java/com/basho/riak/client/core/query/timeseries/ColumnDescription.java
@@ -34,35 +34,13 @@ public class ColumnDescription
 
     public enum ColumnType
     {
-        VARCHAR(0),
-        SINT64(1),
-        DOUBLE(2),
-        TIMESTAMP(3),
-        BOOLEAN(4);
-
-        private static Map<Integer, ColumnType> map = new HashMap<Integer, ColumnType>();
-
-        static {
-            for (ColumnType cTypeEnum : ColumnType.values()) {
-                map.put(cTypeEnum.id, cTypeEnum);
-            }
-        }
-
-        private final int id;
-
-        ColumnType(int id)
-        {
-            this.id = id;
-        }
-
-        public static ColumnType valueOf(int columnType)
-        {
-            return map.get(columnType);
-        }
-
-        public int getId()
-        {
-            return this.id;
-        }
+        /**
+         * Values MUST BE IN THE SAME ORDER AS in the RiakTsPB.TsColumnType
+         */
+        VARCHAR,
+        SINT64,
+        DOUBLE,
+        TIMESTAMP,
+        BOOLEAN
     }
 }

--- a/src/main/java/com/basho/riak/client/core/query/timeseries/ICell.java
+++ b/src/main/java/com/basho/riak/client/core/query/timeseries/ICell.java
@@ -1,0 +1,83 @@
+package com.basho.riak.client.core.query.timeseries;
+
+import com.basho.riak.client.core.util.BinaryValue;
+
+/**
+ * @author Sergey Galkin <srggal at gmail dot com>
+ * @since 2.0.3
+ */
+public interface ICell
+{
+    /**
+     * Indicates whether this Cell contains a Varchar value.
+     * @return true if it contains a Varchar value, false otherwise.
+     */
+    boolean hasVarcharValue();
+
+    /**
+     * Indicates whether this Cell contains a valid signed 64-bit long integer value ({@link Long}).
+     * @return true if it contains a java @{link Long} value, false otherwise.
+     */
+    boolean hasLong();
+
+    /**
+     * Indicates whether this Cell contains a Timestamp value.
+     * Please note that as of Riak TimeSeries Beta 1, any timestamp values returned from Riak will appear
+     * in the Integer value, instead of the Timestamp value.
+     * Please use @{link #hasLong()} instead of @{link #hasTimestamp()} to check if a value exists until further notice.
+     * @return true if it contains a Timestamp value, false otherwise.
+     */
+    boolean hasTimestamp();
+
+    /**
+     * Indicates whether this Cell contains a Boolean value.
+     * @return true if it contains a Boolean value, false otherwise.
+     */
+    boolean hasBoolean();
+
+    /**
+     * Indicates whether this Cell contains a Double value.
+     * @return true if it contains a Double value, false otherwise.
+     */
+    boolean hasDouble();
+
+    /**
+     * Returns the Varchar value, decoded to a UTF8 String.
+     * @return The Varchar value, decoded to a UTF8 String.
+     */
+    String getVarcharAsUTF8String();
+
+    /**
+     * Returns the raw Varchar value as a BinaryValue object.
+     * @return The raw Varchar value as a BinaryValue object.
+     */
+    BinaryValue getVarcharValue();
+
+    /**
+     * Returns the "Integer" value, as a Long.
+     * @return The integer value, as a Java long.
+     */
+    long getLong();
+
+    /**
+     * Returns the the "Double" value.
+     * @return The double value.
+     */
+    double getDouble();
+
+    /**
+     * Returns the raw "Timestamp" value.
+     * Please note that as of Riak TimeSeries Beta 1, any timestamp values returned from Riak will appear
+     * in the "Integer" register, instead of the Timestamp register.
+     * Please use @{link #getLong()} instead of @{link #getTimestamp()} to fetch a value until further notice.
+     * @see #getLong()
+     * @return The timestamp value.
+     */
+    long getTimestamp();
+
+    /**
+     * Returns the raw "Boolean" value.
+     * @return The boolean value.
+     */
+    boolean getBoolean();
+}

--- a/src/main/java/com/basho/riak/client/core/query/timeseries/IColumnDescription.java
+++ b/src/main/java/com/basho/riak/client/core/query/timeseries/IColumnDescription.java
@@ -1,0 +1,22 @@
+package com.basho.riak.client.core.query.timeseries;
+
+/**
+ * @author Sergey Galkin <srggal at gmail dot com>
+ * @since 2.0.3
+ */
+public interface IColumnDescription
+{
+    /**
+     * Values MUST BE IN THE SAME ORDER AS in the RiakTsPB.TsColumnType
+     */
+    enum ColumnType {
+        VARCHAR,
+        SINT64,
+        DOUBLE,
+        TIMESTAMP,
+        BOOLEAN
+    }
+
+    String getName();
+    ColumnType getType();
+}

--- a/src/main/java/com/basho/riak/client/core/query/timeseries/IQueryResult.java
+++ b/src/main/java/com/basho/riak/client/core/query/timeseries/IQueryResult.java
@@ -1,0 +1,16 @@
+package com.basho.riak.client.core.query.timeseries;
+
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * @author Sergey Galkin <srggal at gmail dot com>
+ * @since 2.0.3
+ */
+// TODO: Consider implementation of Iterable<IRow>
+public interface IQueryResult
+{
+    List<IColumnDescription> getColumnDescriptions();
+    Iterator<IRow> rows();
+    int getRowsCount();
+}

--- a/src/main/java/com/basho/riak/client/core/query/timeseries/IRow.java
+++ b/src/main/java/com/basho/riak/client/core/query/timeseries/IRow.java
@@ -1,0 +1,10 @@
+package com.basho.riak.client.core.query.timeseries;
+
+/**
+ * @author Sergey Galkin <srggal at gmail dot com>
+ * @since 2.0.3
+ */
+public interface IRow extends Iterable<ICell>
+{
+    int getCellsCount();
+}

--- a/src/main/java/com/basho/riak/client/core/query/timeseries/QueryResult.java
+++ b/src/main/java/com/basho/riak/client/core/query/timeseries/QueryResult.java
@@ -1,6 +1,5 @@
 package com.basho.riak.client.core.query.timeseries;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -11,17 +10,15 @@ import java.util.List;
  */
 public class QueryResult
 {
+    @SuppressWarnings("unchecked")
+    public static final QueryResult EMPTY = new QueryResult(Collections.EMPTY_LIST, Collections.EMPTY_LIST);
+
     private final List<ColumnDescription> columnDescriptions;
     private final List<Row> rows;
 
     public QueryResult(List<ColumnDescription> columnDescriptions, List<Row> rows) {
         this.columnDescriptions = columnDescriptions;
         this.rows = rows;
-    }
-
-    public static QueryResult emptyResult()
-    {
-        return new QueryResult(new ArrayList<ColumnDescription>(0), new ArrayList<Row>(0));
     }
 
     public List<ColumnDescription> getColumnDescriptions()

--- a/src/main/java/com/basho/riak/client/core/query/timeseries/QueryResult.java
+++ b/src/main/java/com/basho/riak/client/core/query/timeseries/QueryResult.java
@@ -1,14 +1,16 @@
 package com.basho.riak.client.core.query.timeseries;
 
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 
 /**
  *
  * @author Alex Moore <amoore at basho dot com>
+ * @author Sergey Galkin <srggal at gmail dot com>
  * @since 2.0.3
- */
-public class QueryResult
+*/
+public class QueryResult implements IQueryResult
 {
     @SuppressWarnings("unchecked")
     public static final QueryResult EMPTY = new QueryResult(Collections.EMPTY_LIST, Collections.EMPTY_LIST);
@@ -21,13 +23,29 @@ public class QueryResult
         this.rows = rows;
     }
 
-    public List<ColumnDescription> getColumnDescriptions()
+    @SuppressWarnings("unchecked")
+    @Override
+    public List<IColumnDescription> getColumnDescriptions()
     {
-        return this.columnDescriptions;
+        return (List)this.columnDescriptions;
     }
 
     public List<Row> getRows()
     {
-        return this.rows;
+        return rows;
+    }
+
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Iterator<IRow> rows()
+    {
+        return (Iterator)this.rows.iterator();
+    }
+
+    @Override
+    public int getRowsCount()
+    {
+        return this.rows.size();
     }
 }

--- a/src/main/java/com/basho/riak/client/core/query/timeseries/Row.java
+++ b/src/main/java/com/basho/riak/client/core/query/timeseries/Row.java
@@ -1,15 +1,16 @@
 package com.basho.riak.client.core.query.timeseries;
 
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 
 /**
  *
  * @author Alex Moore <amoore at basho dot com>
+ * @author Sergey Galkin <srggal at gmail dot com>
  * @since 2.0.3
  */
-
-public class Row
+public class Row implements IRow
 {
     private final List<Cell> cells;
 
@@ -26,5 +27,18 @@ public class Row
     public List<Cell> getCells()
     {
         return cells;
+    }
+
+    @Override
+    public int getCellsCount()
+    {
+        return cells.size();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Iterator<ICell> iterator()
+    {
+        return (Iterator)cells.iterator();
     }
 }

--- a/src/main/java/com/basho/riak/client/core/query/timeseries/immutable/CellLight.java
+++ b/src/main/java/com/basho/riak/client/core/query/timeseries/immutable/CellLight.java
@@ -1,0 +1,85 @@
+package com.basho.riak.client.core.query.timeseries.immutable;
+
+import com.basho.riak.client.core.query.timeseries.ICell;
+import com.basho.riak.client.core.util.BinaryValue;
+import com.basho.riak.protobuf.RiakTsPB;
+
+/**
+ * @author Sergey Galkin <srggal at gmail dot com>
+ * @since 2.0.3
+ */
+class CellLight implements ICell
+{
+    private final RiakTsPB.TsCell pbCell;
+
+    public CellLight(RiakTsPB.TsCell pbCell)
+    {
+        this.pbCell = pbCell;
+    }
+
+    @Override
+    public boolean hasVarcharValue()
+    {
+        return pbCell.hasVarcharValue();
+    }
+
+    @Override
+    public boolean hasLong()
+    {
+        return pbCell.hasSint64Value();
+    }
+
+    @Override
+    public boolean hasTimestamp()
+    {
+        return pbCell.hasTimestampValue();
+    }
+
+    @Override
+    public boolean hasBoolean()
+    {
+        return pbCell.hasBooleanValue();
+    }
+
+    @Override
+    public boolean hasDouble()
+    {
+        return pbCell.hasDoubleValue();
+    }
+
+    @Override
+    public String getVarcharAsUTF8String()
+    {
+        return pbCell.getVarcharValue().toStringUtf8();
+    }
+
+    @Override
+    public BinaryValue getVarcharValue()
+    {
+        return BinaryValue.unsafeCreate(pbCell.getVarcharValue().toByteArray());
+    }
+
+    @Override
+    public long getLong()
+    {
+        return pbCell.getSint64Value();
+    }
+
+    @Override
+    public double getDouble()
+    {
+        return pbCell.getDoubleValue();
+    }
+
+    @Override
+    public long getTimestamp()
+    {
+        return pbCell.getTimestampValue();
+    }
+
+    @Override
+    public boolean getBoolean()
+    {
+        return pbCell.getBooleanValue();
+    }
+}

--- a/src/main/java/com/basho/riak/client/core/query/timeseries/immutable/QueryResultLight.java
+++ b/src/main/java/com/basho/riak/client/core/query/timeseries/immutable/QueryResultLight.java
@@ -1,0 +1,78 @@
+package com.basho.riak.client.core.query.timeseries.immutable;
+
+import com.basho.riak.client.core.converters.TimeSeriesPBConverter;
+import com.basho.riak.client.core.query.timeseries.IColumnDescription;
+import com.basho.riak.client.core.query.timeseries.IQueryResult;
+import com.basho.riak.client.core.query.timeseries.IRow;
+import com.basho.riak.protobuf.RiakTsPB;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * @author Sergey Galkin <srggal at gmail dot com>
+ * @since 2.0.3
+ */
+class QueryResultLight implements IQueryResult
+{
+    private static class ImmutableRowIterator implements Iterator<IRow>
+    {
+        private Iterator<RiakTsPB.TsRow> itor;
+
+        public ImmutableRowIterator(List<RiakTsPB.TsRow> cells)
+        {
+            this.itor = cells.iterator();
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            return itor.hasNext();
+        }
+
+        @Override
+        public IRow next()
+        {
+            return new RowLight(itor.next());
+        }
+
+        @Override
+        public void remove() throws UnsupportedOperationException
+        {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private final RiakTsPB.TsQueryResp pbResponse;
+    private transient List<IColumnDescription> columns;
+
+    public QueryResultLight(RiakTsPB.TsQueryResp response)
+    {
+        this.pbResponse = response;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public List<IColumnDescription> getColumnDescriptions()
+    {
+        if (columns == null)
+        {
+            columns = Collections.unmodifiableList(
+                    (List)TimeSeriesPBConverter.convertPBColumnDescriptions(pbResponse.getColumnsList()));
+        }
+        return columns;
+    }
+
+    @Override
+    public Iterator<IRow> rows()
+    {
+        return new ImmutableRowIterator(pbResponse.getRowsList());
+    }
+
+    @Override
+    public int getRowsCount()
+    {
+        return pbResponse.getRowsCount();
+    }
+}

--- a/src/main/java/com/basho/riak/client/core/query/timeseries/immutable/RowLight.java
+++ b/src/main/java/com/basho/riak/client/core/query/timeseries/immutable/RowLight.java
@@ -1,0 +1,61 @@
+package com.basho.riak.client.core.query.timeseries.immutable;
+
+import com.basho.riak.client.core.query.timeseries.ICell;
+import com.basho.riak.client.core.query.timeseries.IRow;
+import com.basho.riak.protobuf.RiakTsPB;
+
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * @author Sergey Galkin <srggal at gmail dot com>
+ * @since 2.0.3
+ */
+class RowLight implements IRow
+{
+    private static class ImmutableCellIterator implements Iterator<ICell>
+    {
+        private Iterator<RiakTsPB.TsCell> itor;
+
+        public ImmutableCellIterator(List<RiakTsPB.TsCell> cells)
+        {
+            this.itor = cells.iterator();
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            return itor.hasNext();
+        }
+
+        @Override
+        public ICell next()
+        {
+            return new CellLight(itor.next());
+        }
+
+        @Override
+        public void remove() throws UnsupportedOperationException
+        {
+            throw new UnsupportedOperationException();
+        }
+    }
+    private final RiakTsPB.TsRow pbRow;
+
+    public RowLight(RiakTsPB.TsRow pbRow)
+    {
+        this.pbRow = pbRow;
+    }
+
+    @Override
+    public int getCellsCount()
+    {
+        return pbRow.getCellsCount();
+    }
+
+    @Override
+    public Iterator<ICell> iterator()
+    {
+        return new ImmutableCellIterator(pbRow.getCellsList());
+    }
+}

--- a/src/main/java/com/basho/riak/client/core/query/timeseries/immutable/TimeSeriesPBLightConverter.java
+++ b/src/main/java/com/basho/riak/client/core/query/timeseries/immutable/TimeSeriesPBLightConverter.java
@@ -1,0 +1,19 @@
+package com.basho.riak.client.core.query.timeseries.immutable;
+
+import com.basho.riak.client.core.query.timeseries.IQueryResult;
+import com.basho.riak.protobuf.RiakTsPB;
+
+
+/**
+ * @author Sergey Galkin <srggal at gmail dot com>
+ * @since 2.0.3
+ */
+public final class TimeSeriesPBLightConverter
+{
+    private TimeSeriesPBLightConverter() {}
+
+    public static IQueryResult convertPbGetResp(RiakTsPB.TsQueryResp response)
+    {
+        return new QueryResultLight(response);
+    }
+}

--- a/src/main/java/com/basho/riak/client/core/query/timeseries/immutable/TimeSeriesPBLightConverter.java
+++ b/src/main/java/com/basho/riak/client/core/query/timeseries/immutable/TimeSeriesPBLightConverter.java
@@ -12,7 +12,7 @@ public final class TimeSeriesPBLightConverter
 {
     private TimeSeriesPBLightConverter() {}
 
-    public static IQueryResult convertPbGetResp(RiakTsPB.TsQueryResp response)
+    public static IQueryResult convertPbQueryResp(RiakTsPB.TsQueryResp response)
     {
         return new QueryResultLight(response);
     }

--- a/src/test/java/com/basho/riak/client/core/operations/itest/ts/ITestQueryOperation.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/ts/ITestQueryOperation.java
@@ -3,7 +3,7 @@ package com.basho.riak.client.core.operations.itest.ts;
 import com.basho.riak.client.core.RiakFuture;
 import com.basho.riak.client.core.operations.ts.QueryOperation;
 import com.basho.riak.client.core.operations.ts.StoreOperation;
-import com.basho.riak.client.core.query.timeseries.QueryResult;
+import com.basho.riak.client.core.query.timeseries.IQueryResult;
 import com.basho.riak.client.core.util.BinaryValue;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -42,13 +42,13 @@ public class ITestQueryOperation extends ITestTsBase
                                  "  and user ='user1'" +
                                  "  and geohash ='hash1'";
 
-        final QueryResult queryResult = executeQuery(
+        final IQueryResult queryResult = executeQuery(
                 new QueryOperation.Builder(BinaryValue.create(queryText))
             );
 
         assertNotNull(queryResult);
         assertEquals(0, queryResult.getColumnDescriptions().size());
-        assertEquals(0, queryResult.getRows().size());
+        assertEquals(0, queryResult.getRowsCount());
     }
 
     @Test
@@ -60,12 +60,12 @@ public class ITestQueryOperation extends ITestTsBase
                                  "  and user ='user2'" +
                                  "  and geohash ='hash1'";
 
-        final QueryResult queryResult = executeQuery(
+        final IQueryResult queryResult = executeQuery(
                 new QueryOperation.Builder(BinaryValue.create(queryText))
         );
 
         assertNotNull(queryResult);
         assertEquals(7, queryResult.getColumnDescriptions().size());
-        assertEquals(1, queryResult.getRows().size());
+        assertEquals(1, queryResult.getRowsCount());
     }
 }

--- a/src/test/java/com/basho/riak/client/core/operations/itest/ts/ITestQueryOperation.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/ts/ITestQueryOperation.java
@@ -5,7 +5,6 @@ import com.basho.riak.client.core.operations.ts.QueryOperation;
 import com.basho.riak.client.core.operations.ts.StoreOperation;
 import com.basho.riak.client.core.query.timeseries.QueryResult;
 import com.basho.riak.client.core.util.BinaryValue;
-import junit.framework.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -16,6 +15,7 @@ import static org.junit.Assert.*;
 /**
  * Time Series Query Operation Integration Tests
  * @author Alex Moore <amoore at basho dot com>
+ * @author Sergey Galkin <srggal at gmail dot com>
  * @since 2.0.3
  */
 
@@ -42,13 +42,9 @@ public class ITestQueryOperation extends ITestTsBase
                                  "  and user ='user1'" +
                                  "  and geohash ='hash1'";
 
-        final BinaryValue queryTextBS = BinaryValue.create(queryText);
-
-        QueryOperation queryOp = new QueryOperation.Builder(queryTextBS).build();
-        RiakFuture<QueryResult, BinaryValue> future = cluster.execute(queryOp);
-
-        QueryResult queryResult = future.get();
-        assertTrue(future.isSuccess());
+        final QueryResult queryResult = executeQuery(
+                new QueryOperation.Builder(BinaryValue.create(queryText))
+            );
 
         assertNotNull(queryResult);
         assertEquals(0, queryResult.getColumnDescriptions().size());
@@ -63,13 +59,10 @@ public class ITestQueryOperation extends ITestTsBase
                                  "  and time < "+ now +
                                  "  and user ='user2'" +
                                  "  and geohash ='hash1'";
-        final BinaryValue queryTextBS = BinaryValue.create(queryText);
 
-        QueryOperation queryOp = new QueryOperation.Builder(queryTextBS).build();
-        RiakFuture<QueryResult, BinaryValue> future = cluster.execute(queryOp);
-
-        QueryResult queryResult = future.get();
-        assertTrue(future.isSuccess());
+        final QueryResult queryResult = executeQuery(
+                new QueryOperation.Builder(BinaryValue.create(queryText))
+        );
 
         assertNotNull(queryResult);
         assertEquals(7, queryResult.getColumnDescriptions().size());

--- a/src/test/java/com/basho/riak/client/core/operations/itest/ts/ITestTsBase.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/ts/ITestTsBase.java
@@ -6,7 +6,7 @@ import com.basho.riak.client.core.RiakFuture;
 import com.basho.riak.client.core.operations.itest.ITestBase;
 import com.basho.riak.client.core.operations.ts.QueryOperation;
 import com.basho.riak.client.core.query.timeseries.Cell;
-import com.basho.riak.client.core.query.timeseries.QueryResult;
+import com.basho.riak.client.core.query.timeseries.IQueryResult;
 import com.basho.riak.client.core.query.timeseries.Row;
 import com.basho.riak.client.core.util.BinaryValue;
 import org.junit.Assume;
@@ -46,12 +46,12 @@ public abstract class ITestTsBase extends ITestBase
     protected final static String tableName = "GeoCheckin";
     protected final static BinaryValue tableNameBV = BinaryValue.createFromUtf8(tableName);
 
-    protected final static long now = 1443806900000l; // "now"
-    protected final static long fiveMinsInMS = 5l * 60l * 1000l;
+    protected final static long now = 1443806900000L; // "now"
+    protected final static long fiveMinsInMS = 5L * 60L * 1000L;
     protected final static long fiveMinsAgo = now - fiveMinsInMS;
     protected final static long tenMinsAgo = fiveMinsAgo - fiveMinsInMS;
     protected final static long fifteenMinsAgo = tenMinsAgo - fiveMinsInMS;
-    protected final static long fifteenMinsInFuture = now + (fiveMinsInMS * 3l);
+    protected final static long fifteenMinsInFuture = now + (fiveMinsInMS * 3L);
 
 
     protected final static List<Row> rows = Arrays.asList(
@@ -74,16 +74,18 @@ public abstract class ITestTsBase extends ITestBase
         Assume.assumeTrue(testTimeSeries);
     }
 
-    protected static QueryResult executeQuery(QueryOperation.Builder builder) throws ExecutionException, InterruptedException {
-        final RiakFuture<QueryResult, BinaryValue> future = cluster.execute(builder.build());
-        final QueryResult queryResult = future.get();
+    protected static IQueryResult executeQuery(QueryOperation.Builder builder) throws ExecutionException, InterruptedException
+    {
+        final RiakFuture<IQueryResult, BinaryValue> future = cluster.execute(builder.build());
+        final IQueryResult queryResult = future.get();
 
         assertTrue(future.isSuccess());
 
         return queryResult;
     }
 
-    protected static QueryResult executeQuery(Query.Builder builder) throws ExecutionException, InterruptedException {
+    protected static IQueryResult executeQuery(Query.Builder builder) throws ExecutionException, InterruptedException
+    {
         final RiakClient client = new RiakClient(cluster);
         return client.execute(builder.build());
     }

--- a/src/test/java/com/basho/riak/client/core/operations/itest/ts/ITestTsBase.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/ts/ITestTsBase.java
@@ -1,7 +1,12 @@
 package com.basho.riak.client.core.operations.itest.ts;
 
+import com.basho.riak.client.api.RiakClient;
+import com.basho.riak.client.api.commands.timeseries.Query;
+import com.basho.riak.client.core.RiakFuture;
 import com.basho.riak.client.core.operations.itest.ITestBase;
+import com.basho.riak.client.core.operations.ts.QueryOperation;
 import com.basho.riak.client.core.query.timeseries.Cell;
+import com.basho.riak.client.core.query.timeseries.QueryResult;
 import com.basho.riak.client.core.query.timeseries.Row;
 import com.basho.riak.client.core.util.BinaryValue;
 import org.junit.Assume;
@@ -9,6 +14,9 @@ import org.junit.BeforeClass;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.Assert.assertTrue;
 
 /**
  * Time Series Operation Integration Tests Base
@@ -30,6 +38,7 @@ import java.util.List;
  *   )
  *
  * @author Alex Moore <amoore at basho dot com>
+ * @author Sergey Galkin <srggal at gmail dot com>
  * @since 2.0.3
  */
 public abstract class ITestTsBase extends ITestBase
@@ -42,19 +51,40 @@ public abstract class ITestTsBase extends ITestBase
     protected final static long fiveMinsAgo = now - fiveMinsInMS;
     protected final static long tenMinsAgo = fiveMinsAgo - fiveMinsInMS;
     protected final static long fifteenMinsAgo = tenMinsAgo - fiveMinsInMS;
+    protected final static long fifteenMinsInFuture = now + (fiveMinsInMS * 3l);
+
 
     protected final static List<Row> rows = Arrays.asList(
-            // Geohash, User, timestamp, weather, temperature, UV Index
-            new Row(new Cell("hash1"), new Cell("user2"), Cell.newTimestamp(fifteenMinsAgo), new Cell("rain"), new Cell(79.0), new Cell(1), new Cell(true)),
-            new Row(new Cell("hash1"), new Cell("user2"), Cell.newTimestamp(fiveMinsAgo), new Cell("wind"),  new Cell(50.5), new Cell(2), new Cell(true)),
-            new Row(new Cell("hash1"), new Cell("user2"), Cell.newTimestamp(now), new Cell("snow"),  new Cell(20.0), new Cell(10), new Cell(true)),
-            new Row(new Cell("hash2"), new Cell("user4"), Cell.newTimestamp(fifteenMinsAgo), new Cell("rain"), new Cell(79.0), new Cell(2), new Cell(true)),
+            // "Normal" Data
+            new Row(new Cell("hash1"), new Cell("user1"), Cell.newTimestamp(fifteenMinsAgo), new Cell("cloudy"), new Cell(79.0), new Cell(1), new Cell(true)),
+            new Row(new Cell("hash1"), new Cell("user1"), Cell.newTimestamp(fiveMinsAgo), new Cell("sunny"),  new Cell(80.5), new Cell(2), new Cell(true)),
+            new Row(new Cell("hash1"), new Cell("user1"), Cell.newTimestamp(now), new Cell("sunny"),  new Cell(81.0), new Cell(10), new Cell(false)),
+
+            // Null Cell row
+            new Row(new Cell("hash1"), new Cell("user2"), Cell.newTimestamp(fiveMinsAgo), new Cell("cloudy"), null, null, new Cell(true)),
+
+            // Data for single reads / deletes
+            new Row(new Cell("hash2"), new Cell("user4"), Cell.newTimestamp(fifteenMinsAgo), new Cell("rain"), new Cell(79.0), new Cell(2), new Cell(false)),
             new Row(new Cell("hash2"), new Cell("user4"), Cell.newTimestamp(fiveMinsAgo), new Cell("wind"),  new Cell(50.5), new Cell(3), new Cell(true)),
             new Row(new Cell("hash2"), new Cell("user4"), Cell.newTimestamp(now), new Cell("snow"),  new Cell(20.0), new Cell(11), new Cell(true)));
 
-    //@BeforeClass
-    //public static void BeforeClass()
-    //{
-    //    Assume.assumeTrue(testTimeSeries);
-    //}
+    @BeforeClass
+    public static void BeforeClass()
+    {
+        Assume.assumeTrue(testTimeSeries);
+    }
+
+    protected static QueryResult executeQuery(QueryOperation.Builder builder) throws ExecutionException, InterruptedException {
+        final RiakFuture<QueryResult, BinaryValue> future = cluster.execute(builder.build());
+        final QueryResult queryResult = future.get();
+
+        assertTrue(future.isSuccess());
+
+        return queryResult;
+    }
+
+    protected static QueryResult executeQuery(Query.Builder builder) throws ExecutionException, InterruptedException {
+        final RiakClient client = new RiakClient(cluster);
+        return client.execute(builder.build());
+    }
 }


### PR DESCRIPTION
WIP

Base line (results of microbench for original code):

```
# Run complete. Total time: 00:19:59

Benchmark                                                                      (rowCount)   Mode  Cnt         Score        Error   Units
RiakTsPBBenchmark.decodeFullCycleTsQueryResp                                            1  thrpt  100       763.524 ±     12.359  ops/ms
RiakTsPBBenchmark.decodeFullCycleTsQueryResp:·gc.alloc.rate                             1  thrpt  100      1860.279 ±     30.085  MB/sec
RiakTsPBBenchmark.decodeFullCycleTsQueryResp:·gc.alloc.rate.norm                        1  thrpt  100      2560.007 ±      0.001    B/op
RiakTsPBBenchmark.decodeFullCycleTsQueryResp:·gc.churn.PS_Eden_Space                    1  thrpt  100      1558.209 ±     72.636  MB/sec
RiakTsPBBenchmark.decodeFullCycleTsQueryResp:·gc.churn.PS_Eden_Space.norm               1  thrpt  100      2143.749 ±     91.667    B/op
RiakTsPBBenchmark.decodeFullCycleTsQueryResp:·gc.churn.PS_Survivor_Space                1  thrpt  100         0.419 ±      0.091  MB/sec
RiakTsPBBenchmark.decodeFullCycleTsQueryResp:·gc.churn.PS_Survivor_Space.norm           1  thrpt  100         0.578 ±      0.125    B/op
RiakTsPBBenchmark.decodeFullCycleTsQueryResp:·gc.count                                  1  thrpt  100       256.000               counts
RiakTsPBBenchmark.decodeFullCycleTsQueryResp:·gc.time                                   1  thrpt  100       109.000                   ms
RiakTsPBBenchmark.decodeFullCycleTsQueryResp                                           10  thrpt  100       196.386 ±      3.201  ops/ms
RiakTsPBBenchmark.decodeFullCycleTsQueryResp:·gc.alloc.rate                            10  thrpt  100      2314.539 ±     37.688  MB/sec
RiakTsPBBenchmark.decodeFullCycleTsQueryResp:·gc.alloc.rate.norm                       10  thrpt  100     12384.026 ±      0.001    B/op
RiakTsPBBenchmark.decodeFullCycleTsQueryResp:·gc.churn.PS_Eden_Space                   10  thrpt  100      1900.683 ±     95.503  MB/sec
RiakTsPBBenchmark.decodeFullCycleTsQueryResp:·gc.churn.PS_Eden_Space.norm              10  thrpt  100     10154.601 ±    441.554    B/op
RiakTsPBBenchmark.decodeFullCycleTsQueryResp:·gc.churn.PS_Survivor_Space               10  thrpt  100         0.352 ±      0.095  MB/sec
RiakTsPBBenchmark.decodeFullCycleTsQueryResp:·gc.churn.PS_Survivor_Space.norm          10  thrpt  100         1.878 ±      0.507    B/op
RiakTsPBBenchmark.decodeFullCycleTsQueryResp:·gc.count                                 10  thrpt  100       260.000               counts
RiakTsPBBenchmark.decodeFullCycleTsQueryResp:·gc.time                                  10  thrpt  100       118.000                   ms
RiakTsPBBenchmark.decodeFullCycleTsQueryResp                                          100  thrpt  100        22.762 ±      0.429  ops/ms
RiakTsPBBenchmark.decodeFullCycleTsQueryResp:·gc.alloc.rate                           100  thrpt  100      2425.930 ±     45.718  MB/sec
RiakTsPBBenchmark.decodeFullCycleTsQueryResp:·gc.alloc.rate.norm                      100  thrpt  100    111984.222 ±      0.005    B/op
RiakTsPBBenchmark.decodeFullCycleTsQueryResp:·gc.churn.PS_Eden_Space                  100  thrpt  100      1974.853 ±    104.727  MB/sec
RiakTsPBBenchmark.decodeFullCycleTsQueryResp:·gc.churn.PS_Eden_Space.norm             100  thrpt  100     91165.027 ±   4458.419    B/op
RiakTsPBBenchmark.decodeFullCycleTsQueryResp:·gc.churn.PS_Survivor_Space              100  thrpt  100         0.401 ±      0.136  MB/sec
RiakTsPBBenchmark.decodeFullCycleTsQueryResp:·gc.churn.PS_Survivor_Space.norm         100  thrpt  100        18.440 ±      6.242    B/op
RiakTsPBBenchmark.decodeFullCycleTsQueryResp:·gc.count                                100  thrpt  100       248.000               counts
RiakTsPBBenchmark.decodeFullCycleTsQueryResp:·gc.time                                 100  thrpt  100       114.000                   ms
RiakTsPBBenchmark.decodeFullCycleTsQueryResp                                         1000  thrpt  100         2.260 ±      0.036  ops/ms
RiakTsPBBenchmark.decodeFullCycleTsQueryResp:·gc.alloc.rate                          1000  thrpt  100      2384.113 ±     37.993  MB/sec
RiakTsPBBenchmark.decodeFullCycleTsQueryResp:·gc.alloc.rate.norm                     1000  thrpt  100   1108434.228 ±      0.038    B/op
RiakTsPBBenchmark.decodeFullCycleTsQueryResp:·gc.churn.PS_Eden_Space                 1000  thrpt  100      1818.982 ±     98.598  MB/sec
RiakTsPBBenchmark.decodeFullCycleTsQueryResp:·gc.churn.PS_Eden_Space.norm            1000  thrpt  100    844497.765 ±  41287.878    B/op
RiakTsPBBenchmark.decodeFullCycleTsQueryResp:·gc.churn.PS_Survivor_Space             1000  thrpt  100         1.480 ±      0.696  MB/sec
RiakTsPBBenchmark.decodeFullCycleTsQueryResp:·gc.churn.PS_Survivor_Space.norm        1000  thrpt  100       681.916 ±    321.985    B/op
RiakTsPBBenchmark.decodeFullCycleTsQueryResp:·gc.count                               1000  thrpt  100       200.000               counts
RiakTsPBBenchmark.decodeFullCycleTsQueryResp:·gc.time                                1000  thrpt  100       134.000                   ms
RiakTsPBBenchmark.decodeFullCycleTsQueryResp                                        10000  thrpt  100         0.234 ±      0.004  ops/ms
RiakTsPBBenchmark.decodeFullCycleTsQueryResp:·gc.alloc.rate                         10000  thrpt  100      2468.470 ±     43.397  MB/sec
RiakTsPBBenchmark.decodeFullCycleTsQueryResp:·gc.alloc.rate.norm                    10000  thrpt  100  11090417.471 ±      2.916    B/op
RiakTsPBBenchmark.decodeFullCycleTsQueryResp:·gc.count                              10000  thrpt  100           ≈ 0               counts
RiakTsPBBenchmark.decodeTsQueryResp                                                     1  thrpt  100      2024.114 ±     27.549  ops/ms
RiakTsPBBenchmark.decodeTsQueryResp:·gc.alloc.rate                                      1  thrpt  100      1895.582 ±     25.870  MB/sec
RiakTsPBBenchmark.decodeTsQueryResp:·gc.alloc.rate.norm                                 1  thrpt  100       984.002 ±      0.001    B/op
RiakTsPBBenchmark.decodeTsQueryResp:·gc.churn.PS_Eden_Space                             1  thrpt  100      1539.568 ±     74.753  MB/sec
RiakTsPBBenchmark.decodeTsQueryResp:·gc.churn.PS_Eden_Space.norm                        1  thrpt  100       799.092 ±     36.895    B/op
RiakTsPBBenchmark.decodeTsQueryResp:·gc.churn.PS_Survivor_Space                         1  thrpt  100         0.407 ±      0.107  MB/sec
RiakTsPBBenchmark.decodeTsQueryResp:·gc.churn.PS_Survivor_Space.norm                    1  thrpt  100         0.213 ±      0.056    B/op
RiakTsPBBenchmark.decodeTsQueryResp:·gc.count                                           1  thrpt  100       252.000               counts
RiakTsPBBenchmark.decodeTsQueryResp:·gc.time                                            1  thrpt  100       113.000                   ms
RiakTsPBBenchmark.decodeTsQueryResp                                                    10  thrpt  100       641.616 ±      8.993  ops/ms
RiakTsPBBenchmark.decodeTsQueryResp:·gc.alloc.rate                                     10  thrpt  100      2818.683 ±     39.451  MB/sec
RiakTsPBBenchmark.decodeTsQueryResp:·gc.alloc.rate.norm                                10  thrpt  100      4616.008 ±      0.001    B/op
RiakTsPBBenchmark.decodeTsQueryResp:·gc.churn.PS_Eden_Space                            10  thrpt  100      2309.103 ±    105.554  MB/sec
RiakTsPBBenchmark.decodeTsQueryResp:·gc.churn.PS_Eden_Space.norm                       10  thrpt  100      3782.268 ±    167.163    B/op
RiakTsPBBenchmark.decodeTsQueryResp:·gc.churn.PS_Survivor_Space                        10  thrpt  100         0.415 ±      0.117  MB/sec
RiakTsPBBenchmark.decodeTsQueryResp:·gc.churn.PS_Survivor_Space.norm                   10  thrpt  100         0.679 ±      0.191    B/op
RiakTsPBBenchmark.decodeTsQueryResp:·gc.count                                          10  thrpt  100       251.000               counts
RiakTsPBBenchmark.decodeTsQueryResp:·gc.time                                           10  thrpt  100       108.000                   ms
RiakTsPBBenchmark.decodeTsQueryResp                                                   100  thrpt  100        70.393 ±      0.937  ops/ms
RiakTsPBBenchmark.decodeTsQueryResp:·gc.alloc.rate                                    100  thrpt  100      2745.175 ±     36.628  MB/sec
RiakTsPBBenchmark.decodeTsQueryResp:·gc.alloc.rate.norm                               100  thrpt  100     40976.072 ±      0.001    B/op
RiakTsPBBenchmark.decodeTsQueryResp:·gc.churn.PS_Eden_Space                           100  thrpt  100      2238.010 ±    111.562  MB/sec
RiakTsPBBenchmark.decodeTsQueryResp:·gc.churn.PS_Eden_Space.norm                      100  thrpt  100     33398.025 ±   1592.001    B/op
RiakTsPBBenchmark.decodeTsQueryResp:·gc.churn.PS_Survivor_Space                       100  thrpt  100         0.374 ±      0.128  MB/sec
RiakTsPBBenchmark.decodeTsQueryResp:·gc.churn.PS_Survivor_Space.norm                  100  thrpt  100         5.545 ±      1.884    B/op
RiakTsPBBenchmark.decodeTsQueryResp:·gc.count                                         100  thrpt  100       252.000               counts
RiakTsPBBenchmark.decodeTsQueryResp:·gc.time                                          100  thrpt  100       113.000                   ms
RiakTsPBBenchmark.decodeTsQueryResp                                                  1000  thrpt  100         6.900 ±      0.089  ops/ms
RiakTsPBBenchmark.decodeTsQueryResp:·gc.alloc.rate                                   1000  thrpt  100      2657.038 ±     34.428  MB/sec
RiakTsPBBenchmark.decodeTsQueryResp:·gc.alloc.rate.norm                              1000  thrpt  100    404576.732 ±      0.013    B/op
RiakTsPBBenchmark.decodeTsQueryResp:·gc.churn.PS_Eden_Space                          1000  thrpt  100      2093.529 ±    100.815  MB/sec
RiakTsPBBenchmark.decodeTsQueryResp:·gc.churn.PS_Eden_Space.norm                     1000  thrpt  100    318928.524 ±  15053.034    B/op
RiakTsPBBenchmark.decodeTsQueryResp:·gc.churn.PS_Survivor_Space                      1000  thrpt  100         0.927 ±      0.357  MB/sec
RiakTsPBBenchmark.decodeTsQueryResp:·gc.churn.PS_Survivor_Space.norm                 1000  thrpt  100       141.797 ±     55.035    B/op
RiakTsPBBenchmark.decodeTsQueryResp:·gc.count                                        1000  thrpt  100       221.000               counts
RiakTsPBBenchmark.decodeTsQueryResp:·gc.time                                         1000  thrpt  100       116.000                   ms
RiakTsPBBenchmark.decodeTsQueryResp                                                 10000  thrpt  100         0.651 ±      0.013  ops/ms
RiakTsPBBenchmark.decodeTsQueryResp:·gc.alloc.rate                                  10000  thrpt  100      2505.529 ±     48.187  MB/sec
RiakTsPBBenchmark.decodeTsQueryResp:·gc.alloc.rate.norm                             10000  thrpt  100   4040607.707 ±      0.154    B/op
RiakTsPBBenchmark.decodeTsQueryResp:·gc.count                                       10000  thrpt  100           ≈ 0               counts
RiakTsPBBenchmark.encodeFullCycleTsPutReq                                               1  thrpt  100      1736.658 ±     22.718  ops/ms
RiakTsPBBenchmark.encodeFullCycleTsPutReq:·gc.alloc.rate                                1  thrpt  100      1798.293 ±     23.533  MB/sec
RiakTsPBBenchmark.encodeFullCycleTsPutReq:·gc.alloc.rate.norm                           1  thrpt  100      1088.003 ±      0.001    B/op
RiakTsPBBenchmark.encodeFullCycleTsPutReq:·gc.churn.PS_Eden_Space                       1  thrpt  100      1468.575 ±     72.815  MB/sec
RiakTsPBBenchmark.encodeFullCycleTsPutReq:·gc.churn.PS_Eden_Space.norm                  1  thrpt  100       887.819 ±     41.121    B/op
RiakTsPBBenchmark.encodeFullCycleTsPutReq:·gc.churn.PS_Survivor_Space                   1  thrpt  100         0.408 ±      0.118  MB/sec
RiakTsPBBenchmark.encodeFullCycleTsPutReq:·gc.churn.PS_Survivor_Space.norm              1  thrpt  100         0.247 ±      0.072    B/op
RiakTsPBBenchmark.encodeFullCycleTsPutReq:·gc.count                                     1  thrpt  100       247.000               counts
RiakTsPBBenchmark.encodeFullCycleTsPutReq:·gc.time                                      1  thrpt  100       105.000                   ms
RiakTsPBBenchmark.encodeFullCycleTsPutReq                                              10  thrpt  100       194.816 ±      2.542  ops/ms
RiakTsPBBenchmark.encodeFullCycleTsPutReq:·gc.alloc.rate                               10  thrpt  100      1516.001 ±     19.803  MB/sec
RiakTsPBBenchmark.encodeFullCycleTsPutReq:·gc.alloc.rate.norm                          10  thrpt  100      8176.026 ±      0.001    B/op
RiakTsPBBenchmark.encodeFullCycleTsPutReq:·gc.churn.PS_Eden_Space                      10  thrpt  100      1245.085 ±     62.894  MB/sec
RiakTsPBBenchmark.encodeFullCycleTsPutReq:·gc.churn.PS_Eden_Space.norm                 10  thrpt  100      6706.532 ±    305.512    B/op
RiakTsPBBenchmark.encodeFullCycleTsPutReq:·gc.churn.PS_Survivor_Space                  10  thrpt  100         0.338 ±      0.095  MB/sec
RiakTsPBBenchmark.encodeFullCycleTsPutReq:·gc.churn.PS_Survivor_Space.norm             10  thrpt  100         1.835 ±      0.515    B/op
RiakTsPBBenchmark.encodeFullCycleTsPutReq:·gc.count                                    10  thrpt  100       250.000               counts
RiakTsPBBenchmark.encodeFullCycleTsPutReq:·gc.time                                     10  thrpt  100       108.000                   ms
RiakTsPBBenchmark.encodeFullCycleTsPutReq                                             100  thrpt  100        22.506 ±      0.376  ops/ms
RiakTsPBBenchmark.encodeFullCycleTsPutReq:·gc.alloc.rate                              100  thrpt  100      1700.861 ±     28.472  MB/sec
RiakTsPBBenchmark.encodeFullCycleTsPutReq:·gc.alloc.rate.norm                         100  thrpt  100     79400.225 ±      0.005    B/op
RiakTsPBBenchmark.encodeFullCycleTsPutReq:·gc.churn.PS_Eden_Space                     100  thrpt  100      1371.831 ±     69.962  MB/sec
RiakTsPBBenchmark.encodeFullCycleTsPutReq:·gc.churn.PS_Eden_Space.norm                100  thrpt  100     64001.168 ±   2949.649    B/op
RiakTsPBBenchmark.encodeFullCycleTsPutReq:·gc.churn.PS_Survivor_Space                 100  thrpt  100         0.366 ±      0.122  MB/sec
RiakTsPBBenchmark.encodeFullCycleTsPutReq:·gc.churn.PS_Survivor_Space.norm            100  thrpt  100        17.067 ±      5.708    B/op
RiakTsPBBenchmark.encodeFullCycleTsPutReq:·gc.count                                   100  thrpt  100       243.000               counts
RiakTsPBBenchmark.encodeFullCycleTsPutReq:·gc.time                                    100  thrpt  100       107.000                   ms
RiakTsPBBenchmark.encodeFullCycleTsPutReq                                            1000  thrpt  100         2.055 ±      0.028  ops/ms
RiakTsPBBenchmark.encodeFullCycleTsPutReq:·gc.alloc.rate                             1000  thrpt  100      1502.967 ±     20.174  MB/sec
RiakTsPBBenchmark.encodeFullCycleTsPutReq:·gc.alloc.rate.norm                        1000  thrpt  100    768228.204 ±      9.513    B/op
RiakTsPBBenchmark.encodeFullCycleTsPutReq:·gc.churn.PS_Eden_Space                    1000  thrpt  100      1205.323 ±     54.459  MB/sec
RiakTsPBBenchmark.encodeFullCycleTsPutReq:·gc.churn.PS_Eden_Space.norm               1000  thrpt  100    615738.622 ±  25237.893    B/op
RiakTsPBBenchmark.encodeFullCycleTsPutReq:·gc.churn.PS_Survivor_Space                1000  thrpt  100         1.215 ±      0.454  MB/sec
RiakTsPBBenchmark.encodeFullCycleTsPutReq:·gc.churn.PS_Survivor_Space.norm           1000  thrpt  100       626.382 ±    234.940    B/op
RiakTsPBBenchmark.encodeFullCycleTsPutReq:·gc.count                                  1000  thrpt  100       219.000               counts
RiakTsPBBenchmark.encodeFullCycleTsPutReq:·gc.time                                   1000  thrpt  100       119.000                   ms
RiakTsPBBenchmark.encodeFullCycleTsPutReq                                           10000  thrpt  100         0.180 ±      0.003  ops/ms
RiakTsPBBenchmark.encodeFullCycleTsPutReq:·gc.alloc.rate                            10000  thrpt  100      1361.195 ±     23.063  MB/sec
RiakTsPBBenchmark.encodeFullCycleTsPutReq:·gc.alloc.rate.norm                       10000  thrpt  100   7923902.324 ±   4330.951    B/op
RiakTsPBBenchmark.encodeFullCycleTsPutReq:·gc.churn.PS_Eden_Space                   10000  thrpt  100       896.975 ±     86.015  MB/sec
RiakTsPBBenchmark.encodeFullCycleTsPutReq:·gc.churn.PS_Eden_Space.norm              10000  thrpt  100   5227586.194 ± 501872.968    B/op
RiakTsPBBenchmark.encodeFullCycleTsPutReq:·gc.churn.PS_Survivor_Space               10000  thrpt  100         0.629 ±      1.066  MB/sec
RiakTsPBBenchmark.encodeFullCycleTsPutReq:·gc.churn.PS_Survivor_Space.norm          10000  thrpt  100      3620.864 ±   6145.322    B/op
RiakTsPBBenchmark.encodeFullCycleTsPutReq:·gc.count                                 10000  thrpt  100       111.000               counts
RiakTsPBBenchmark.encodeFullCycleTsPutReq:·gc.time                                  10000  thrpt  100       149.000                   ms
RiakTsPBBenchmark.encodePbRows                                                          1  thrpt  100      3440.831 ±     55.390  ops/ms
RiakTsPBBenchmark.encodePbRows:·gc.alloc.rate                                           1  thrpt  100      3379.510 ±     54.334  MB/sec
RiakTsPBBenchmark.encodePbRows:·gc.alloc.rate.norm                                      1  thrpt  100      1032.001 ±      0.001    B/op
RiakTsPBBenchmark.encodePbRows:·gc.churn.PS_Eden_Space                                  1  thrpt  100      2757.112 ±    141.414  MB/sec
RiakTsPBBenchmark.encodePbRows:·gc.churn.PS_Eden_Space.norm                             1  thrpt  100       840.909 ±     39.167    B/op
RiakTsPBBenchmark.encodePbRows:·gc.churn.PS_Survivor_Space                              1  thrpt  100         0.393 ±      0.118  MB/sec
RiakTsPBBenchmark.encodePbRows:·gc.churn.PS_Survivor_Space.norm                         1  thrpt  100         0.119 ±      0.036    B/op
RiakTsPBBenchmark.encodePbRows:·gc.count                                                1  thrpt  100       250.000               counts
RiakTsPBBenchmark.encodePbRows:·gc.time                                                 1  thrpt  100       106.000                   ms
RiakTsPBBenchmark.encodePbRows                                                         10  thrpt  100       457.481 ±      6.907  ops/ms
RiakTsPBBenchmark.encodePbRows:·gc.alloc.rate                                          10  thrpt  100      2925.836 ±     44.240  MB/sec
RiakTsPBBenchmark.encodePbRows:·gc.alloc.rate.norm                                     10  thrpt  100      6720.011 ±      0.001    B/op
RiakTsPBBenchmark.encodePbRows:·gc.churn.PS_Eden_Space                                 10  thrpt  100      2423.295 ±    113.828  MB/sec
RiakTsPBBenchmark.encodePbRows:·gc.churn.PS_Eden_Space.norm                            10  thrpt  100      5564.278 ±    246.085    B/op
RiakTsPBBenchmark.encodePbRows:·gc.churn.PS_Survivor_Space                             10  thrpt  100         0.346 ±      0.106  MB/sec
RiakTsPBBenchmark.encodePbRows:·gc.churn.PS_Survivor_Space.norm                        10  thrpt  100         0.789 ±      0.242    B/op
RiakTsPBBenchmark.encodePbRows:·gc.count                                               10  thrpt  100       265.000               counts
RiakTsPBBenchmark.encodePbRows:·gc.time                                                10  thrpt  100       118.000                   ms
RiakTsPBBenchmark.encodePbRows                                                        100  thrpt  100        43.628 ±      0.793  ops/ms
RiakTsPBBenchmark.encodePbRows:·gc.alloc.rate                                         100  thrpt  100      2941.354 ±     53.541  MB/sec
RiakTsPBBenchmark.encodePbRows:·gc.alloc.rate.norm                                    100  thrpt  100     70840.116 ±      0.002    B/op
RiakTsPBBenchmark.encodePbRows:·gc.churn.PS_Eden_Space                                100  thrpt  100      2385.471 ±    121.564  MB/sec
RiakTsPBBenchmark.encodePbRows:·gc.churn.PS_Eden_Space.norm                           100  thrpt  100     57376.938 ±   2610.621    B/op
RiakTsPBBenchmark.encodePbRows:·gc.churn.PS_Survivor_Space                            100  thrpt  100         0.341 ±      0.124  MB/sec
RiakTsPBBenchmark.encodePbRows:·gc.churn.PS_Survivor_Space.norm                       100  thrpt  100         8.087 ±      2.922    B/op
RiakTsPBBenchmark.encodePbRows:·gc.count                                              100  thrpt  100       248.000               counts
RiakTsPBBenchmark.encodePbRows:·gc.time                                               100  thrpt  100       112.000                   ms
RiakTsPBBenchmark.encodePbRows                                                       1000  thrpt  100         4.140 ±      0.110  ops/ms
RiakTsPBBenchmark.encodePbRows:·gc.alloc.rate                                        1000  thrpt  100      2789.632 ±     74.477  MB/sec
RiakTsPBBenchmark.encodePbRows:·gc.alloc.rate.norm                                   1000  thrpt  100    708041.225 ±      0.039    B/op
RiakTsPBBenchmark.encodePbRows:·gc.count                                             1000  thrpt  100           ≈ 0               counts
RiakTsPBBenchmark.encodePbRows                                                      10000  thrpt  100         0.402 ±      0.016  ops/ms
RiakTsPBBenchmark.encodePbRows:·gc.alloc.rate                                       10000  thrpt  100      2711.917 ±    106.541  MB/sec
RiakTsPBBenchmark.encodePbRows:·gc.alloc.rate.norm                                  10000  thrpt  100   7080052.552 ±      0.619    B/op
RiakTsPBBenchmark.encodePbRows:·gc.count                                            10000  thrpt  100           ≈ 0               counts
RiakTsPBBenchmark.parseTsQueryResp                                                      1  thrpt  100      1307.102 ±     20.081  ops/ms
RiakTsPBBenchmark.parseTsQueryResp:·gc.alloc.rate                                       1  thrpt  100      1960.316 ±     30.148  MB/sec
RiakTsPBBenchmark.parseTsQueryResp:·gc.alloc.rate.norm                                  1  thrpt  100      1576.004 ±      0.001    B/op
RiakTsPBBenchmark.parseTsQueryResp:·gc.churn.PS_Eden_Space                              1  thrpt  100      1600.325 ±     81.560  MB/sec
RiakTsPBBenchmark.parseTsQueryResp:·gc.churn.PS_Eden_Space.norm                         1  thrpt  100      1285.150 ±     59.110    B/op
RiakTsPBBenchmark.parseTsQueryResp:·gc.churn.PS_Survivor_Space                          1  thrpt  100         0.371 ±      0.101  MB/sec
RiakTsPBBenchmark.parseTsQueryResp:·gc.churn.PS_Survivor_Space.norm                     1  thrpt  100         0.300 ±      0.082    B/op
RiakTsPBBenchmark.parseTsQueryResp:·gc.count                                            1  thrpt  100       251.000               counts
RiakTsPBBenchmark.parseTsQueryResp:·gc.time                                             1  thrpt  100       111.000                   ms
RiakTsPBBenchmark.parseTsQueryResp                                                     10  thrpt  100       298.801 ±      4.665  ops/ms
RiakTsPBBenchmark.parseTsQueryResp:·gc.alloc.rate                                      10  thrpt  100      2208.900 ±     34.521  MB/sec
RiakTsPBBenchmark.parseTsQueryResp:·gc.alloc.rate.norm                                 10  thrpt  100      7768.017 ±      0.001    B/op
RiakTsPBBenchmark.parseTsQueryResp:·gc.churn.PS_Eden_Space                             10  thrpt  100      1786.399 ±     85.482  MB/sec
RiakTsPBBenchmark.parseTsQueryResp:·gc.churn.PS_Eden_Space.norm                        10  thrpt  100      6282.569 ±    283.740    B/op
RiakTsPBBenchmark.parseTsQueryResp:·gc.churn.PS_Survivor_Space                         10  thrpt  100         0.368 ±      0.097  MB/sec
RiakTsPBBenchmark.parseTsQueryResp:·gc.churn.PS_Survivor_Space.norm                    10  thrpt  100         1.301 ±      0.348    B/op
RiakTsPBBenchmark.parseTsQueryResp:·gc.count                                           10  thrpt  100       244.000               counts
RiakTsPBBenchmark.parseTsQueryResp:·gc.time                                            10  thrpt  100       103.000                   ms
RiakTsPBBenchmark.parseTsQueryResp                                                    100  thrpt  100        34.575 ±      0.518  ops/ms
RiakTsPBBenchmark.parseTsQueryResp:·gc.alloc.rate                                     100  thrpt  100      2336.509 ±     35.021  MB/sec
RiakTsPBBenchmark.parseTsQueryResp:·gc.alloc.rate.norm                                100  thrpt  100     71008.146 ±      0.003    B/op
RiakTsPBBenchmark.parseTsQueryResp:·gc.churn.PS_Eden_Space                            100  thrpt  100      1884.442 ±     92.348  MB/sec
RiakTsPBBenchmark.parseTsQueryResp:·gc.churn.PS_Eden_Space.norm                       100  thrpt  100     57256.822 ±   2612.492    B/op
RiakTsPBBenchmark.parseTsQueryResp:·gc.churn.PS_Survivor_Space                        100  thrpt  100         0.318 ±      0.119  MB/sec
RiakTsPBBenchmark.parseTsQueryResp:·gc.churn.PS_Survivor_Space.norm                   100  thrpt  100         9.656 ±      3.655    B/op
RiakTsPBBenchmark.parseTsQueryResp:·gc.count                                          100  thrpt  100       243.000               counts
RiakTsPBBenchmark.parseTsQueryResp:·gc.time                                           100  thrpt  100        94.000                   ms
RiakTsPBBenchmark.parseTsQueryResp                                                   1000  thrpt  100         3.360 ±      0.049  ops/ms
RiakTsPBBenchmark.parseTsQueryResp:·gc.alloc.rate                                    1000  thrpt  100      2250.764 ±     33.032  MB/sec
RiakTsPBBenchmark.parseTsQueryResp:·gc.alloc.rate.norm                               1000  thrpt  100    703833.497 ±      0.023    B/op
RiakTsPBBenchmark.parseTsQueryResp:·gc.churn.PS_Eden_Space                           1000  thrpt  100      1813.061 ±     93.781  MB/sec
RiakTsPBBenchmark.parseTsQueryResp:·gc.churn.PS_Eden_Space.norm                      1000  thrpt  100    566314.632 ±  26686.821    B/op
RiakTsPBBenchmark.parseTsQueryResp:·gc.churn.PS_Survivor_Space                       1000  thrpt  100         0.787 ±      0.398  MB/sec
RiakTsPBBenchmark.parseTsQueryResp:·gc.churn.PS_Survivor_Space.norm                  1000  thrpt  100       244.138 ±    123.827    B/op
RiakTsPBBenchmark.parseTsQueryResp:·gc.count                                         1000  thrpt  100       220.000               counts
RiakTsPBBenchmark.parseTsQueryResp:·gc.time                                          1000  thrpt  100       124.000                   ms
RiakTsPBBenchmark.parseTsQueryResp                                                  10000  thrpt  100         0.362 ±      0.004  ops/ms
RiakTsPBBenchmark.parseTsQueryResp:·gc.alloc.rate                                   10000  thrpt  100      2426.370 ±     29.618  MB/sec
RiakTsPBBenchmark.parseTsQueryResp:·gc.alloc.rate.norm                              10000  thrpt  100   7049789.774 ±      0.187    B/op
RiakTsPBBenchmark.parseTsQueryResp:·gc.count                                        10000  thrpt  100           ≈ 0               counts
```
