### PR TITLE
Filter SSL Ciphers list to those supported by Java and Erlang R16

### DIFF
--- a/src/main/java/com/basho/riak/client/api/RiakClient.java
+++ b/src/main/java/com/basho/riak/client/api/RiakClient.java
@@ -37,18 +37,18 @@ import java.util.concurrent.Future;
  * <img src="doc-files/client-image.png">
  * </p>
  * <p>
- * The easiest way to get started with the client API is using one of the static 
+ * The easiest way to get started with the client API is using one of the static
  * methods provided to instantiate and start the client:
  * </p>
  * <pre class="prettyprint">
  * {@code
- * RiakClient client = 
+ * RiakClient client =
  *     RiakClient.newClient("192.168.1.1","192.168.1.2","192.168.1.3"); } </pre>
- * 
- * Note that the Riak Java client uses the Riak Protocol Buffers API exclusively. 
+ *
+ * Note that the Riak Java client uses the Riak Protocol Buffers API exclusively.
  * <p>
  * For more complex configurations you will instantiate one or more {@link com.basho.riak.client.core.RiakNode}s
- * and build a {@link com.basho.riak.client.core.RiakCluster} to supply to the 
+ * and build a {@link com.basho.riak.client.core.RiakCluster} to supply to the
  * RiakClient constructor.
  * </p>
  * <pre class="prettyprint">
@@ -56,12 +56,12 @@ import java.util.concurrent.Future;
  * RiakNode.Builder builder = new RiakNode.Builder();
  * builder.withMinConnections(10);
  * builder.withMaxConnections(50);
- * 
+ *
  * List<String> addresses = new LinkedList<String>();
  * addresses.add("192.168.1.1");
  * addresses.add("192.168.1.2");
  * addresses.add("192.168.1.3");
- * 
+ *
  * List<RiakNode> nodes = RiakNode.Builder.buildNodes(builder, addresses);
  * RiakCluster cluster = new RiakCluster.Builder(nodes).build();
  * cluster.start();
@@ -78,7 +78,7 @@ import java.util.concurrent.Future;
  * RiakObject obj = response.getValue(RiakObject.class);}</pre>
  * </p>
  * <p>
