### PR TITLE
Fix TS test for minor 1.2 changes.

### DIFF
--- a/src/test/java/com/basho/riak/client/api/commands/itest/ITestTimeSeries.java
+++ b/src/test/java/com/basho/riak/client/api/commands/itest/ITestTimeSeries.java
@@ -28,7 +28,7 @@ import static org.junit.Assert.*;
  *
  * Schema for the Timeseries table we're using:
  *
- *   CREATE TABLE GeoCheckin
+ *   CREATE TABLE GeoCheckin&lt;RandomInteger&gt;
  *   (
  *      geohash     varchar   not null,
  *      user        varchar   not null,

--- a/src/test/java/com/basho/riak/client/api/commands/itest/ITestTimeSeries.java
+++ b/src/test/java/com/basho/riak/client/api/commands/itest/ITestTimeSeries.java
@@ -10,7 +10,9 @@ import com.basho.riak.client.core.operations.FetchBucketPropsOperation;
 import com.basho.riak.client.core.operations.itest.ts.ITestTsBase;
 import com.basho.riak.client.core.query.Namespace;
 import com.basho.riak.client.core.query.timeseries.*;
+import org.junit.FixMethodOrder;
 import org.junit.Test;
+import org.junit.runners.MethodSorters;
 
 import java.util.*;
 import java.util.concurrent.ExecutionException;
@@ -41,6 +43,7 @@ import static org.junit.Assert.*;
  *      )
  *   )
  */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class ITestTimeSeries extends ITestTsBase
 {
     private final static String tableName = "GeoHash" + new Random().nextInt(Integer.MAX_VALUE);
@@ -59,7 +62,7 @@ public class ITestTimeSeries extends ITestTsBase
     private static final String BAD_TABLE_NAME = "GeoChicken";
 
     @Test
-    public void TestCreateTableAndChangeNVal() throws InterruptedException, ExecutionException
+    public void test_a_TestCreateTableAndChangeNVal() throws InterruptedException, ExecutionException
     {
         RiakClient client = new RiakClient(cluster);
 
@@ -88,7 +91,7 @@ public class ITestTimeSeries extends ITestTsBase
     }
 
     @Test
-    public void TestCreateBadTable() throws InterruptedException
+    public void test_b_TestCreateBadTable() throws InterruptedException
     {
         RiakClient client = new RiakClient(cluster);
 
@@ -101,7 +104,7 @@ public class ITestTimeSeries extends ITestTsBase
     }
 
     @Test
-    public void StoringData() throws ExecutionException, InterruptedException
+    public void test_c_StoringData() throws ExecutionException, InterruptedException
     {
         RiakClient client = new RiakClient(cluster);
 
@@ -114,7 +117,7 @@ public class ITestTimeSeries extends ITestTsBase
     }
 
     @Test
-    public void TestListingKeysReturnsThem() throws ExecutionException, InterruptedException
+    public void test_d_TestListingKeysReturnsThem() throws ExecutionException, InterruptedException
     {
         RiakClient client = new RiakClient(cluster);
 
@@ -130,7 +133,7 @@ public class ITestTimeSeries extends ITestTsBase
     }
 
     @Test
-    public void QueryingDataNoMatches() throws ExecutionException, InterruptedException
+    public void test_e_QueryingDataNoMatches() throws ExecutionException, InterruptedException
     {
         final String queryText = "select * from " + tableName + " Where time > 1 and time < 10 and user='user1' and geohash='hash1'";
         final QueryResult queryResult = executeQuery(new Query.Builder(queryText));
@@ -141,7 +144,7 @@ public class ITestTimeSeries extends ITestTsBase
     }
 
     @Test
-    public void QueryingDataWithMinimumPredicate() throws ExecutionException, InterruptedException
+    public void test_f_QueryingDataWithMinimumPredicate() throws ExecutionException, InterruptedException
     {
         // Timestamp fields lower bounds are inclusive, upper bounds are exclusive
         // Should only return the 2nd row (one from "5 mins ago")
@@ -162,7 +165,7 @@ public class ITestTimeSeries extends ITestTsBase
     }
 
     @Test
-    public void QueryingDataWithExtraPredicate() throws ExecutionException, InterruptedException
+    public void test_g_QueryingDataWithExtraPredicate() throws ExecutionException, InterruptedException
     {
         // Timestamp fields lower bounds are inclusive, upper bounds are exclusive
         // Should only return the 2nd row (one from "5 mins ago")
@@ -183,7 +186,7 @@ public class ITestTimeSeries extends ITestTsBase
     }
 
     @Test
-    public void QueryingDataAcrossManyQuantum() throws ExecutionException, InterruptedException
+    public void test_h_QueryingDataAcrossManyQuantum() throws ExecutionException, InterruptedException
     {
         // Timestamp fields lower bounds are inclusive, upper bounds are exclusive
         // Should return the 2nd & 3rd rows. Query should cover 2 quantums at least.
@@ -205,7 +208,7 @@ public class ITestTimeSeries extends ITestTsBase
     }
 
     @Test
-    public void TestThatNullsAreSavedAndFetchedCorrectly() throws ExecutionException, InterruptedException
+    public void test_i_TestThatNullsAreSavedAndFetchedCorrectly() throws ExecutionException, InterruptedException
     {
         final String queryText = "select temperature from " + tableName + " " +
                 "where user = 'user2' and " +
@@ -225,7 +228,7 @@ public class ITestTimeSeries extends ITestTsBase
     }
 
     @Test
-    public void TestQueryingInvalidTableNameResultsInError() throws ExecutionException, InterruptedException
+    public void test_j_TestQueryingInvalidTableNameResultsInError() throws ExecutionException, InterruptedException
     {
         RiakClient client = new RiakClient(cluster);
 
@@ -239,7 +242,7 @@ public class ITestTimeSeries extends ITestTsBase
     }
 
     @Test
-    public void TestStoringDataOutOfOrderResultsInError() throws ExecutionException, InterruptedException
+    public void test_k_TestStoringDataOutOfOrderResultsInError() throws ExecutionException, InterruptedException
     {
         RiakClient client = new RiakClient(cluster);
 
@@ -253,7 +256,7 @@ public class ITestTimeSeries extends ITestTsBase
     }
 
     @Test
-    public void TestFetchingSingleRowsWorks() throws ExecutionException, InterruptedException
+    public void test_l_TestFetchingSingleRowsWorks() throws ExecutionException, InterruptedException
     {
         RiakClient client = new RiakClient(cluster);
 
@@ -271,7 +274,7 @@ public class ITestTimeSeries extends ITestTsBase
     }
 
     @Test
-    public void TestFetchingWithNotFoundKeyReturnsNoRows() throws ExecutionException, InterruptedException
+    public void test_m_TestFetchingWithNotFoundKeyReturnsNoRows() throws ExecutionException, InterruptedException
     {
         RiakClient client = new RiakClient(cluster);
 
@@ -284,7 +287,7 @@ public class ITestTimeSeries extends ITestTsBase
     }
 
     @Test
-    public void TestDeletingRowRemovesItFromQueries() throws ExecutionException, InterruptedException
+    public void test_n_TestDeletingRowRemovesItFromQueries() throws ExecutionException, InterruptedException
     {
         final List<Cell> keyCells = Arrays.asList(new Cell("hash2"), new Cell("user4"), com.basho.riak.client.core.query.timeseries.Cell
                 .newTimestamp(fiveMinsAgo));
@@ -311,7 +314,7 @@ public class ITestTimeSeries extends ITestTsBase
     }
 
     @Test
-    public void TestDeletingWithNotFoundKeyDoesNotReturnError() throws ExecutionException, InterruptedException
+    public void test_o_TestDeletingWithNotFoundKeyDoesNotReturnError() throws ExecutionException, InterruptedException
     {
         RiakClient client = new RiakClient(cluster);
 
@@ -322,11 +325,11 @@ public class ITestTimeSeries extends ITestTsBase
         final RiakFuture<Void, String> deleteFuture = client.executeAsync(delete);
 
         deleteFuture.await();
-        assertFutureSuccess(deleteFuture);
+        assertFutureFailure(deleteFuture);
     }
 
     @Test
-    public void TestDescribeTable() throws InterruptedException, ExecutionException
+    public void test_p_TestDescribeTable() throws InterruptedException, ExecutionException
     {
         RiakClient client = new RiakClient(cluster);
 
@@ -343,7 +346,7 @@ public class ITestTimeSeries extends ITestTsBase
     }
 
     @Test
-    public void TestDescribeTableCommand() throws InterruptedException, ExecutionException
+    public void test_q_TestDescribeTableCommand() throws InterruptedException, ExecutionException
     {
         RiakClient client = new RiakClient(cluster);
 
@@ -362,7 +365,7 @@ public class ITestTimeSeries extends ITestTsBase
     }
 
     @Test
-    public void TestDescribeTableCommandForNonExistingTable() throws InterruptedException, ExecutionException
+    public void test_r_TestDescribeTableCommandForNonExistingTable() throws InterruptedException, ExecutionException
     {
         RiakClient client = new RiakClient(cluster);
 
@@ -375,7 +378,7 @@ public class ITestTimeSeries extends ITestTsBase
 
         final String message = describeFuture.cause().getMessage();
         assertTrue(message.toLowerCase().contains(BAD_TABLE_NAME.toLowerCase()));
-        assertTrue(message.toLowerCase().contains("does not exist."));
+        assertTrue(message.toLowerCase().contains("not an active table."));
     }
 
     private static List<FullColumnDescription> GetCreatedTableFullDescriptions()

--- a/src/test/java/com/basho/riak/client/core/operations/itest/ts/ITestQueryOperation.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/ts/ITestQueryOperation.java
@@ -33,8 +33,9 @@ public class ITestQueryOperation extends ITestTsBase
     @Test
     public void queryNoMatches() throws ExecutionException, InterruptedException
     {
-        final String queryText = "select * from GeoCheckin " +
-                                 "where time > 0 " +
+        final String queryText = "select * from " +
+                                 tableName +
+                                 " where time > 0 " +
                                  "  and time < 10 " +
                                  "  and user ='user1'" +
                                  "  and geohash ='hash1'";
@@ -51,8 +52,9 @@ public class ITestQueryOperation extends ITestTsBase
     @Test
     public void querySomeMatches() throws ExecutionException, InterruptedException
     {
-        final String queryText = "select * from GeoCheckin " +
-                                 "where time > " + tenMinsAgo +
+        final String queryText = "select * from " +
+                                 tableName +
+                                 " where time > " + tenMinsAgo +
                                  "  and time < "+ now +
                                  "  and user ='user2'" +
                                  "  and geohash ='hash1'";

--- a/src/test/java/com/basho/riak/client/core/operations/itest/ts/ITestTsBase.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/ts/ITestTsBase.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertTrue;
  *
  * Schema for the Timeseries table we're using:
  *
- *   CREATE TABLE GeoCheckin
+ *   CREATE TABLE GeoCheckin_Wide
  *   (
  *      geohash     varchar   not null,
  *      user        varchar   not null,

--- a/src/test/java/com/basho/riak/client/core/operations/itest/ts/ITestTsBase.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/ts/ITestTsBase.java
@@ -42,7 +42,7 @@ import static org.junit.Assert.assertTrue;
  */
 public abstract class ITestTsBase extends ITestAutoCleanupBase
 {
-    protected final static String tableName = "GeoCheckin";
+    protected final static String tableName = "GeoCheckin_Wide";
 
     protected final static long now = 1443806900000L; // "now"
     protected final static long fiveMinsInMS = 5L * 60L * 1000L;


### PR DESCRIPTION
Make the main TS integration test run in top-to-bottom order.  Change two tests for behavior / messages that changed between TS 1.1 and 1.2. Switch table names to new version.
