### PR TITLE
Add timeout-constrained version of execute on RiakClient

### DIFF
--- a/src/main/java/com/basho/riak/client/api/RiakClient.java
+++ b/src/main/java/com/basho/riak/client/api/RiakClient.java
@@ -330,38 +330,38 @@ public class RiakClient
 		return command.execute(cluster);
 	}
 
-	/**
-	 * Execute a RiakCommand synchronously with a specified client timeout.
-	 * <p>
-	 * Calling this method causes the client to execute the provided RiakCommand synchronously. 
-	 * It will block until the operation completes or up to the given timeout.
-	 * It will either return the response on success or throw an
-	 * exception on failure.
-	 * Note: Using this timeout is different that setting a timeout on the command 
+    /**
+     * Execute a RiakCommand synchronously with a specified client timeout.
+     * <p>
+     * Calling this method causes the client to execute the provided RiakCommand synchronously. 
+     * It will block until the operation completes or up to the given timeout.
+     * It will either return the response on success or throw an
+     * exception on failure.
+     * Note: Using this timeout is different that setting a timeout on the command 
      * itself using the timeout() method of the command's associated builder. 
      * The command timeout is a Riak-side timeout value. This timeout is client-side.
-	 * </p>
-	 *
-	 * @param command
-	 *            The RiakCommand to execute.
+     * </p>
+     *
+     * @param command
+     *            The RiakCommand to execute.
      * @param timeout the amount of time to wait before returning an exception
      * @param unit the unit of time.
-	 * @param <T>
-	 *            The RiakCommand's return type.
-	 * @param <S>
-	 *            The RiakCommand's query info type.
-	 * @return a response from Riak.
-	 * @throws ExecutionException
-	 *             if the command fails for any reason.
-	 * @throws InterruptedException
-	 * @throws TimeoutException
-	 *             if the call to execute the command did not finish within the time limit
-	 */
-	public <T, S> T execute(RiakCommand<T, S> command, long timeout, TimeUnit unit) throws ExecutionException,
-		InterruptedException, TimeoutException {
-		return command.execute(cluster, timeout, unit);
-	}
-	
+     * @param <T>
+     *            The RiakCommand's return type.
+     * @param <S>
+     *            The RiakCommand's query info type.
+     * @return a response from Riak.
+     * @throws ExecutionException
+     *             if the command fails for any reason.
+     * @throws InterruptedException
+     * @throws TimeoutException
+     *             if the call to execute the command did not finish within the time limit
+     */
+    public <T, S> T execute(RiakCommand<T, S> command, long timeout, TimeUnit unit) throws ExecutionException,
+    InterruptedException, TimeoutException {
+        return command.execute(cluster, timeout, unit);
+    }
+    
     /**
      * Execute a RiakCommand asynchronously.
      * <p>

--- a/src/main/java/com/basho/riak/client/api/RiakClient.java
+++ b/src/main/java/com/basho/riak/client/api/RiakClient.java
@@ -26,6 +26,8 @@ import java.util.List;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 
 /**
@@ -328,6 +330,38 @@ public class RiakClient
 		return command.execute(cluster);
 	}
 
+	/**
+	 * Execute a RiakCommand synchronously with a specified client timeout.
+	 * <p>
+	 * Calling this method causes the client to execute the provided RiakCommand synchronously. 
+	 * It will block until the operation completes or up to the given timeout.
+	 * It will either return the response on success or throw an
+	 * exception on failure.
+	 * Note: Using this timeout is different that setting a timeout on the command 
+     * itself using the timeout() method of the command's associated builder. 
+     * The command timeout is a Riak-side timeout value. This timeout is client-side.
+	 * </p>
+	 *
+	 * @param command
+	 *            The RiakCommand to execute.
+     * @param timeout the amount of time to wait before returning an exception
+     * @param unit the unit of time.
+	 * @param <T>
+	 *            The RiakCommand's return type.
+	 * @param <S>
+	 *            The RiakCommand's query info type.
+	 * @return a response from Riak.
+	 * @throws ExecutionException
+	 *             if the command fails for any reason.
+	 * @throws InterruptedException
+	 * @throws TimeoutException
+	 *             if the call to execute the command did not finish within the time limit
+	 */
+	public <T, S> T execute(RiakCommand<T, S> command, long timeout, TimeUnit unit) throws ExecutionException,
+		InterruptedException, TimeoutException {
+		return command.execute(cluster, timeout, unit);
+	}
+	
     /**
      * Execute a RiakCommand asynchronously.
      * <p>

--- a/src/main/java/com/basho/riak/client/api/RiakCommand.java
+++ b/src/main/java/com/basho/riak/client/api/RiakCommand.java
@@ -91,11 +91,11 @@ public abstract class RiakCommand<T,S>
         return future.get();
     }
     
-	protected final T execute(RiakCluster cluster, long timeout, TimeUnit unit) throws ExecutionException,
-		InterruptedException, TimeoutException {
-		RiakFuture<T, S> future = executeAsync(cluster);
-		return future.get(timeout, unit);
-	}
+    protected final T execute(RiakCluster cluster, long timeout, TimeUnit unit) throws ExecutionException,
+    InterruptedException, TimeoutException {
+        RiakFuture<T, S> future = executeAsync(cluster);
+        return future.get(timeout, unit);
+    }
     
     protected abstract RiakFuture<T,S> executeAsync(RiakCluster cluster);    
 } 

--- a/src/main/java/com/basho/riak/client/api/RiakCommand.java
+++ b/src/main/java/com/basho/riak/client/api/RiakCommand.java
@@ -18,6 +18,7 @@ package com.basho.riak.client.api;
 
 import com.basho.riak.client.core.RiakCluster;
 import com.basho.riak.client.core.RiakFuture;
+
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -25,7 +26,7 @@ import java.util.concurrent.TimeoutException;
 /**
  * The base class for all Riak Commands.
  * <p>
- * All the commands the {@link RiakClient} can execute extend this class. 
+ * All the commands the {@link RiakClient} can execute extend this class.
  * <h2>Client Commands</h2>
  * <h4>Fetching, storing and deleting objects</h4>
  * <ul>
@@ -67,8 +68,8 @@ import java.util.concurrent.TimeoutException;
  * <li>{@link com.basho.riak.client.api.commands.search.DeleteIndex}</li>
  * <li>{@link com.basho.riak.client.api.commands.search.FetchSchema}</li>
  * <li>{@link com.basho.riak.client.api.commands.search.StoreSchema}</li>
-* </ul>
-* <h4>Map-Reduce</h4>
+ * </ul>
+ * <h4>Map-Reduce</h4>
  * <ul>
  * <li>{@link com.basho.riak.client.api.commands.mapreduce.BucketMapReduce}</li>
  * <li>{@link com.basho.riak.client.api.commands.mapreduce.BucketKeyMapReduce}</li>
@@ -76,27 +77,29 @@ import java.util.concurrent.TimeoutException;
  * <li>{@link com.basho.riak.client.api.commands.mapreduce.SearchMapReduce}</li>
  * </ul>
  * </p>
- * @author Dave Rusek
- * @author Brian Roach <roach at basho.com>
+ *
  * @param <T> The response type
  * @param <S> The query info type
+ * @author Dave Rusek
+ * @author Brian Roach <roach at basho.com>
  * @since 2.0
  */