- * You can also execute all {@literal RiakCommand}s asynchronously. A 
+ * You can also execute all {@literal RiakCommand}s asynchronously. A
  * {@link RiakFuture} for the operation is immediately returned:
  * <pre class="prettyprint">
  * {@code
@@ -162,8 +162,8 @@ public class RiakClient
     /**
 	 * Create a new RiakClient to perform operations on the given cluster.
      * <p>
-     * The RiakClient provides a user API on top of the client core. Once 
-     * instantiated, commands are submitted to it for execution on Riak. 
+     * The RiakClient provides a user API on top of the client core. Once
+     * instantiated, commands are submitted to it for execution on Riak.
      * </p>
      * @param cluster the started RiakCluster to use.
 	 */
@@ -176,9 +176,9 @@ public class RiakClient
      * Static factory method to create a new client instance.
      * This method produces a client that connects to 127.0.0.1 on the default
      * protocol buffers port (8087).
-     *  
+     *
      * @return a new client instance.
-     * @throws UnknownHostException 
+     * @throws UnknownHostException
      */
     public static RiakClient newClient() throws UnknownHostException
     {
@@ -187,9 +187,9 @@ public class RiakClient
         RiakCluster cluster = new RiakCluster.Builder(builder.build()).build();
         cluster.start();
         return new RiakClient(cluster);
-        
+
     }
-    
+
     /**
      * Static factory method to create a new client instance.
      * This method produces a client connected to the supplied addresses on
@@ -203,7 +203,7 @@ public class RiakClient
      {
          return newClient(port, Arrays.asList(remoteAddresses));
      }
-    
+
     /**
      * Static factory method to create a new client instance.
      * This method produces a client connected to the supplied addresses on
@@ -216,7 +216,7 @@ public class RiakClient
     {
         return newClient(RiakNode.Builder.DEFAULT_REMOTE_PORT, remoteAddresses);
     }
-    
+
     /**
      * Static factory method to create a new client instance.
      * This method produces a client connected to the supplied addresses on
@@ -229,7 +229,7 @@ public class RiakClient
     {
         return newClient(RiakNode.Builder.DEFAULT_REMOTE_PORT, Arrays.asList(remoteAddresses));
     }
-    
+
     /**
      * Static factory method to create a new client instance.
      * This method produces a client connected to the supplied addresses on
@@ -245,12 +245,12 @@ public class RiakClient
                                         .withRemotePort(port);
         return newClient(builder, remoteAddresses);
     }
-    
+
     /**
-     * Static factory method to create a new client instance. 
+     * Static factory method to create a new client instance.
      * This method produces a client connected to the supplied addresses.
      * @param addresses one or more addresses to connect to.
-     * @return a new RiakClient instance. 
+     * @return a new RiakClient instance.
      * @throws java.net.UnknownHostException if a supplied hostname cannot be resolved.
      */
     public static RiakClient newClient(InetSocketAddress... addresses) throws UnknownHostException
@@ -309,11 +309,11 @@ public class RiakClient
 	/**
 	 * Execute a RiakCommand synchronously.
      * <p>
-     * Calling this method causes the client to execute the provided RiakCommand synchronously. 
-     * It will block until the operation completes then either return the response 
+     * Calling this method causes the client to execute the provided RiakCommand synchronously.
+     * It will block until the operation completes then either return the response
      * on success or throw an exception on failure.
 	 * </p>
-     * 
+     *
 	 * @param command
 	 * 	The RiakCommand to execute.
 	 * @param <T>
@@ -332,8 +332,8 @@ public class RiakClient
      * Execute a RiakCommand asynchronously.
      * <p>
      * Calling this method  causes the client to execute the provided RiakCommand
-     * asynchronously. It will immediately return a RiakFuture that contains the 
-     * running operation. 
+     * asynchronously. It will immediately return a RiakFuture that contains the
+     * running operation.
      * @param <T> RiakCommand's return type.
      * @param <S> The RiakCommand's query info type.
      * @param command The RiakCommand to execute.
@@ -344,12 +344,12 @@ public class RiakClient
     {
         return command.executeAsync(cluster);
     }
-    
+
 	/**
 	 * Shut down the client and the underlying RiakCluster.
 	 * <p>
-     * The underlying client core (RiakCluster) uses a number of threads as 
-     * does Netty. Calling this method will shut down all those threads cleanly. 
+     * The underlying client core (RiakCluster) uses a number of threads as
+     * does Netty. Calling this method will shut down all those threads cleanly.
      * Failure to do so may prevent your application from exiting.
      * </p>
 	 * @return a future that will complete when shutdown
@@ -358,7 +358,7 @@ public class RiakClient
 	{
 		return cluster.shutdown();
 	}
-    
+
     /**
      * Get the RiakCluster being used by this client.
      * <p>

--- a/src/main/java/com/basho/riak/client/core/RiakNode.java
+++ b/src/main/java/com/basho/riak/client/core/RiakNode.java
@@ -90,7 +90,6 @@ public class RiakNode implements RiakResponseListener
     private volatile int connectionTimeout;
     private volatile boolean blockOnMaxConnections;
 
-    private final String[] riakSupportedSSLCiphers;
     private final AtomicReference<String[]> commonSupportedSSLCiphers = new AtomicReference<>();
 
     private HealthCheckFactory healthCheckFactory;
@@ -192,7 +191,6 @@ public class RiakNode implements RiakResponseListener
         this.keyStore = builder.keyStore;
         this.keyPassword = builder.keyPassword;
         this.healthCheckFactory = builder.healthCheckFactory;
-        this.riakSupportedSSLCiphers = Constants.SUPPORTED_RIAK_R16_CIPHERS;
 
         if (builder.bootstrap != null)
         {
@@ -808,7 +806,7 @@ public class RiakNode implements RiakResponseListener
     {
         if(commonSupportedSSLCiphers.get() == null)
         {
-            final HashSet<String> riakCiphers = new HashSet<>(Arrays.asList(riakSupportedSSLCiphers));
+            final HashSet<String> riakCiphers = new HashSet<>(Arrays.asList(Constants.SUPPORTED_RIAK_R16_CIPHERS));
             final HashSet<String> javaCiphers = new HashSet<>(Arrays.asList(engine.getEnabledCipherSuites()));
 
             javaCiphers.retainAll(riakCiphers); // Intersect the two sets
@@ -1332,8 +1330,6 @@ public class RiakNode implements RiakResponseListener
         private KeyStore trustStore;
         private KeyStore keyStore;
         private String keyPassword;
-        private String[] SSL_CIPHERS;
-
 
         /**
          * Default constructor. Returns a new builder for a RiakNode with

--- a/src/main/java/com/basho/riak/client/core/RiakNode.java
+++ b/src/main/java/com/basho/riak/client/core/RiakNode.java
@@ -41,6 +41,7 @@ import java.security.Security;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * @author Brian Roach <roach at basho dot com>
@@ -88,6 +89,9 @@ public class RiakNode implements RiakResponseListener
     private volatile long idleTimeoutInNanos;
     private volatile int connectionTimeout;
     private volatile boolean blockOnMaxConnections;
+
+    private final String[] riakSupportedSSLCiphers;
+    private final AtomicReference<String[]> commonSupportedSSLCiphers = new AtomicReference<>();
 
     private HealthCheckFactory healthCheckFactory;
 
@@ -188,6 +192,7 @@ public class RiakNode implements RiakResponseListener
         this.keyStore = builder.keyStore;
         this.keyPassword = builder.keyPassword;
         this.healthCheckFactory = builder.healthCheckFactory;
+        this.riakSupportedSSLCiphers = Constants.SUPPORTED_RIAK_R16_CIPHERS;
 
         if (builder.bootstrap != null)
         {
@@ -764,6 +769,10 @@ public class RiakNode implements RiakResponseListener
             logger.debug("Using TLSv1.1");
         }
 
+        final String[] commonSupportedCiphers = getCommonSupportedCiphers(engine);
+
+        engine.setEnabledCipherSuites(commonSupportedCiphers);
+
         engine.setUseClientMode(true);
         RiakSecurityDecoder decoder = new RiakSecurityDecoder(engine, username, password);
         c.pipeline().addFirst(decoder);
@@ -784,8 +793,6 @@ public class RiakNode implements RiakResponseListener
                 logger.error("Failure during Auth; {}:{} {}",remoteAddress, port, promise.cause());
                 throw new ConnectionFailedException(promise.cause());
             }
-
-
         }
         catch (InterruptedException e)
         {
@@ -795,6 +802,23 @@ public class RiakNode implements RiakResponseListener
             Thread.currentThread().interrupt();
             throw new ConnectionFailedException(e);
         }
+    }
+
+    private synchronized String[] getCommonSupportedCiphers(SSLEngine engine)
+    {
+        if(commonSupportedSSLCiphers.get() == null)
+        {
+            final HashSet<String> riakCiphers = new HashSet<>(Arrays.asList(riakSupportedSSLCiphers));
+            final HashSet<String> javaCiphers = new HashSet<>(Arrays.asList(engine.getEnabledCipherSuites()));
+
+            javaCiphers.retainAll(riakCiphers); // Intersect the two sets
+            String[] commonCiphers = new String[javaCiphers.size()];
+
+            javaCiphers.toArray(commonCiphers);
+            commonSupportedSSLCiphers.set(commonCiphers);
+        }
+
+        return commonSupportedSSLCiphers.get();
     }
 
     /**
@@ -1308,6 +1332,7 @@ public class RiakNode implements RiakResponseListener
         private KeyStore trustStore;
         private KeyStore keyStore;
         private String keyPassword;
+        private String[] SSL_CIPHERS;
 
 
         /**

--- a/src/main/java/com/basho/riak/client/core/util/Constants.java
+++ b/src/main/java/com/basho/riak/client/core/util/Constants.java
@@ -88,7 +88,7 @@ public interface Constants {
 
     // List bucket operation parameters
     public static String LIST_BUCKETS = "true";
-    
+
     // Netty Channel handler constants
     public static final String MESSAGE_CODEC = "codec";
     public static final String OPERATION_ENCODER = "operationEncoder";
@@ -97,4 +97,28 @@ public interface Constants {
     public static final String HEALTHCHECK_CODEC = "healthCheckCodec";
 
     public static final String CLIENT_OPTION_CHARSET = "com.basho.riak.client.DefaultCharset";
+
+    // SSL Ciphers supported by Erlang R16 + Java 7/8 with and without the JCE
+    // Your system may not support all of these ciphers.
+    public static final String[] SUPPORTED_RIAK_R16_CIPHERS = new String[]{
+        // Supported by both vanilla Java 7 / 8
+        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+        "TLS_RSA_WITH_AES_128_CBC_SHA256",
+        "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256",
+        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+        "TLS_RSA_WITH_AES_128_CBC_SHA",
+        "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
+
+        // Supported via Java 7/8 Cryptography Extension Unlimited Strength Jurisdiction Policy
+        "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",
+        "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256",
+        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
+        "TLS_RSA_WITH_AES_256_CBC_SHA",
+        "TLS_RSA_WITH_AES_256_CBC_SHA256",
+
+        // RC4 (Java 7)
+        "TLS_ECDHE_RSA_WITH_RC4_128_SHA",
+        "SSL_RSA_WITH_RC4_128_SHA"
+    };
 }

--- a/src/test/java/com/basho/riak/client/core/RiakClusterFixtureTest.java
+++ b/src/test/java/com/basho/riak/client/core/RiakClusterFixtureTest.java
@@ -36,11 +36,11 @@ import static org.junit.Assert.*;
  *
  * @author Brian Roach <roach at basho dot com>
  */
-public class RiakClusterFixtureTest 
+public class RiakClusterFixtureTest
 {
     private NetworkTestFixture[] fixtures;
-    
-    
+
+
     @Before
     public void setUp() throws IOException
     {
@@ -51,7 +51,7 @@ public class RiakClusterFixtureTest
             new Thread(fixtures[i]).start();
         }
     }
-    
+
     @After
     public void tearDown() throws IOException
     {
@@ -60,12 +60,12 @@ public class RiakClusterFixtureTest
             fixtures[i].shutdown();
         }
     }
