### PR TITLE
Bump plugins and dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <powermock.version>1.6.4</powermock.version>
+        <powermock.version>1.6.5</powermock.version>
+        <slf4j.version>1.7.21</slf4j.version>
+        <jackson.version>2.8.0</jackson.version>
     </properties>
 
     <distributionManagement>
@@ -89,7 +91,7 @@
                 <dependency>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-nop</artifactId>
-                    <version>1.7.5</version>
+                    <version>${slf4j.version}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -100,7 +102,7 @@
                 <dependency>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-simple</artifactId>
-                    <version>1.7.5</version>
+                    <version>${slf4j.version}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -287,7 +289,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.2</version>
+                <version>2.5.3</version>
                 <configuration>
                     <mavenExecutorId>forked-path</mavenExecutorId>
                 </configuration>
@@ -295,7 +297,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.4.201502262128</version>
+                <version>0.7.7.201606060606</version>
                 <executions>
                     <execution>
                         <id>jacoco-initialize</id>
@@ -330,7 +332,7 @@
                 be used even when compiling with java 1.8+ -->
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>1.14</version>
+                <version>1.15</version>
                 <configuration>
                     <signature>
                         <groupId>org.codehaus.mojo.signature</groupId>
@@ -350,7 +352,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.14</version>
+                <version>2.19.1</version>
                 <configuration>
                     <systemPropertyVariables>
                         <org.slf4j.simpleLogger.defaultLogLevel>debug</org.slf4j.simpleLogger.defaultLogLevel>
@@ -362,7 +364,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.3</version>
+                <version>2.10.4</version>
                 <configuration>
                     <excludePackageNames>com.basho.riak.protobuf.util</excludePackageNames>
                 </configuration>
@@ -373,7 +375,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.21</version>
+            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
@@ -402,24 +404,24 @@
         <dependency>
             <groupId>com.jayway.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>1.3.5</version>
+            <version>1.6.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.7.3</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-joda</artifactId>
-            <version>2.7.3</version>
+            <version>${jackson.version}</version>
             <type>jar</type>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.0.33.Final</version>
+            <version>4.0.38.Final</version>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>
@@ -429,7 +431,7 @@
         <dependency>
             <groupId>org.erlang.otp</groupId>
             <artifactId>jinterface</artifactId>
-            <version>1.5.6</version>
+            <version>1.6.1</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -421,7 +421,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.0.38.Final</version>
+            <version>4.1.3.Final</version>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>

--- a/src/main/java/com/basho/riak/client/core/RiakCluster.java
+++ b/src/main/java/com/basho/riak/client/core/RiakCluster.java
@@ -424,7 +424,7 @@ public class  RiakCluster implements OperationRetrier, NodeStateListener
                 {
                     this.state = State.SHUTDOWN;
                     executor.shutdown();
-                    bootstrap.group().shutdownGracefully();
+                    bootstrap.config().group().shutdownGracefully();
                     logger.debug("RiakCluster shut down bootstrap");
                     logger.info("RiakCluster has shut down");
                     shutdownLatch.countDown();

--- a/src/main/java/com/basho/riak/client/core/RiakNode.java
+++ b/src/main/java/com/basho/riak/client/core/RiakNode.java
@@ -1243,7 +1243,7 @@ public class RiakNode implements RiakResponseListener
                 }
                 if (ownsBootstrap)
                 {
-                    bootstrap.group().shutdownGracefully();
+                    bootstrap.config().group().shutdownGracefully();
                 }
                 logger.debug("RiakNode shut down {}:{}", remoteAddress, port);
                 shutdownLatch.countDown();


### PR DESCRIPTION
Bump plugins and dependencies, the following are the most relevant:
- Netty to 4.0.38.Final
- Jackson to 2.8.0
- Slf4j to 1.7.21
- Jinterface to 1.6.1

It all compiles and all tests ran locally passed.
