### PR TITLE
Ready: Connection Tests

### DIFF
--- a/buildbot/Makefile
+++ b/buildbot/Makefile
@@ -47,7 +47,7 @@ test: test-normal test-security
 
 test-normal:
 	$(RIAK_ADMIN) security disable
-	@cd ..; mvn -Pitest,default -Dcom.basho.riak.2i=true -Dcom.basho.riak.yokozuna=true -Dcom.basho.riak.buckettype=true -Dcom.basho.riak.crdt=true verify
+	@cd ..; mvn -Pitest,default -Dcom.basho.riak.2i=true -Dcom.basho.riak.yokozuna=true -Dcom.basho.riak.buckettype=true -Dcom.basho.riak.crdt=true -Dcom.basho.riak.lifecycle=true verify
 
 test-security:
 	$(RIAK_ADMIN) security enable

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <name>Riak Client for Java</name>
     <description>Java client for Riak 2.0</description>
     <url>https://github.com/basho/riak-java-client</url>
-  
+
     <licenses>
         <license>
             <name>The Apache Software License, Version 2.0</name>
@@ -43,7 +43,7 @@
             <organizationUrl>http://www.basho.com</organizationUrl>
         </developer>
     </developers>
-    
+
     <scm>
         <connection>scm:git:ssh://git@github.com/basho/riak-java-client.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/basho/riak-java-client.git</developerConnection>
@@ -56,7 +56,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <powermock.version>1.6.4</powermock.version>
     </properties>
-    
+
     <distributionManagement>
         <snapshotRepository>
             <id>sonatype-nexus-snapshots</id>
@@ -69,7 +69,7 @@
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
         </repository>
     </distributionManagement>
-    
+
     <profiles>
         <profile>
             <id>default</id>
@@ -234,9 +234,9 @@
             <plugin>
                 <artifactId>maven-release-plugin</artifactId>
                 <version>2.5.2</version>
-                <configuration> 
-                    <mavenExecutorId>forked-path</mavenExecutorId> 
-                </configuration> 
+                <configuration>
+                    <mavenExecutorId>forked-path</mavenExecutorId>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -338,6 +338,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.jayway.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <version>1.3.5</version>

--- a/src/main/java/com/basho/riak/client/core/FutureOperation.java
+++ b/src/main/java/com/basho/riak/client/core/FutureOperation.java
@@ -161,7 +161,7 @@ public abstract class FutureOperation<T, U, S> implements RiakFuture<T,S>
         exception = null;
         if (done(decodedMessage))
         {
-            logger.debug("Setting done but not complete");
+            logger.debug("Setting Done but not Complete");
             remainingTries--;
             if (retrier != null)
             {

--- a/src/main/java/com/basho/riak/client/core/RiakNode.java
+++ b/src/main/java/com/basho/riak/client/core/RiakNode.java
@@ -889,8 +889,8 @@ public class RiakNode implements RiakResponseListener
         consecutiveFailedOperations.incrementAndGet();
         if (inProgress != null)
         {
-            inProgress.setException(ex);
             returnConnection(channel); // release permit
+            inProgress.setException(ex);
         }
     }
 

--- a/src/main/java/com/basho/riak/client/core/RiakNode.java
+++ b/src/main/java/com/basho/riak/client/core/RiakNode.java
@@ -627,6 +627,8 @@ public class RiakNode implements RiakResponseListener
         {
             try
             {
+                logger.debug("Attempting to acquire channel permit");
+
                 if (!permits.tryAcquire())
                 {
                     logger.info("All connections in use for {}; had to wait for one.",
@@ -642,6 +644,7 @@ public class RiakNode implements RiakResponseListener
         }
         else
         {
+            logger.debug("Attempting to acquire channel permit");
             acquired = permits.tryAcquire();
         }
 
@@ -865,8 +868,15 @@ public class RiakNode implements RiakResponseListener
 
             if (inProgress.isDone())
             {
-                inProgressMap.remove(channel);
-                returnConnection(channel); // return permit
+                try
+                {
+                    inProgressMap.remove(channel);
+                    returnConnection(channel); // return permit
+                }
+                finally
+                {
+                    inProgress.setComplete();
+                }
             }
         }
     }

--- a/src/main/java/com/basho/riak/client/core/RiakNode.java
+++ b/src/main/java/com/basho/riak/client/core/RiakNode.java
@@ -907,8 +907,8 @@ public class RiakNode implements RiakResponseListener
         // already been handled.
         if (inProgress != null)
         {
-            inProgress.setException(t);
             returnConnection(channel); // release permit
+            inProgress.setException(t);
         }
     }
 

--- a/src/main/java/com/basho/riak/client/core/netty/RiakResponseHandler.java
+++ b/src/main/java/com/basho/riak/client/core/netty/RiakResponseHandler.java
@@ -34,13 +34,13 @@ public class RiakResponseHandler extends ChannelInboundHandlerAdapter
 
     private RiakResponseListener listener;
     private final Logger logger = LoggerFactory.getLogger(RiakResponseHandler.class);
-    
+
     public RiakResponseHandler(RiakResponseListener listener)
     {
         super();
         this.listener = listener;
     }
-    
+
     @Override
     public void channelRead(ChannelHandlerContext chc, Object message) throws Exception
     {
@@ -48,9 +48,9 @@ public class RiakResponseHandler extends ChannelInboundHandlerAdapter
         if (riakMessage.getCode() == RiakMessageCodes.MSG_ErrorResp)
         {
             RiakPB.RpbErrorResp error = RiakPB.RpbErrorResp.parseFrom(riakMessage.getData());
-                                                
-            listener.onRiakErrorResponse(chc.channel(), 
-                                         new RiakResponseException(error.getErrcode(), 
+
+            listener.onRiakErrorResponse(chc.channel(),
+                                         new RiakResponseException(error.getErrcode(),
                                              error.getErrmsg().toStringUtf8()));
         }
         else
@@ -58,15 +58,15 @@ public class RiakResponseHandler extends ChannelInboundHandlerAdapter
             listener.onSuccess(chc.channel(), riakMessage);
         }
     }
-    
+
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause)
-            throws Exception 
+            throws Exception
     {
-        // On any exception in the pipeline we explitly close the context here 
-        // so the channel doesn't get reused by the ConnectionPool. 
+        // On any exception in the pipeline we explitly close the context here
+        // so the channel doesn't get reused by the ConnectionPool.
         listener.onException(ctx.channel(), cause);
         ctx.close();
     }
-    
+
 }