-    
+
     @Test(timeout = 10000)
     public void operationSuccess() throws UnknownHostException, InterruptedException, ExecutionException
     {
         List<RiakNode> list = new LinkedList<RiakNode>();
-        
+
         for (int i = 5000; i < 8000; i += 1000)
         {
             RiakNode.Builder builder = new RiakNode.Builder()
@@ -73,18 +73,18 @@ public class RiakClusterFixtureTest
                                         .withRemotePort(i + NetworkTestFixture.PB_FULL_WRITE_STAY_OPEN);
             list.add(builder.build());
         }
-        
+
         RiakCluster cluster = new RiakCluster.Builder(list).build();
         cluster.start();
-        
+
         Namespace ns = new Namespace(Namespace.DEFAULT_BUCKET_TYPE, "test_bucket");
         Location location = new Location(ns, "test_key2");
-        
-        FetchOperation operation = 
+
+        FetchOperation operation =
             new FetchOperation.Builder(location).build();
 
         cluster.execute(operation);
-        
+
         try
         {
             FetchOperation.Response response = operation.get();
@@ -93,19 +93,19 @@ public class RiakClusterFixtureTest
         }
         catch(InterruptedException ignored)
         {
-            
+
         }
         finally
         {
             cluster.shutdown();
         }
     }