-public abstract class RiakCommand<T,S>
+public abstract class RiakCommand<T, S>
 {
     protected final T execute(RiakCluster cluster) throws ExecutionException, InterruptedException
     {
-        RiakFuture<T,S> future = executeAsync(cluster);
+        RiakFuture<T, S> future = executeAsync(cluster);
         future.await();
         return future.get();
     }
-    
-    protected final T execute(RiakCluster cluster, long timeout, TimeUnit unit) throws ExecutionException,
-    InterruptedException, TimeoutException {
+
+    protected final T execute(RiakCluster cluster, long timeout, TimeUnit unit)
+            throws ExecutionException, InterruptedException, TimeoutException
+    {
         RiakFuture<T, S> future = executeAsync(cluster);
         return future.get(timeout, unit);
     }
-    
-    protected abstract RiakFuture<T,S> executeAsync(RiakCluster cluster);    
-} 
+
+    protected abstract RiakFuture<T, S> executeAsync(RiakCluster cluster);
+}
 

--- a/src/main/java/com/basho/riak/client/api/RiakCommand.java
+++ b/src/main/java/com/basho/riak/client/api/RiakCommand.java
@@ -19,6 +19,8 @@ package com.basho.riak.client.api;
 import com.basho.riak.client.core.RiakCluster;
 import com.basho.riak.client.core.RiakFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * The base class for all Riak Commands.
