### PR TITLE
Make domain name more invalid for UnknownHostException test.

### DIFF
--- a/src/test/java/com/basho/riak/client/core/RiakNodeTest.java
+++ b/src/test/java/com/basho/riak/client/core/RiakNodeTest.java
@@ -532,7 +532,7 @@ public class RiakNodeTest
 
     @Test(expected = UnknownHostException.class )
     public void failsResolvingHostname() throws UnknownHostException {
-        RiakNode node = new RiakNode.Builder().withRemoteAddress("invalid-host-name.com").build();
+        RiakNode node = new RiakNode.Builder().withRemoteAddress("invalid-host-name").build();
         node.start();
     }
 


### PR DESCRIPTION
Makes the domain name more invalid for the RiakNodeTest::failsResolvingHostname test.  
The current test domain name is taken on some of our Mesos workers that we use for testing.

Fixes #640 (CLIENTS-926) 