-    
+
     @Test(timeout = 10000)
     public void operationFail() throws UnknownHostException, ExecutionException, InterruptedException
     {
         List<RiakNode> list = new LinkedList<RiakNode>();
-        
+
         for (int i = 5000; i < 8000; i += 1000)
         {
             RiakNode.Builder builder = new RiakNode.Builder()
@@ -113,20 +113,20 @@ public class RiakClusterFixtureTest
                                         .withRemotePort(i + NetworkTestFixture.ACCEPT_THEN_CLOSE);
             list.add(builder.build());
         }
-        
+
         RiakCluster cluster = new RiakCluster.Builder(list).build();
-        
+
         cluster.start();
-        
+
         Namespace ns = new Namespace(Namespace.DEFAULT_BUCKET_TYPE, "test_bucket");
         Location location = new Location(ns, "test_key2");
-        
-        FetchOperation operation = 
+
+        FetchOperation operation =
             new FetchOperation.Builder(location)
                     .build();
 
         cluster.execute(operation);
-        
+
         try
         {
             operation.await();
@@ -138,12 +138,12 @@ public class RiakClusterFixtureTest
             cluster.shutdown();
         }
     }
-    
+
     @Test(timeout = 10000)
     public void testStateListener() throws UnknownHostException, InterruptedException, ExecutionException
     {
         List<RiakNode> list = new LinkedList<RiakNode>();
-        
+
         for (int i = 5000; i < 8000; i += 1000)
         {
             RiakNode.Builder builder = new RiakNode.Builder()
@@ -151,20 +151,20 @@ public class RiakClusterFixtureTest
                                         .withRemotePort(i + NetworkTestFixture.PB_FULL_WRITE_STAY_OPEN);
             list.add(builder.build());
         }
-        
+
         RiakCluster cluster = new RiakCluster.Builder(list).build();
-        
+
         StateListener listener = new StateListener();
         cluster.registerNodeStateListener(listener);
-        
+
         cluster.start();
-        
+
         // Yeah, yeah, fragile ... whatever
         Thread.sleep(3000);
-        
+
         cluster.shutdown().get();
-        
-        
+
+
         // Upon registering the initial node state of each node should be sent.
         assertEquals(3, listener.stateCreated);
         // All three nodes should go through all three states and notify.
@@ -248,7 +248,7 @@ public class RiakClusterFixtureTest
         public int stateRunning;
         public int stateShuttingDown;
         public int stateShutdown;
-        
+
         @Override
         public void nodeStateChanged(RiakNode node, RiakNode.State state)
         {

--- a/src/test/java/com/basho/riak/client/core/RiakClusterTest.java
+++ b/src/test/java/com/basho/riak/client/core/RiakClusterTest.java
@@ -87,7 +87,7 @@ public class RiakClusterTest
             }
         }
     }