@@ -88,6 +90,13 @@ public abstract class RiakCommand<T,S>
         future.await();
         return future.get();
     }
+    
+	protected final T execute(RiakCluster cluster, long timeout, TimeUnit unit) throws ExecutionException,
+		InterruptedException, TimeoutException {
+		RiakFuture<T, S> future = executeAsync(cluster);
+		return future.get(timeout, unit);
+	}
+    
     protected abstract RiakFuture<T,S> executeAsync(RiakCluster cluster);    
 } 
 

--- a/src/test/java/com/basho/riak/client/core/RiakClientTest.java
+++ b/src/test/java/com/basho/riak/client/core/RiakClientTest.java
@@ -50,6 +50,8 @@ public class RiakClientTest
     public class CommandFake extends RiakCommand<String, String>
     {
         private boolean executeAsyncCalled = false;
+
+        @SuppressWarnings("unchecked")
         private RiakFuture<String, String> mockFuture = (RiakFuture<String, String>) mock(RiakFuture.class);
 
         @Override

--- a/src/test/java/com/basho/riak/client/core/RiakClientTest.java
+++ b/src/test/java/com/basho/riak/client/core/RiakClientTest.java
@@ -1,0 +1,72 @@
+package com.basho.riak.client.core;
+
+import com.basho.riak.client.api.RiakClient;
+import com.basho.riak.client.api.RiakCommand;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.net.UnknownHostException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+/**
+ *
+ * @author Alex Moore <amoore at basho dot com>
+ */
+public class RiakClientTest
+{
+    private static RiakClient client = new RiakClient(mock(RiakCluster.class));
+
+    @Test
+    public void clientExecutesCommand() throws UnknownHostException, ExecutionException, InterruptedException
+    {
+        final CommandFake command = new CommandFake();
+
+        client.execute(command);
+        assertTrue(command.executeAsyncCalled);
+    }
+
+    @Test
+    public void clientExecutesTimeoutCommand()
+            throws UnknownHostException, ExecutionException, InterruptedException, TimeoutException
+    {
+        final CommandFake command = new CommandFake();
+
+        client.execute(command, 1, TimeUnit.SECONDS);
+        assertTrue(command.executeAsyncCalled);
+        verify(command.getMockFuture()).get(1, TimeUnit.SECONDS);
+    }
+
+    public class CommandFake extends RiakCommand<String, String>
+    {
+        private boolean executeAsyncCalled = false;
+        private RiakFuture<String, String> mockFuture = (RiakFuture<String, String>) mock(RiakFuture.class);
+
+        @Override
+        protected RiakFuture<String, String> executeAsync(RiakCluster cluster)
+        {
+            executeAsyncCalled = true;
+            return mockFuture;
+        }
+
+        public boolean wasExecuteAsyncCalled()
+        {
+            return executeAsyncCalled;
+        }
+
+        public RiakFuture<String, String> getMockFuture()
+        {
+            return mockFuture;
+        }
+    }
+}


### PR DESCRIPTION
This supersedes PR #610 (CLIENTS-922), by adding tests to the original PR. 
