### PR TITLE
Fix RiakNode.Builder:setMaxConnections(0), clean up RiakNodeTest.java

### DIFF
--- a/src/main/java/com/basho/riak/client/core/RiakNode.java
+++ b/src/main/java/com/basho/riak/client/core/RiakNode.java
@@ -44,6 +44,7 @@ import java.util.concurrent.atomic.AtomicLong;
 /**
  * @author Brian Roach <roach at basho dot com>
  * @author Sergey Galkin <srggal at gmail dot com>
+ * @author Alex Moore <amoore at basho dot com>
  * @since 2.0
  */
 public class RiakNode implements RiakResponseListener
@@ -1309,6 +1310,13 @@ public class RiakNode implements RiakResponseListener
          * Set the minimum number of active connections to maintain.
          * These connections are exempt from the idle timeout.
          *
+         * <p>
+         * It is recommended that the number of minimum connections is >= 3.
+         * This is to allow free connections for the Retry Queue Worker,
+         * the Operation Queue Drain Worker, and asynchronous update commands
+         * as needed without blocking when the node is in a low number of connections state.
+         * </p>
+         *
          * @param minConnections - number of connections to maintain.
          * @return this
          * @see #DEFAULT_MIN_CONNECTIONS
@@ -1336,7 +1344,7 @@ public class RiakNode implements RiakResponseListener
          */
         public Builder withMaxConnections(int maxConnections)
         {
-            if (maxConnections >= minConnections)
+            if (maxConnections == DEFAULT_MAX_CONNECTIONS ||  maxConnections >= minConnections)
             {
                 this.maxConnections = maxConnections;
             }

--- a/src/main/java/com/basho/riak/client/core/RiakNode.java
+++ b/src/main/java/com/basho/riak/client/core/RiakNode.java
@@ -1310,13 +1310,6 @@ public class RiakNode implements RiakResponseListener
          * Set the minimum number of active connections to maintain.
          * These connections are exempt from the idle timeout.
          *
-         * <p>
-         * It is recommended that the number of minimum connections is >= 3.
-         * This is to allow free connections for the Retry Queue Worker,
-         * the Operation Queue Drain Worker, and asynchronous update commands
-         * as needed without blocking when the node is in a low number of connections state.
-         * </p>
-         *
          * @param minConnections - number of connections to maintain.
          * @return this
          * @see #DEFAULT_MIN_CONNECTIONS


### PR DESCRIPTION
Addresses issue #580 (CLIENTS-685) 

Add ability to set MaxConnections explicitly to 0 (unlimited), and cleanup the RiakNodeTest.java file a bit. 

Add note about recommended minConnections.  Wont' change the minConnections setting now, since it would break people's code that have maxConnections = 1 or 2.