-    
+
     @Test
     public void addNodeToCluster() throws UnknownHostException
     {
@@ -95,13 +95,13 @@ public class RiakClusterTest
         RiakNode node = mock(RiakNode.class);
         RiakNode.Builder nodeBuilder = spy(new RiakNode.Builder());
         doReturn(node).when(nodeBuilder).build();
-        
+
         RiakCluster cluster = new RiakCluster.Builder(nodeBuilder.build()).withNodeManager(nodeManager).build();
         cluster.addNode(nodeBuilder.build());
         assertEquals(2, cluster.getNodes().size());
         verify(nodeManager).addNode(node);
     }
-    
+
     @Test
     public void removeNodeFromCluster()
     {
@@ -110,13 +110,13 @@ public class RiakClusterTest
         RiakNode.Builder nodeBuilder = spy(new RiakNode.Builder());
         doReturn(node).when(nodeBuilder).build();
         doReturn(true).when(nodeManager).removeNode(node);
-        
+
         RiakCluster cluster = new RiakCluster.Builder(nodeBuilder.build()).withNodeManager(nodeManager).build();
         assertTrue(cluster.removeNode(node));
         verify(nodeManager).removeNode(node);
         assertEquals(0, cluster.getNodes().size());
     }
-    
+
     @Test
     public void allNodesShutdownStopsCluster()
     {
@@ -125,13 +125,13 @@ public class RiakClusterTest
         RiakNode.Builder nodeBuilder = spy(new RiakNode.Builder());
         doReturn(node).when(nodeBuilder).build();
         doReturn(true).when(nodeManager).removeNode(node);
-        
+
         RiakCluster cluster = new RiakCluster.Builder(nodeBuilder.build()).withNodeManager(nodeManager).build();
         cluster.nodeStateChanged(node, RiakNode.State.SHUTDOWN);
         RiakCluster.State state = Whitebox.getInternalState(cluster, "state");
         assertEquals(state, RiakCluster.State.SHUTDOWN);
     }
