### PR TITLE
An attempt to unify FutureOperation success and error handling

### DIFF
--- a/src/main/java/com/basho/riak/client/core/FutureOperation.java
+++ b/src/main/java/com/basho/riak/client/core/FutureOperation.java
@@ -246,7 +246,6 @@ public abstract class FutureOperation<T, U, S> implements RiakFuture<T,S>
         {
             // Connection should be returned before calling
             state = State.CLEANUP_WAIT;
-            setComplete();
         }
         else
         {
@@ -395,4 +394,12 @@ public abstract class FutureOperation<T, U, S> implements RiakFuture<T,S>
     @Override
     abstract public S getQueryInfo();
 
+    void setFailedDueToLackOfAvailableNodes(String message)
+    {
+        setException(new NoNodesAvailableException(message));
+        if (isDone())
+        {
+            setComplete();
+        }
+    }
 }

--- a/src/main/java/com/basho/riak/client/core/RiakCluster.java
+++ b/src/main/java/com/basho/riak/client/core/RiakCluster.java
@@ -249,7 +249,7 @@ public class  RiakCluster implements OperationRetrier, NodeStateListener
             }
             else // Out of connections, retrier will pick it up later.
             {
-                operation.setException(new NoNodesAvailableException());
+                operation.setFailedDueToLackOfAvailableNodes(null);
             }
         }
 
@@ -266,7 +266,7 @@ public class  RiakCluster implements OperationRetrier, NodeStateListener
         {
             logger.warn("No Nodes Available, and Operation Queue at Max Depth");
             operation.setRetrier(this, 1);
-            operation.setException(new NoNodesAvailableException("No Nodes Available, and Operation Queue at Max Depth"));
+            operation.setFailedDueToLackOfAvailableNodes("No Nodes Available, and Operation Queue at Max Depth");
             return;
         }
 
@@ -466,7 +466,7 @@ public class  RiakCluster implements OperationRetrier, NodeStateListener
 
         if (!gotConnection)
         {
-            operation.setException(new NoNodesAvailableException());
+            operation.setFailedDueToLackOfAvailableNodes(null);
         }
     }
 

--- a/src/test/java/com/basho/riak/client/core/FutureOperationTest.java
+++ b/src/test/java/com/basho/riak/client/core/FutureOperationTest.java
@@ -212,6 +212,7 @@ public class FutureOperationTest
         });
 
         operation.setException(new Exception());
+        operation.setComplete();
 
         assertTrue(operation.isDone());
         assertTrue(called.get());
@@ -237,6 +238,7 @@ public class FutureOperationTest
 
         operation.setResponse(response);
         operation.setException(new Exception());
+        operation.setComplete();
 
         assertEquals(1, called.get());
         assertTrue(operation.isDone());


### PR DESCRIPTION
@alexmoore Not sure whether the resulting code is more intuitive than the original code, please feel free to drop it off