--- a/src/main/java/com/basho/riak/client/core/operations/ListKeysOperation.java
+++ b/src/main/java/com/basho/riak/client/core/operations/ListKeysOperation.java
@@ -23,15 +23,18 @@ import com.basho.riak.protobuf.RiakMessageCodes;
 import com.basho.riak.protobuf.RiakKvPB;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class ListKeysOperation extends FutureOperation<ListKeysOperation.Response, RiakKvPB.RpbListKeysResp, Namespace>
 {
+    private final Logger logger = LoggerFactory.getLogger("ListKeysOperation");
     private final Namespace namespace;
     private final RiakKvPB.RpbListKeysReq.Builder reqBuilder;
-    
+
     private ListKeysOperation(Builder builder)
     {
         this.reqBuilder = builder.reqBuilder;
@@ -39,7 +42,7 @@ public class ListKeysOperation extends FutureOperation<ListKeysOperation.Respons
     }
 
     @Override
-    protected Response convert(List<RiakKvPB.RpbListKeysResp> rawResponse) 
+    protected Response convert(List<RiakKvPB.RpbListKeysResp> rawResponse)
     {
         Response.Builder builder = new Response.Builder();
         for (RiakKvPB.RpbListKeysResp resp : rawResponse)
@@ -83,13 +86,13 @@ public class ListKeysOperation extends FutureOperation<ListKeysOperation.Respons
     {
         return namespace;
     }
-    
+
     public static class Builder
     {
         private final RiakKvPB.RpbListKeysReq.Builder reqBuilder =
             RiakKvPB.RpbListKeysReq.newBuilder();
         private final Namespace namespace;
-        
+
         /**
          * Construct a builder for a ListKeysOperaiton.
          * @param namespace The namespace in Riak.
@@ -104,7 +107,7 @@ public class ListKeysOperation extends FutureOperation<ListKeysOperation.Respons
             reqBuilder.setType(ByteString.copyFrom(namespace.getBucketType().unsafeGetValue()));
             this.namespace = namespace;
         }
-        
+
         public Builder withTimeout(int timeout)
         {
             if (timeout <= 0)
@@ -114,13 +117,13 @@ public class ListKeysOperation extends FutureOperation<ListKeysOperation.Respons
             reqBuilder.setTimeout(timeout);
             return this;
         }
-        
+
         public ListKeysOperation build()
         {
             return new ListKeysOperation(this);
         }
     }
-    
+
     public static class Response
     {
         private final List<BinaryValue> keys;
@@ -128,23 +131,23 @@ public class ListKeysOperation extends FutureOperation<ListKeysOperation.Respons
         {
             this.keys = builder.keys;
         }
-        
+
         public List<BinaryValue> getKeys()
         {
             return keys;
         }
-        
+
         static class Builder
         {
             private List<BinaryValue> keys = new ArrayList<BinaryValue>();
-            
+
             Builder addKeys(List<BinaryValue> keys)
             {
                 this.keys.addAll(keys);
                 return this;
             }
-            
-            Builder addKey(BinaryValue key) 
+
+            Builder addKey(BinaryValue key)
             {
                 this.keys.add(key);
                 return this;
@@ -154,7 +157,7 @@ public class ListKeysOperation extends FutureOperation<ListKeysOperation.Respons
             {
                 return new Response(this);
             }
-            
+
         }
 
     }

--- a/src/test/java/com/basho/riak/client/api/ITestClusterLifecycle.java
+++ b/src/test/java/com/basho/riak/client/api/ITestClusterLifecycle.java
@@ -1,0 +1,80 @@
+package com.basho.riak.client.api;
+
+
+import com.basho.riak.client.api.commands.kv.StoreValue;
+import com.basho.riak.client.core.RiakCluster;
+import com.basho.riak.client.core.RiakFuture;
+import com.basho.riak.client.core.RiakNode;
+import com.basho.riak.client.core.query.Location;
+import com.basho.riak.client.core.query.Namespace;
+import org.junit.Test;
+
+import java.util.Random;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.Assert.*;
+
+public class ITestClusterLifecycle
+{
+    protected static RiakCluster cluster;
+    protected static boolean testLifecycle;
+    protected static String hostname;
+    protected static int pbcPort;
+    protected static Random random = new Random();
+
+    public ITestClusterLifecycle()
+    {
+        testLifecycle = Boolean.getBoolean("com.basho.riak.lifecycle");
+        hostname = System.getProperty("com.basho.riak.host", RiakNode.Builder.DEFAULT_REMOTE_ADDRESS);
+
+        pbcPort = Integer.getInteger("com.basho.riak.pbcport", RiakNode.Builder.DEFAULT_REMOTE_PORT);
+
+        RiakNode.Builder builder = new RiakNode.Builder()
+                                               .withRemoteAddress(hostname)
+                                               .withRemotePort(10017)
+                                               .withMinConnections(1)
+                                               .withMaxConnections(1);
+
+        cluster = new RiakCluster.Builder(builder.build()).build();
+    }
+
+    @Test
+    public void testManyCommandsOneConnection() throws InterruptedException, ExecutionException, TimeoutException
+    {
+        RiakClient client = null;
+        try
+        {
+            client = new RiakClient(cluster);
+            cluster.start();
+
+            final Namespace namespace = new Namespace("plain", Integer.toString(random.nextInt()));
+
+            for (int i = 0; i < 10000; i++)
+            {
+                createAndStoreObject(client, new Location(namespace, Integer.toString(i)));
+            }
+
+        }
+        catch (Exception ex)
+        {
+            assertNull(ex);
+        }
+        finally
+        {
+            final Boolean shutdownClean = client.shutdown().get(3, TimeUnit.SECONDS);
+            assertTrue(shutdownClean);
+        }
+    }
+
+    private void createAndStoreObject(RiakClient client, Location location)
+            throws ExecutionException, InterruptedException, TimeoutException
+    {
+        final StoreValue storeCmd = new StoreValue.Builder("value").withLocation(location).build();
+        final RiakFuture<StoreValue.Response, Location> execute = client.executeAsync(storeCmd);
+        final StoreValue.Response response = execute.get(1, TimeUnit.SECONDS);
+
+        assertNotNull(response);
+    }
+}

--- a/src/test/java/com/basho/riak/client/core/FutureOperationTest.java
+++ b/src/test/java/com/basho/riak/client/core/FutureOperationTest.java
@@ -125,6 +125,7 @@ public class FutureOperationTest
         operation.setResponse(response);
         verify(retrier).operationComplete(operation, NUM_TRIES - 1);
         assertTrue(operation.isDone());
+        operation.setComplete();
         assertNotNull(operation.get());
     }
 
@@ -161,6 +162,7 @@ public class FutureOperationTest
         });
 
         operation.setResponse(response);
+        operation.setComplete();
 
         assertTrue(operation.isDone());
         assertTrue(called.get());
@@ -186,6 +188,7 @@ public class FutureOperationTest
 
         operation.setResponse(response);
         operation.setResponse(response);
+        operation.setComplete();
 
         assertTrue(operation.isDone());
         assertEquals(1, called.get());
@@ -248,6 +251,7 @@ public class FutureOperationTest
         RiakMessage response = PowerMockito.mock(RiakMessage.class);
 
         operation.setResponse(response);
+        operation.setComplete();
 
         final AtomicBoolean called = new AtomicBoolean(false);
         operation.addListener(new RiakFutureListener<String, Void>()
@@ -344,7 +348,7 @@ public class FutureOperationTest
         }
 
         @Override
-        protected String convert(List<Message> rawResponse) 
+        protected String convert(List<Message> rawResponse)
         {
             return "Fake!";
         }


### PR DESCRIPTION
This gives a test + fix for a lurking race condition as described in #523.  

On the Netty worker thread: After an operation's response read, we would set the response to the FutureOperation class (time A), and then return the connection after verifying it was done (time B). 

When the response was set on the FutureOperation class, it would notice it was done and fire any listeners, which would signal to the main Thread to unblock and proceed.  After being signaled at time A, the main thread could race ahead and try to grab the connection before it was returned to the pool by the Netty thread at time B. 

Since the Netty thread hasn't returned the connection yet, the operation will retry 2 more times.  If the timing is right (or bad), the retries can also happen and fail before the connection is returned. This results in the "NoNodesAvailable" exception.

I will look into a separate fix in the future to slow down retries, but this should fix the main issue.