-    
+
     @Test
     @SuppressWarnings("unchecked")
     public void clusterExecutesOperation()
@@ -142,7 +142,7 @@ public class RiakClusterTest
         RiakNode.Builder nodeBuilder = spy(new RiakNode.Builder());
         doReturn(node).when(nodeBuilder).build();
         doReturn(true).when(node).execute(operation);
-        
+
         RiakCluster cluster = new RiakCluster.Builder(nodeBuilder.build()).withNodeManager(nodeManager).build();
         Whitebox.setInternalState(cluster, "state", RiakCluster.State.RUNNING);
         cluster.execute(operation);
@@ -150,7 +150,7 @@ public class RiakClusterTest
         verify(nodeManager).executeOnNode(operation, null);
         cluster.operationComplete(operation, 2);
         assertEquals(0, cluster.inFlightCount());
-        
+
         cluster.execute(operation);
         cluster.operationFailed(operation, 1);
         LinkedBlockingQueue<?> retryQueue = Whitebox.getInternalState(cluster, "retryQueue");

--- a/src/test/java/com/basho/riak/client/core/SSLEngineTests.java
+++ b/src/test/java/com/basho/riak/client/core/SSLEngineTests.java
@@ -1,0 +1,165 @@
+package com.basho.riak.client.core;
+
+import com.basho.riak.client.core.util.Constants;
+import org.junit.Assume;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.powermock.reflect.Whitebox;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.TrustManagerFactory;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class SSLEngineTests
+{
+    private final String[] enabledCiphers;
+    private final KeyStore trustStore;
+    private final boolean security;
+    private final Integer pbcPort;
+
+    public SSLEngineTests() throws NoSuchAlgorithmException, CertificateException, KeyStoreException, IOException,
+            KeyManagementException
+    {
+        security = Boolean.parseBoolean(System.getProperty("com.basho.riak.security"));
+
+        if(!security)
+        {
+            enabledCiphers = null;
+            trustStore = null;
+            pbcPort = 0;
+            return;
+        }
+
+        pbcPort = Integer.getInteger("com.basho.riak.pbcport", RiakNode.Builder.DEFAULT_REMOTE_PORT);
+
+        this.trustStore = getTrustStore();
+
+        final SSLContext context = SSLContext.getInstance("TLS");
+
+        TrustManagerFactory tmf =
+                TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        tmf.init(trustStore);
+
+        context.init(null, tmf.getTrustManagers(), null);
+
+        SSLEngine engine = context.createSSLEngine();
+
+        this.enabledCiphers = engine.getEnabledCipherSuites();
+    }
+
+    private static KeyStore getTrustStore()
+            throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException
+    {
+        CertificateFactory cFactory = CertificateFactory.getInstance("X.509");
+
+        InputStream in = Thread.currentThread().getContextClassLoader().getResourceAsStream("cacert.pem");
+        X509Certificate caCert = (X509Certificate) cFactory.generateCertificate(in);
+        in.close();
+
+        in = Thread.currentThread().getContextClassLoader().getResourceAsStream("riak-test-cert.pem");
+        X509Certificate serverCert = (X509Certificate) cFactory.generateCertificate(in);
+        in.close();
+
+        final KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        trustStore.load(null, "basho".toCharArray());
+        trustStore.setCertificateEntry("cacert", caCert);
+        trustStore.setCertificateEntry("server", serverCert);
+        return trustStore;
+    }
+
+    @Test
+    public void VerifyCurrentCipherListSupport() throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException
+    {
+        Assume.assumeTrue(security);
+        Set<String> r16Ciphers = new LinkedHashSet<>(Arrays.asList(Constants.SUPPORTED_RIAK_R16_CIPHERS));
+
+        Set<String> localSupported = new LinkedHashSet<>();
+        Set<String> localUnsupported = new LinkedHashSet<>();
+
+        testAllLocalCiphers(localSupported, localUnsupported);
+
+        localSupported.removeAll(r16Ciphers);
+
+        assertEquals("Ciphers found that are supported on Riak, but not listed as such internally ", 0, localSupported.size());
+    }
+
+    @Test
+    @Ignore("Run to get the current platform's list of supported ciphers.")
+    public void PrintSupportedLocalCipherList()
+            throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException
+    {
+        Assume.assumeTrue(security);
+        Set<String> r16Ciphers = new LinkedHashSet<>(Arrays.asList(Constants.SUPPORTED_RIAK_R16_CIPHERS));
+
+        Set<String> localSupported = new LinkedHashSet<>();
+        Set<String> localUnsupported = new LinkedHashSet<>();
+
+        testAllLocalCiphers(localSupported, localUnsupported);
+
+        System.out.println("JAVA VERSION: " + System.getProperty("java.version"));
+
+        System.out.println("\nLocal Supported Ciphers:");
+        for (String s : localSupported)
+        {
+            System.out.println(s);
+        }
+
+        System.out.println("\nLocal Unsupported Ciphers: ");
+        for (String s : localUnsupported)
+        {
+            System.out.println(s);
+        }
+
+        r16Ciphers.removeAll(localSupported);
+
+        System.out.println("\nUnsupported R16 Ciphers:");
+
+        for (String r16Cipher : r16Ciphers)
+        {
+            System.out.println(r16Cipher);
+        }
+    }
+
+    private void testAllLocalCiphers(Set<String> localSupported, Set<String> localUnsupported)
+            throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException
+    {
+        for (String enabledCipher : enabledCiphers)
+        {
+            RiakNode node = new RiakNode.Builder().withAuth("riakpass", "Test1234", trustStore)
+                                                  .withRemotePort(pbcPort).build();
+
+            Whitebox.setInternalState(node, "commonSupportedSSLCiphers",
+                                      new AtomicReference<>(new String[]{enabledCipher}));
+
+            node.start();
+
+            final LinkedBlockingDeque<Object> available = Whitebox.getInternalState(node, "available");
+            final int i = available.size();
+            if(i == 0)
+            {
+                localUnsupported.add(enabledCipher);
+            }
+            else
+            {
+                localSupported.add(enabledCipher);
+            }
+        }
+    }
+}

--- a/src/test/java/com/basho/riak/client/core/operations/itest/ITestBase.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/ITestBase.java
@@ -92,21 +92,21 @@ public abstract class ITestBase
 
         security = Boolean.parseBoolean(System.getProperty("com.basho.riak.security"));
         overrideCert = System.getProperty("com.basho.riak.security.cacert");
-        
+
         /**
          * Yokozuna.
-         * 
+         *
          * You need to create a bucket type in Riak for YZ:
-         * 
+         *
          * riak-admin bucket-type create jvtest_yz_search '{"props":{}}'
          * riak-admin bucket-type activate jvtest_yz_search
          */
         yokozunaBucketType = BinaryValue.create("jvtest_yz_search");
         testYokozuna = Boolean.parseBoolean(System.getProperty("com.basho.riak.yokozuna"));
-        
+
         /**
          * Bucket type
-         * 
+         *
          * you must create the type 'jvtest_test_type' to use this:
          *
          * riak-admin bucket-type create jvtest_test_type '{"props":{}}'
@@ -114,18 +114,18 @@ public abstract class ITestBase
          */
         testBucketType = Boolean.parseBoolean(System.getProperty("com.basho.riak.buckettype"));
         bucketType = BinaryValue.unsafeCreate("jvtest_test_type".getBytes());
-        
+
         /**
          * Secondary indexes
-         * 
+         *
          * The backend must be 'leveldb' in riak config to us this
          */
         test2i = Boolean.parseBoolean(System.getProperty("com.basho.riak.2i"));
-        
-        
+
+
         legacyRiakSearch = Boolean.parseBoolean(System.getProperty("com.basho.riak.riakSearch"));
-        
-        
+
+
         /**
          * In order to run the CRDT itests you must first manually
          * create the following bucket types in your riak instance
@@ -203,13 +203,13 @@ public abstract class ITestBase
             resetAndEmptyBucket(defaultNamespace());
         }
     }
-    
+
     @AfterClass
     public static void tearDown() throws InterruptedException, ExecutionException, TimeoutException
     {
         cluster.shutdown().get(2, TimeUnit.SECONDS);
     }
-    
+
     public static void resetAndEmptyBucket(BinaryValue name) throws InterruptedException, ExecutionException
     {
         resetAndEmptyBucket(new Namespace(Namespace.DEFAULT_BUCKET_TYPE, name.toString()));
@@ -218,13 +218,13 @@ public abstract class ITestBase
     protected static void resetAndEmptyBucket(Namespace namespace) throws InterruptedException, ExecutionException
     {
         ListKeysOperation.Builder keysOpBuilder = new ListKeysOperation.Builder(namespace);
-        
+
         ListKeysOperation keysOp = keysOpBuilder.build();
         cluster.execute(keysOp);
         List<BinaryValue> keyList = keysOp.get().getKeys();
         final Semaphore semaphore = new Semaphore(NUMBER_OF_PARALLEL_REQUESTS);
         final CountDownLatch latch = new CountDownLatch(keyList.size());
-        
+
         RiakFutureListener<Void, Location> listener = new RiakFutureListener<Void, Location>() {
             @Override
             public void handle(RiakFuture<Void, Location> f)
@@ -244,9 +244,9 @@ public abstract class ITestBase
                 semaphore.release();
                 latch.countDown();
             }
-            
+
         };
-        
+
         for (BinaryValue k : keyList)
         {
             Location location = new Location(namespace, k);
@@ -259,15 +259,15 @@ public abstract class ITestBase
 
         latch.await();
 
-        ResetBucketPropsOperation.Builder resetOpBuilder = 
+        ResetBucketPropsOperation.Builder resetOpBuilder =
             new ResetBucketPropsOperation.Builder(namespace);
-        
+
         ResetBucketPropsOperation resetOp = resetOpBuilder.build();
         cluster.execute(resetOp);
         resetOp.get();
 
     }
-    
+
     public static boolean assureIndexExists(String indexName) throws InterruptedException
     {
         for (int x = 0; x < 5; x++)
@@ -281,7 +281,7 @@ public abstract class ITestBase
                 return true;
             }
         }
-        
+
         return false;
     }
 


### PR DESCRIPTION
Added test to verify this list in the future / on new javas/erlangs. 
Added test to print supported/unsupported lists for future reference. 
