### PR TITLE
Add equals(), hashCode() and toString() to RiakObject and friends

### DIFF
--- a/src/main/java/com/basho/riak/client/api/commands/indexes/BinIndexQuery.java
+++ b/src/main/java/com/basho/riak/client/api/commands/indexes/BinIndexQuery.java
@@ -16,10 +16,10 @@
 
 package com.basho.riak.client.api.commands.indexes;
 
+import com.basho.riak.client.api.commands.CoreFutureAdapter;
 import com.basho.riak.client.core.RiakCluster;
 import com.basho.riak.client.core.RiakFuture;
 import com.basho.riak.client.core.operations.SecondaryIndexQueryOperation;
-import com.basho.riak.client.api.commands.CoreFutureAdapter;
 import com.basho.riak.client.core.query.Location;
 import com.basho.riak.client.core.query.Namespace;
 import com.basho.riak.client.core.util.BinaryValue;
@@ -34,7 +34,7 @@ import java.util.List;
  * <script src="https://google-code-prettify.googlecode.com/svn/loader/run_prettify.js"></script>
  * <p>
  * A RawIndexQuery is used when you are using strings for your 2i keys. The
- * parameters are provided as String objects. 
+ * parameters are provided as String objects.
  * </p>
  * <pre class="prettyprint">
  * {@code
@@ -42,6 +42,7 @@ import java.util.List;
  * String key = "some_key";
  * BinIndexQuery q = new BinIndexQuery.Builder(ns, "my_index", key).build();
  * BinIndexQuery.Response resp = client.execute(q);}</pre>
+ *
  * @author Brian Roach <roach at basho dot com>
  * @since 2.0
  */
@@ -50,14 +51,14 @@ public class BinIndexQuery extends SecondaryIndexQuery<String, BinIndexQuery.Res
     private final Charset charset;
     private final IndexConverter<String> converter;
 
-    protected  BinIndexQuery(Init<String,?> builder)
+    protected BinIndexQuery(Init<String, ?> builder)
     {
         super(builder);
         this.charset = builder.charset;
         this.converter = new StringIndexConverter();
     }
 
-    @Override 
+    @Override
     protected IndexConverter<String> getConverter()
     {
         return converter;
@@ -67,8 +68,8 @@ public class BinIndexQuery extends SecondaryIndexQuery<String, BinIndexQuery.Res
     protected RiakFuture<Response, BinIndexQuery> executeAsync(RiakCluster cluster)
     {
         RiakFuture<SecondaryIndexQueryOperation.Response, SecondaryIndexQueryOperation.Query> coreFuture =
-            executeCoreAsync(cluster);
-        
+                executeCoreAsync(cluster);
+
         BinQueryFuture future = new BinQueryFuture(coreFuture);
         coreFuture.addListener(future);
         return future;
@@ -77,22 +78,31 @@ public class BinIndexQuery extends SecondaryIndexQuery<String, BinIndexQuery.Res
     @Override
     public boolean equals(Object o)
     {
-        if (this == o) {
+        if (this == o)
+        {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (o == null || getClass() != o.getClass())
+        {
             return false;
         }
-        if (!super.equals(o)) {
+        if (!super.equals(o))
+        {
             return false;
         }
 
         BinIndexQuery that = (BinIndexQuery) o;
-        if (!charset.equals(that.charset)) {
+
+        if (!charset.equals(that.charset))
+        {
+            return false;
+        }
+        if (!converter.equals(that.converter))
+        {
             return false;
         }
 
-        return converter.equals(that.converter);
+        return true;
     }
 
     @Override
@@ -104,27 +114,7 @@ public class BinIndexQuery extends SecondaryIndexQuery<String, BinIndexQuery.Res
         return result;
     }
 
-    protected final class BinQueryFuture extends CoreFutureAdapter<Response, BinIndexQuery, SecondaryIndexQueryOperation.Response, SecondaryIndexQueryOperation.Query>
-    {
-        public BinQueryFuture(RiakFuture<SecondaryIndexQueryOperation.Response, SecondaryIndexQueryOperation.Query> coreFuture)
-        {
-            super(coreFuture);
-        }
-        
-        @Override
-        protected Response convertResponse(SecondaryIndexQueryOperation.Response coreResponse)
-        {
-            return new Response(namespace, coreResponse, converter);
-        }
-
-        @Override
-        protected BinIndexQuery convertQueryInfo(SecondaryIndexQueryOperation.Query coreQueryInfo)
-        {
-            return BinIndexQuery.this;
-        }
-    }
-    
-    protected static abstract class Init<S, T extends Init<S,T>> extends SecondaryIndexQuery.Init<S,T>
+    protected static abstract class Init<S, T extends Init<S, T>> extends SecondaryIndexQuery.Init<S, T>
     {
         private Charset charset = DefaultCharset.get();
 
@@ -156,12 +146,13 @@ public class BinIndexQuery extends SecondaryIndexQuery<String, BinIndexQuery.Res
          * Construct a Builder for a BinIndexQuery with a range.
          * <p>
          * Note that your index name should not include the Riak {@literal _int} or
-         * {@literal _bin} extension. 
+         * {@literal _bin} extension.
          * <p>
+         *
          * @param namespace The namespace in Riak to query.
          * @param indexName The index name in Riak to query.
-         * @param start The start of the 2i range.
-         * @param end The end of the 2i range.
+         * @param start     The start of the 2i range.
+         * @param end       The end of the 2i range.
          */
         public Builder(Namespace namespace, String indexName, String start, String end)
         {
@@ -172,11 +163,12 @@ public class BinIndexQuery extends SecondaryIndexQuery<String, BinIndexQuery.Res
          * Construct a Builder for a BinIndexQuery with a single 2i key.
          * <p>
          * Note that your index name should not include the Riak {@literal _int} or
-         * {@literal _bin} extension. 
+         * {@literal _bin} extension.
          * <p>
+         *
          * @param namespace The namespace in Riak to query.
          * @param indexName The name of the index in Riak.
-         * @param match the 2i key.
+         * @param match     the 2i key.
          */
         public Builder(Namespace namespace, String indexName, String match)
         {
@@ -191,6 +183,7 @@ public class BinIndexQuery extends SecondaryIndexQuery<String, BinIndexQuery.Res
 
         /**
          * Construct the query.
+         *
          * @return a new BinIndexQuery
          */
         public BinIndexQuery build()
@@ -199,14 +192,16 @@ public class BinIndexQuery extends SecondaryIndexQuery<String, BinIndexQuery.Res
         }
 
     }
-    
+
     public static class Response extends SecondaryIndexQuery.Response<String>
     {
-        protected Response(Namespace queryLocation, SecondaryIndexQueryOperation.Response coreResponse, IndexConverter<String> converter)
+        protected Response(Namespace queryLocation,
+                           SecondaryIndexQueryOperation.Response coreResponse,
+                           IndexConverter<String> converter)
         {
             super(queryLocation, coreResponse, converter);
         }
-        
+
         @Override
         public List<Entry> getEntries()
         {
@@ -230,6 +225,29 @@ public class BinIndexQuery extends SecondaryIndexQuery<String, BinIndexQuery.Res
         }
     }
 
+    protected final class BinQueryFuture
+            extends CoreFutureAdapter<Response, BinIndexQuery, SecondaryIndexQueryOperation.Response,
+            SecondaryIndexQueryOperation.Query>
+    {
+        public BinQueryFuture(RiakFuture<SecondaryIndexQueryOperation.Response, SecondaryIndexQueryOperation.Query>
+                                      coreFuture)
+        {
+            super(coreFuture);
+        }
+
+        @Override
+        protected Response convertResponse(SecondaryIndexQueryOperation.Response coreResponse)
+        {
+            return new Response(namespace, coreResponse, converter);
+        }
+
+        @Override
+        protected BinIndexQuery convertQueryInfo(SecondaryIndexQueryOperation.Query coreQueryInfo)
+        {
+            return BinIndexQuery.this;
+        }
+    }
+
     private class StringIndexConverter implements IndexConverter<String>
     {
         @Override
@@ -247,10 +265,12 @@ public class BinIndexQuery extends SecondaryIndexQuery<String, BinIndexQuery.Res
         @Override
         public boolean equals(Object o)
         {
-            if (this == o) {
+            if (this == o)
+            {
                 return true;
             }
-            if (o == null || getClass() != o.getClass()) {
+            if (o == null || getClass() != o.getClass())
+            {
                 return false;
             }
             return true;

--- a/src/main/java/com/basho/riak/client/api/commands/indexes/SecondaryIndexQuery.java
+++ b/src/main/java/com/basho/riak/client/api/commands/indexes/SecondaryIndexQuery.java
@@ -23,39 +23,21 @@ import com.basho.riak.client.core.operations.SecondaryIndexQueryOperation;
 import com.basho.riak.client.core.query.Location;
 import com.basho.riak.client.core.query.Namespace;
 import com.basho.riak.client.core.util.BinaryValue;
+
 import java.util.List;
 
 /**
-     * A Secondary Index Query.
-     * <p>
-     * Serves as a base class for all 2i queries.
-     * <p>
-     * @param <S> the type being used for the query.
-     * 
-     * @author Brian Roach <roach at basho dot com>
-     * @since 2.0
-     */
-public abstract class SecondaryIndexQuery<T,S,U> extends RiakCommand<S, U> 
+ * A Secondary Index Query.
+ * <p>
+ * Serves as a base class for all 2i queries.
+ * <p>
+ *
+ * @param <S> the type being used for the query.
+ * @author Brian Roach <roach at basho dot com>
+ * @since 2.0
+ */
+public abstract class SecondaryIndexQuery<T, S, U> extends RiakCommand<S, U>
 {
-    public enum Type
-    {
-        _INT("_int"), _BIN("_bin"), _BUCKET(""), _KEY("");
-        
-        private String suffix;
-        
-        Type(String suffix)
-        {
-            this.suffix = suffix;
-        }
-        
-        @Override
-        public String toString()
-        {
-            return suffix;
-        }
-    }
-    
-    
     protected final Namespace namespace;
     protected final String indexName;
     protected final BinaryValue continuation;
@@ -67,10 +49,7 @@ public abstract class SecondaryIndexQuery<T,S,U> extends RiakCommand<S, U>
     protected final boolean paginationSort;
     protected final String termFilter;
     protected Integer timeout;
-
-    protected abstract IndexConverter<T> getConverter();
-
-    protected SecondaryIndexQuery(Init<T,?> builder)
+    protected SecondaryIndexQuery(Init<T, ?> builder)
     {
         this.namespace = builder.namespace;
         this.indexName = builder.indexName;
@@ -85,8 +64,11 @@ public abstract class SecondaryIndexQuery<T,S,U> extends RiakCommand<S, U>
         this.timeout = builder.timeout;
     }
 
+    protected abstract IndexConverter<T> getConverter();
+
     /**
      * Get the location for this query.
+     *
      * @return the location encompassing a bucket and bucket type.
      */
     public Namespace getNamespace()
@@ -96,6 +78,7 @@ public abstract class SecondaryIndexQuery<T,S,U> extends RiakCommand<S, U>
 
     /**
      * Get the full index name for this query.
+     *
      * @return the index name including Riak suffix.
      */
     public String getIndexName()
@@ -105,6 +88,7 @@ public abstract class SecondaryIndexQuery<T,S,U> extends RiakCommand<S, U>
 
     /**
      * Get the match value supplied for this query.
+     *
      * @return the single index key to match, or null if not present
      */
     public T getMatchValue()
@@ -114,6 +98,7 @@ public abstract class SecondaryIndexQuery<T,S,U> extends RiakCommand<S, U>
 
     /**
      * Get the range start value for this query.
+     *
      * @return the range start, or null if not present.
      */
     public T getRangeStart()
@@ -123,6 +108,7 @@ public abstract class SecondaryIndexQuery<T,S,U> extends RiakCommand<S, U>
 
     /**
      * Get the range end value for this query.
+     *
      * @return the range end value, or null if not present
      */
     public T getRangeEnd()
@@ -132,6 +118,7 @@ public abstract class SecondaryIndexQuery<T,S,U> extends RiakCommand<S, U>
 
     /**
      * Get the max number of results for this query.
+     *
      * @return the max number of results, or null if not present.
      */
     public Integer getMaxResults()
@@ -140,7 +127,8 @@ public abstract class SecondaryIndexQuery<T,S,U> extends RiakCommand<S, U>
     }
 
     /**
-     * Get whether this query will return both index keys and object keys. 
+     * Get whether this query will return both index keys and object keys.
+     *
      * @return true if specified, false otherwise.
      */
     public boolean getReturnKeyAndIndex()
@@ -150,6 +138,7 @@ public abstract class SecondaryIndexQuery<T,S,U> extends RiakCommand<S, U>
 
     /**
      * Get the pagination sort setting.
+     *
      * @return true if set, false otherwise.
      */
     public boolean getPaginationSort()
@@ -159,6 +148,7 @@ public abstract class SecondaryIndexQuery<T,S,U> extends RiakCommand<S, U>
 
     /**
      * Get the regex term filter for this query.
+     *
      * @return the filter, or null if not set.
      */
     public String getTermFilter()
@@ -168,6 +158,7 @@ public abstract class SecondaryIndexQuery<T,S,U> extends RiakCommand<S, U>
 
     /**
      * Get the continuation supplied for this query.
+     *
      * @return the continuation, or null if not set.
      */
     public BinaryValue getContinuation()
@@ -177,22 +168,23 @@ public abstract class SecondaryIndexQuery<T,S,U> extends RiakCommand<S, U>
 
     /**
      * Get the timeout value for this query.
+     *
      * @return the timeout value, or null if not set.
      */
     public Integer getTimeout()
     {
         return timeout;
     }
-    
+
     protected final SecondaryIndexQueryOperation.Query createCoreQuery()
     {
         IndexConverter<T> converter = getConverter();
 
-        SecondaryIndexQueryOperation.Query.Builder coreQueryBuilder =
-            new SecondaryIndexQueryOperation.Query.Builder(namespace, BinaryValue.create(indexName))
-                .withContinuation(continuation)
-                .withReturnKeyAndIndex(returnTerms)
-                .withPaginationSort(paginationSort);
+        SecondaryIndexQueryOperation.Query.Builder coreQueryBuilder = new SecondaryIndexQueryOperation.Query.Builder(
+                namespace,
+                BinaryValue.create(indexName)).withContinuation(continuation)
+                                              .withReturnKeyAndIndex(returnTerms)
+                                              .withPaginationSort(paginationSort);
 
         if (termFilter != null)
         {
@@ -205,15 +197,14 @@ public abstract class SecondaryIndexQuery<T,S,U> extends RiakCommand<S, U>
         }
         else
         {
-            coreQueryBuilder.withRangeStart(converter.convert(start))
-                            .withRangeEnd(converter.convert(end));
+            coreQueryBuilder.withRangeStart(converter.convert(start)).withRangeEnd(converter.convert(end));
         }
 
         if (maxResults != null)
         {
             coreQueryBuilder.withMaxResults(maxResults);
         }
-        
+
         if (timeout != null)
         {
             coreQueryBuilder.withTimeout(timeout);
@@ -222,55 +213,66 @@ public abstract class SecondaryIndexQuery<T,S,U> extends RiakCommand<S, U>
         return coreQueryBuilder.build();
     }
 
-    protected RiakFuture<SecondaryIndexQueryOperation.Response, 
-                        SecondaryIndexQueryOperation.Query> executeCoreAsync(RiakCluster cluster)
+    protected RiakFuture<SecondaryIndexQueryOperation.Response, SecondaryIndexQueryOperation.Query> executeCoreAsync(
+            RiakCluster cluster)
     {
-        SecondaryIndexQueryOperation.Builder builder =
-            new SecondaryIndexQueryOperation.Builder(this.createCoreQuery());
-        
+        SecondaryIndexQueryOperation.Builder builder = new SecondaryIndexQueryOperation.Builder(this.createCoreQuery());
+
         return cluster.execute(builder.build());
     }
 
     @Override
     public boolean equals(Object o)
     {
-        if (this == o) {
+        if (this == o)
+        {
             return true;
         }
-        if (!(o instanceof SecondaryIndexQuery)) {
+        if (!(o instanceof SecondaryIndexQuery))
+        {
             return false;
         }
 
         SecondaryIndexQuery<?, ?, ?> that = (SecondaryIndexQuery<?, ?, ?>) o;
 
-        if (returnTerms != that.returnTerms) {
+        if (returnTerms != that.returnTerms)
+        {
             return false;
         }
-        if (paginationSort != that.paginationSort) {
+        if (paginationSort != that.paginationSort)
+        {
             return false;
         }
-        if (namespace != null ? !namespace.equals(that.namespace) : that.namespace != null) {
+        if (namespace != null ? !namespace.equals(that.namespace) : that.namespace != null)
+        {
             return false;
         }
-        if (indexName != null ? !indexName.equals(that.indexName) : that.indexName != null) {
+        if (indexName != null ? !indexName.equals(that.indexName) : that.indexName != null)
+        {
             return false;
         }
-        if (continuation != null ? !continuation.equals(that.continuation) : that.continuation != null) {
+        if (continuation != null ? !continuation.equals(that.continuation) : that.continuation != null)
+        {
             return false;
         }
-        if (match != null ? !match.equals(that.match) : that.match != null) {
+        if (match != null ? !match.equals(that.match) : that.match != null)
+        {
             return false;
         }
-        if (start != null ? !start.equals(that.start) : that.start != null) {
+        if (start != null ? !start.equals(that.start) : that.start != null)
+        {
             return false;
         }
-        if (end != null ? !end.equals(that.end) : that.end != null) {
+        if (end != null ? !end.equals(that.end) : that.end != null)
+        {
             return false;
         }
-        if (maxResults != null ? !maxResults.equals(that.maxResults) : that.maxResults != null) {
+        if (maxResults != null ? !maxResults.equals(that.maxResults) : that.maxResults != null)
+        {
             return false;
         }
-        if (termFilter != null ? !termFilter.equals(that.termFilter) : that.termFilter != null) {
+        if (termFilter != null ? !termFilter.equals(that.termFilter) : that.termFilter != null)
+        {
             return false;
         }
         return !(timeout != null ? !timeout.equals(that.timeout) : that.timeout != null);
@@ -311,13 +313,35 @@ public abstract class SecondaryIndexQuery<T,S,U> extends RiakCommand<S, U>
                 '}';
     }
 
+    public enum Type
+    {
+        _INT("_int"),
+        _BIN("_bin"),
+        _BUCKET(""),
+        _KEY("");
+
+        private String suffix;
+
+        Type(String suffix)
+        {
+            this.suffix = suffix;
+        }
+
+        @Override
+        public String toString()
+        {
+            return suffix;
+        }
+    }
+
     protected interface IndexConverter<T>
     {
         T convert(BinaryValue input);
+
         BinaryValue convert(T input);
     }
-    
-    public static abstract class Init<S, T extends Init<S,T>>
+
+    public static abstract class Init<S, T extends Init<S, T>>
     {
         private final Namespace namespace;
         private final String indexName;
@@ -331,18 +355,17 @@ public abstract class SecondaryIndexQuery<T,S,U> extends RiakCommand<S, U>
         private volatile String termFilter;
         private volatile Integer timeout;
 
-        protected abstract T self();
-
         /**
          * Build a range query.
          * <p>
          * Returns all objects in Riak that have an index value
          * in the specified range.
          * </p>
+         *
          * @param namespace the namespace for this query.
          * @param indexName the indexname
-         * @param start the start index value
-         * @param end the end index value
+         * @param start     the start index value
+         * @param end       the end index value
          */
         public Init(Namespace namespace, String indexName, S start, S end)
         {
@@ -358,9 +381,10 @@ public abstract class SecondaryIndexQuery<T,S,U> extends RiakCommand<S, U>
          * Returns all objects in Riak that have an index value matching the
          * one supplied.
          * </p>
+         *
          * @param namespace the namespace for this query
          * @param indexName the index name
-         * @param match the index value.
+         * @param match     the index value.
          */
         public Init(Namespace namespace, String indexName, S match)
         {
@@ -369,11 +393,14 @@ public abstract class SecondaryIndexQuery<T,S,U> extends RiakCommand<S, U>
             this.match = match;
         }
 
+        protected abstract T self();
+
         /**
          * Set the continuation for this query.
          * <p>
-         * The continuation is returned by a previous paginated query.  
+         * The continuation is returned by a previous paginated query.
          * </p>
+         *
          * @param continuation
          * @return a reference to this object.
          */
@@ -385,19 +412,21 @@ public abstract class SecondaryIndexQuery<T,S,U> extends RiakCommand<S, U>
 
         /**
          * Set the maximum number of results returned by the query.
+         *
          * @param maxResults the number of results.
          * @return a reference to this object.
          */
         public T withMaxResults(Integer maxResults)
         {
             this.maxResults = maxResults;
-            return self();            
+            return self();
         }
 
         /**
          * Set whether to return the index keys with the Riak object keys.
          * Setting this to true will return both the index key and the Riak
          * object's key. The default is false (only to return the Riak object keys).
+         *
          * @param returnBoth true to return both index and object keys, false to return only object keys.
          * @return a reference to this object.
          */
@@ -414,9 +443,9 @@ public abstract class SecondaryIndexQuery<T,S,U> extends RiakCommand<S, U>
          * </p>
          * <p>
          * Note that this is not recommended for queries that could return a large
-         * result set; the overhead in Riak is substantial. 
+         * result set; the overhead in Riak is substantial.
          * </p>
-         * 
+         *
          * @param orderByKey true to sort the results, false to return as-is.
          * @return a reference to this object.
          */
@@ -428,6 +457,7 @@ public abstract class SecondaryIndexQuery<T,S,U> extends RiakCommand<S, U>
 
         /**
          * Set the regex to filter result terms by for this query.
+         *
          * @param filter the regex to filter terms by.
          * @return a reference to this object.
          */
@@ -436,14 +466,15 @@ public abstract class SecondaryIndexQuery<T,S,U> extends RiakCommand<S, U>
             this.termFilter = filter;
             return self();
         }
-        
+
         /**
          * Set the Riak-side timeout value.
          * <p>
          * By default, riak has a 60s timeout for operations. Setting
-         * this value will override that default for both the 
+         * this value will override that default for both the
          * fetch and store operation.
          * </p>
+         *
          * @param timeout the timeout in milliseconds
          * @return a reference to this object.
          */
@@ -453,94 +484,102 @@ public abstract class SecondaryIndexQuery<T,S,U> extends RiakCommand<S, U>
             return self();
         }
     }
-    
+
     /**
      * Base class for all 2i responses.
+     *
      * @param <T> The type contained in the resposne.
      */
-    public abstract static class Response<T> 
+    public abstract static class Response<T>
     {
         final IndexConverter<T> converter;
         final SecondaryIndexQueryOperation.Response coreResponse;
         final Namespace queryLocation;
-        
-        protected Response(Namespace queryLocation, SecondaryIndexQueryOperation.Response coreResponse, IndexConverter<T> converter)
+
+        protected Response(Namespace queryLocation,
+                           SecondaryIndexQueryOperation.Response coreResponse,
+                           IndexConverter<T> converter)
         {
             this.coreResponse = coreResponse;
             this.converter = converter;
             this.queryLocation = queryLocation;
         }
-        
+
         /**
          * Check if this response has a continuation.
+         *
          * @return true if the response contains a continuation.
          */
         public boolean hasContinuation()
         {
             return coreResponse.hasContinuation();
         }
-        
+
         /**
          * Get the continuation from this response.
+         *
          * @return the continuation, or null if none is present.
          */
         public BinaryValue getContinuation()
         {
             return coreResponse.getContinuation();
         }
-        
+
         /**
          * Check is this response contains any entries.
+         *
          * @return true if entries are present, false otherwise.
          */
         public boolean hasEntries()
         {
             return !coreResponse.getEntryList().isEmpty();
         }
-        
-        
+
+
         protected final Location getLocationFromCoreEntry(SecondaryIndexQueryOperation.Response.Entry e)
         {
             Location loc = new Location(queryLocation, e.getObjectKey());
             return loc;
         }
-                
+
         public abstract List<?> getEntries();
-        
+
         public abstract static class Entry<T>
         {
             private final Location RiakObjectLocation;
             private final BinaryValue indexKey;
             private final IndexConverter<T> converter;
-            
+
             protected Entry(Location riakObjectLocation, BinaryValue indexKey, IndexConverter<T> converter)
             {
                 this.RiakObjectLocation = riakObjectLocation;
                 this.indexKey = indexKey;
                 this.converter = converter;
             }
-            
+
             /**
              * Get the location for this entry.
+             *
              * @return the location for this object in Riak.
              */
             public Location getRiakObjectLocation()
             {
                 return RiakObjectLocation;
             }
-            
+
             /**
              * Get this 2i key for this entry.
-             * Note this will only be present if the {@literal withKeyAndIndex(true)} 
-             * method was used when constructing the query. 
+             * Note this will only be present if the {@literal withKeyAndIndex(true)}
+             * method was used when constructing the query.
+             *
              * @return The 2i key for this entry or null if not present.
              */
             public T getIndexKey()
             {
                 return converter.convert(indexKey);
             }
-            
+
         }
-        
+
     }
 }

--- a/src/main/java/com/basho/riak/client/api/commands/indexes/SecondaryIndexQuery.java
+++ b/src/main/java/com/basho/riak/client/api/commands/indexes/SecondaryIndexQuery.java
@@ -230,7 +230,87 @@ public abstract class SecondaryIndexQuery<T,S,U> extends RiakCommand<S, U>
         
         return cluster.execute(builder.build());
     }
-                        
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof SecondaryIndexQuery)) {
+            return false;
+        }
+
+        SecondaryIndexQuery<?, ?, ?> that = (SecondaryIndexQuery<?, ?, ?>) o;
+
+        if (returnTerms != that.returnTerms) {
+            return false;
+        }
+        if (paginationSort != that.paginationSort) {
+            return false;
+        }
+        if (namespace != null ? !namespace.equals(that.namespace) : that.namespace != null) {
+            return false;
+        }
+        if (indexName != null ? !indexName.equals(that.indexName) : that.indexName != null) {
+            return false;
+        }
+        if (continuation != null ? !continuation.equals(that.continuation) : that.continuation != null) {
+            return false;
+        }
+        if (match != null ? !match.equals(that.match) : that.match != null) {
+            return false;
+        }
+        if (start != null ? !start.equals(that.start) : that.start != null) {
+            return false;
+        }
+        if (end != null ? !end.equals(that.end) : that.end != null) {
+            return false;
+        }
+        if (maxResults != null ? !maxResults.equals(that.maxResults) : that.maxResults != null) {
+            return false;
+        }
+        if (termFilter != null ? !termFilter.equals(that.termFilter) : that.termFilter != null) {
+            return false;
+        }
+        return !(timeout != null ? !timeout.equals(that.timeout) : that.timeout != null);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = namespace != null ? namespace.hashCode() : 0;
+        result = 31 * result + (indexName != null ? indexName.hashCode() : 0);
+        result = 31 * result + (continuation != null ? continuation.hashCode() : 0);
+        result = 31 * result + (match != null ? match.hashCode() : 0);
+        result = 31 * result + (start != null ? start.hashCode() : 0);
+        result = 31 * result + (end != null ? end.hashCode() : 0);
+        result = 31 * result + (maxResults != null ? maxResults.hashCode() : 0);
+        result = 31 * result + (returnTerms ? 1 : 0);
+        result = 31 * result + (paginationSort ? 1 : 0);
+        result = 31 * result + (termFilter != null ? termFilter.hashCode() : 0);
+        result = 31 * result + (timeout != null ? timeout.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "SecondaryIndexQuery{" +
+                ", continuation: " + continuation +
+                ", namespace: " + namespace +
+                ", indexName: " + indexName +
+                ", match: " + match +
+                ", start: " + start +
+                ", end: " + end +
+                ", maxResults: " + maxResults +
+                ", returnTerms: " + returnTerms +
+                ", paginationSort: " + paginationSort +
+                ", termFilter: '" + termFilter + '\'' +
+                ", timeout: " + timeout +
+                '}';
+    }
+
     protected interface IndexConverter<T>
     {
         T convert(BinaryValue input);

--- a/src/main/java/com/basho/riak/client/core/query/RiakObject.java
+++ b/src/main/java/com/basho/riak/client/core/query/RiakObject.java
@@ -386,4 +386,76 @@ public final class RiakObject
     {
         return isDeleted;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        RiakObject that = (RiakObject) o;
+
+        if (isDeleted != that.isDeleted) {
+            return false;
+        }
+        if (isModified != that.isModified) {
+            return false;
+        }
+        if (lastModified != that.lastModified) {
+            return false;
+        }
+        if (value != null ? !value.equals(that.value) : that.value != null) {
+            return false;
+        }
+        if (riakIndexes != null ? !riakIndexes.equals(that.riakIndexes) : that.riakIndexes != null) {
+            return false;
+        }
+        if (links != null ? !links.equals(that.links) : that.links != null) {
+            return false;
+        }
+        if (userMeta != null ? !userMeta.equals(that.userMeta) : that.userMeta != null) {
+            return false;
+        }
+        if (contentType != null ? !contentType.equals(that.contentType) : that.contentType != null) {
+            return false;
+        }
+        if (vtag != null ? !vtag.equals(that.vtag) : that.vtag != null) {
+            return false;
+        }
+        return !(vclock != null ? !vclock.equals(that.vclock) : that.vclock != null);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = value != null ? value.hashCode() : 0;
+        result = 31 * result + (riakIndexes != null ? riakIndexes.hashCode() : 0);
+        result = 31 * result + (links != null ? links.hashCode() : 0);
+        result = 31 * result + (userMeta != null ? userMeta.hashCode() : 0);
+        result = 31 * result + (contentType != null ? contentType.hashCode() : 0);
+        result = 31 * result + (vtag != null ? vtag.hashCode() : 0);
+        result = 31 * result + (isDeleted ? 1 : 0);
+        result = 31 * result + (isModified ? 1 : 0);
+        result = 31 * result + (vclock != null ? vclock.hashCode() : 0);
+        result = 31 * result + (int) (lastModified ^ (lastModified >>> 32));
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "RiakObject{" +
+                "contentType: " + contentType +
+                ", value: " + value +
+                ", riakIndexes: " + riakIndexes +
+                ", links: " + links +
+                ", userMeta: " + userMeta +
+                ", vtag: " + vtag +
+                ", isDeleted: " + isDeleted +
+                ", isModified: " + isModified +
+                ", vclock: " + vclock +
+                ", lastModified: " + lastModified +
+                '}';
+    }
 }

--- a/src/main/java/com/basho/riak/client/core/query/RiakObject.java
+++ b/src/main/java/com/basho/riak/client/core/query/RiakObject.java
@@ -22,6 +22,7 @@ import com.basho.riak.client.core.query.indexes.RiakIndexes;
 import com.basho.riak.client.core.query.links.RiakLinks;
 import com.basho.riak.client.core.util.BinaryValue;
 import com.basho.riak.client.core.util.CharsetUtils;
+
 import java.nio.charset.Charset;
 
 /**
@@ -44,6 +45,7 @@ import java.nio.charset.Charset;
  * that if you use any of the methods prefixed with "unsafe" you need to
  * understand the ramifications as noted in their Javadoc.
  * </p>
+ *
  * @author Brian Roach <roach at basho dot com>
  * @since 2.0
  */
@@ -52,6 +54,7 @@ public final class RiakObject
     /**
      * The default content type assigned when storing in Riak if one is not
      * provided. {@value #DEFAULT_CONTENT_TYPE}
+     *
      * @see RiakObject#setContentType(java.lang.String)
      */
     public final static String DEFAULT_CONTENT_TYPE = "application/octet-stream";
@@ -93,6 +96,7 @@ public final class RiakObject
 
     /**
      * Returns whether or not this RiakObject has a value
+     *
      * @return true if the value has been asSet, false otherwise
      */
     public boolean hasValue()
@@ -119,6 +123,7 @@ public final class RiakObject
      * <br/><b>Thread Safety:</b><br/>
      * Unsafe modifications to the supplied BinaryValue's
      * underlying byte[] would be a bad thing.
+     *
      * @param value the value to be stored in Riak.
      * @return a reference to this object.
      * @throws IllegalArgumentException if {@code value} is zero length.
@@ -135,6 +140,7 @@ public final class RiakObject
 
     /**
      * Get the vector clock for this RiakObject.
+     *
      * @return The vector clock, or null if not set.
      */
     public VClock getVClock()
@@ -144,6 +150,7 @@ public final class RiakObject
 
     /**
      * Set the vector clock for this RiakObject.
+     *
      * @param vclock a vector clock.
      * @return a reference to this object.
      */
@@ -185,6 +192,7 @@ public final class RiakObject
      * <p>
      * The timestamp is returned as a {@code long} (Unix) epoch time.
      * </p>
+     *
      * @return The last modified time or {@code 0} if it has not been asSet.
      * @see RiakObject#setLastModified(long)
      */
@@ -212,6 +220,7 @@ public final class RiakObject
      * Due to Riak's HTTP API this is represented as a string suitable for
      * a HTTP {@code Content-Type} header.
      * </p>
+     *
      * @return a {@code String} representing the content type of this object's value
      * @see RiakObject#setVClock(com.basho.riak.client.api.cap.VClock)
      */
@@ -227,6 +236,7 @@ public final class RiakObject
      * Due to Riak's HTTP API this is represented as a string suitable for
      * a HTTP {@code Content-Type} header.
      * </p>
+     *
      * @param contentType a {@code String} representing the content type of this object's value
      * @return a reference to this object
      * @see RiakObject#setValue(com.basho.riak.client.core.util.BinaryValue)
@@ -239,6 +249,7 @@ public final class RiakObject
 
     /**
      * Determine if there is a charset set in either the charset or content-type settings.
+     *
      * @return true if a charset is present, false otherwise.
      */
     public boolean hasCharset()
@@ -254,13 +265,14 @@ public final class RiakObject
      * Due to Riak's HTTP API this is represented as a string suitable for
      * a HTTP {@code Content-Type} header.
      * </p>
+     *
      * @return The character asSet {@code String}
      * @see RiakObject#setCharset(java.lang.String)
      * @see RiakObject#setValue(com.basho.riak.client.core.util.BinaryValue)
      */
     public String getCharset()
     {
-        if(charset != null)
+        if (charset != null)
         {
             return charset;
         }
@@ -274,6 +286,7 @@ public final class RiakObject
      * Due to Riak's HTTP API this is represented as a string suitable for
      * a HTTP {@code Content-Type} header.
      * </p>
+     *
      * @param charset the {@link Charset} to be asSet
      * @return a reference to this object
      * @see RiakObject#setValue(com.basho.riak.client.core.util.BinaryValue)
@@ -288,6 +301,7 @@ public final class RiakObject
 
     /**
      * Returns whether this RiakObject has secondary indexes (2i)
+     *
      * @return {@code true} if indexes are present, {@code false} otherwise
      * @see <a href="http://docs.basho.com/riak/latest/dev/advanced/2i/">Riak Secondary Indexes</a>
      */
@@ -304,6 +318,7 @@ public final class RiakObject
      * <br/><b>Thread Safety:</b><br/> The returned <code>RiakIndexes</code> object encapsulates any/all
      * indexes for this <code>RiakObject}</code>, is mutable, and thread safe. Any changes
      * are directly applied to this <code>RiakObject</code>.
+     *
      * @return the {@link RiakIndexes} that encapsulates any/all indexes for this RiakObject
      * @see <a href="http://docs.basho.com/riak/latest/dev/advanced/2i/">Riak Secondary Indexes</a>
      */
@@ -318,8 +333,10 @@ public final class RiakObject
     }
 
     // Links
+
     /**
      * Returns whether this RiakObject containsKeyKey links
+     *
      * @return {@code true} if links are present, {@code false} otherwise
      */
     public boolean hasLinks()
@@ -332,6 +349,7 @@ public final class RiakObject
      * <br/><b>Thread Safety:</b><br/> The returned <code>RiakLinks</code> object encapsulates any/all
      * links for this <code>RiakObject</code>, is mutable, and thread safe. Any changes
      * are directly applied to this <code>RiakObject</code>.
+     *
      * @return the {@link RiakIndexes} that encapsulates all/any links for this {@code RiakObject}
      */
     public synchronized RiakLinks getLinks()
@@ -349,6 +367,7 @@ public final class RiakObject
 
     /**
      * Returns if there are any User Meta entries for this RiakObject
+     *
      * @return {@code true} if user meta entries are present, {@code false} otherwise.
      */
     public boolean hasUserMeta()
@@ -362,6 +381,7 @@ public final class RiakObject
      * The returned <code>RiakUserMetadata</code> encapsulates any/all
      * user meta entries for this <code>RiakObject</code>, is mutable, and thread safe. Any changes
      * are directly applied to this <code>RiakObject</code>.
+     *
      * @return the {@code RiakUserMetadata} that containsKeyKey any/all User Meta entries for this {@code RiakObject}
      */
     public synchronized RiakUserMetadata getUserMeta()
@@ -376,6 +396,16 @@ public final class RiakObject
     }
 
     /**
+     * Returns whether or not this RiakObject is marked as being deleted (a tombstone)
+     *
+     * @return [{@code true} is this {@code RiakObject} is a tombstone, {@code false} otherwise
+     */
+    public boolean isDeleted()
+    {
+        return isDeleted;
+    }
+
+    /**
      * Marks this RiakObject as being a tombstone in Riak
      *
      * @param isDeleted
@@ -387,63 +417,77 @@ public final class RiakObject
         return this;
     }
 
-    /**
-     * Returns whether or not this RiakObject is marked as being deleted (a tombstone)
-     * @return [{@code true} is this {@code RiakObject} is a tombstone, {@code false} otherwise
-     */
-    public boolean isDeleted()
-    {
-        return isDeleted;
-    }
-
     @Override
-    public boolean equals(Object o) {
-        if (this == o) {
+    public boolean equals(Object o)
+    {
+        if (this == o)
+        {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (o == null || getClass() != o.getClass())
+        {
             return false;
         }
 
         RiakObject that = (RiakObject) o;
 
-        if (isDeleted != that.isDeleted) {
+        if (isDeleted != that.isDeleted)
+        {
             return false;
         }
-        if (isModified != that.isModified) {
+        if (isModified != that.isModified)
+        {
             return false;
         }
-        if (lastModified != that.lastModified) {
+        if (lastModified != that.lastModified)
+        {
             return false;
         }
-        if (value != null ? !value.equals(that.value) : that.value != null) {
+        if (value != null ? !value.equals(that.value) : that.value != null)
+        {
             return false;
         }
-        if (riakIndexes != null ? !riakIndexes.equals(that.riakIndexes) : that.riakIndexes != null) {
+        if (riakIndexes != null ? !riakIndexes.equals(that.riakIndexes) : that.riakIndexes != null)
+        {
             return false;
         }
-        if (links != null ? !links.equals(that.links) : that.links != null) {
+        if (links != null ? !links.equals(that.links) : that.links != null)
+        {
             return false;
         }
-        if (userMeta != null ? !userMeta.equals(that.userMeta) : that.userMeta != null) {
+        if (userMeta != null ? !userMeta.equals(that.userMeta) : that.userMeta != null)
+        {
             return false;
         }
-        if (contentType != null ? !contentType.equals(that.contentType) : that.contentType != null) {
+        if (contentType != null ? !contentType.equals(that.contentType) : that.contentType != null)
+        {
             return false;
         }
-        if (vtag != null ? !vtag.equals(that.vtag) : that.vtag != null) {
+        if (charset != null ? !charset.equals(that.charset) : that.charset != null)
+        {
             return false;
         }
-        return !(vclock != null ? !vclock.equals(that.vclock) : that.vclock != null);
+        if (vtag != null ? !vtag.equals(that.vtag) : that.vtag != null)
+        {
+            return false;
+        }
+        if (vclock != null ? !vclock.equals(that.vclock) : that.vclock != null)
+        {
+            return false;
+        }
+
+        return true;
     }
 
     @Override
-    public int hashCode() {
+    public int hashCode()
+    {
         int result = value != null ? value.hashCode() : 0;
         result = 31 * result + (riakIndexes != null ? riakIndexes.hashCode() : 0);
         result = 31 * result + (links != null ? links.hashCode() : 0);
         result = 31 * result + (userMeta != null ? userMeta.hashCode() : 0);
         result = 31 * result + (contentType != null ? contentType.hashCode() : 0);
+        result = 31 * result + (charset != null ? charset.hashCode() : 0);
         result = 31 * result + (vtag != null ? vtag.hashCode() : 0);
         result = 31 * result + (isDeleted ? 1 : 0);
         result = 31 * result + (isModified ? 1 : 0);
@@ -453,7 +497,8 @@ public final class RiakObject
     }
 
     @Override
-    public String toString() {
+    public String toString()
+    {
         return "RiakObject{" +
                 "contentType: " + contentType +
                 ", value: " + value +

--- a/src/main/java/com/basho/riak/client/core/query/UserMetadata/RiakUserMetadata.java
+++ b/src/main/java/com/basho/riak/client/core/query/UserMetadata/RiakUserMetadata.java
@@ -234,7 +234,30 @@ public class RiakUserMetadata
     {
         return meta.size();
     }
-    
-    
-    
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        RiakUserMetadata that = (RiakUserMetadata) o;
+        return meta.equals(that.meta);
+    }
+
+    @Override
+    public int hashCode() {
+        return meta.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "RiakUserMetadata{" +
+                "meta: " + meta +
+                '}';
+    }
 }

--- a/src/main/java/com/basho/riak/client/core/query/UserMetadata/RiakUserMetadata.java
+++ b/src/main/java/com/basho/riak/client/core/query/UserMetadata/RiakUserMetadata.java
@@ -27,8 +27,8 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * A threadsafe container for user metadata.
  * <p>
- * Arbitrary user metadata can be attached to an object in Riak. These are simply key/value 
- * pairs meaningful outside of the actual value of the object. This container 
+ * Arbitrary user metadata can be attached to an object in Riak. These are simply key/value
+ * pairs meaningful outside of the actual value of the object. This container
  * allows the user to manipulate that data.
  * </p>
  * <p>
@@ -36,57 +36,60 @@ import java.util.concurrent.ConcurrentHashMap;
  * to either use your default character asSet or supply a specific one to convert to and
  * from {@code String}s.
  * <p>
- * 
+ *
  * @author Brian Roach <roach at basho dot com>
+ * @see com.basho.riak.client.core.query.RiakObject#getUserMeta()
  * @since 2.0
- * @see com.basho.riak.client.core.query.RiakObject#getUserMeta() 
  */
 public class RiakUserMetadata
 {
-    private final ConcurrentHashMap<BinaryValue, BinaryValue> meta =
-        new ConcurrentHashMap<BinaryValue, BinaryValue>();
-    
+    private final ConcurrentHashMap<BinaryValue, BinaryValue> meta = new ConcurrentHashMap<BinaryValue, BinaryValue>();
+
     /**
      * Determine if usermeta is present.
+     *
      * @return {@code true} if there are no entries, {@code false} otherwise.
      */
     public boolean isEmpty()
     {
         return meta.isEmpty();
     }
-    
+
     /**
      * Determine if a specific usermeta entry is present.
      * <p>
      * This method uses the default {@code Charset} to convert the supplied key.
      * </p>
-     * @param key the metadata key 
+     *
+     * @param key the metadata key
      * @return {@code true} if the entry is present, {@code false} otherwise.
      */
     public boolean containsKey(String key)
     {
         return containsKey(key, DefaultCharset.get());
     }
-    
+
     /**
      * Determine if a specific usermeta entry is present.
      * <p>
      * This method uses the supplied {@code Charset} to convert the supplied key.
      * </p>
-     * @param key the metadata key 
+     *
+     * @param key the metadata key
      * @return {@code true} if the entry is present, {@code false} otherwise.
      */
     public boolean containsKey(String key, Charset charset)
     {
         return meta.containsKey(BinaryValue.unsafeCreate(key.getBytes(charset)));
     }
-    
+
     /**
      * Get a user metadata entry.
      * <p>
      * This method and its {@link RiakUserMetadata#put(java.lang.String, java.lang.String) }
      * counterpart use the default {@code Charset} to convert the {@code String}s.
      * </p>
+     *
      * @param key the key for the user metadata entry as a {@code String} encoded using the default {@code Charset}
      * @return the value for the entry converted to a {@code String} using the default {@code Charset}
      */
@@ -94,14 +97,15 @@ public class RiakUserMetadata
     {
         return get(key, DefaultCharset.get());
     }
-    
+
     /**
      * Get a user metadata entry.
      * <p>
      * This method and its {@link RiakUserMetadata#put(java.lang.String, java.lang.String, java.nio.charset.Charset)  }
      * counterpart use the supplied {@code Charset} to convert the {@code String}s.
      * </p>
-     * @param key the key for the user metadata entry as a {@code String} encoded using the supplied {@code Charset}  
+     *
+     * @param key the key for the user metadata entry as a {@code String} encoded using the supplied {@code Charset}
      * @return the value for the entry converted to a {@code String} using the supplied {@code Charset}
      */
     public String get(String key, Charset charset)
@@ -118,55 +122,60 @@ public class RiakUserMetadata
         }
 
     }
-    
+
     /**
      * Get a user metadata entry.
      * <p>
-     * This method and its {@link RiakUserMetadata#put(com.basho.riak.client.core.util.BinaryValue, com.basho.riak.client.core.util.BinaryValue)}
+     * This method and its
+     * {@link RiakUserMetadata#put(com.basho.riak.client.core.util.BinaryValue, com.basho.riak.client.core.util.BinaryValue)}
      * allow access to the raw bytes.
      * </p>
-     * @param key the key for the user metadata entry  
-     * @return the value for the entry 
+     *
+     * @param key the key for the user metadata entry
+     * @return the value for the entry
      */
     public BinaryValue get(BinaryValue key)
     {
         return meta.get(key);
     }
-    
+
     /**
      * Get the user metadata entries
      * <p>
-     * This method allows access to the user metadata entries directly as raw bytes. The 
-     * {@code Set} is an unmodifiable view of all the entries. 
+     * This method allows access to the user metadata entries directly as raw bytes. The
+     * {@code Set} is an unmodifiable view of all the entries.
      * <p>
+     *
      * @return an unmodifiable view of all the entries.
      */
     public Set<Map.Entry<BinaryValue, BinaryValue>> getUserMetadata()
     {
         return Collections.unmodifiableSet(meta.entrySet());
     }
-    
+
     /**
      * Set a user metadata entry.
      * <p>
      * This method and its {@link RiakUserMetadata#get(java.lang.String) }
      * counterpart use the default {@code Charset} to convert the {@code String}s.
      * </p>
-     * @param key the key for the user metadata entry as a {@code String} encoded using the default {@code Charset}
+     *
+     * @param key   the key for the user metadata entry as a {@code String} encoded using the default {@code Charset}
      * @param value the value for the entry as a {@code String} encoded using the default {@code Charset}
      */
     public void put(String key, String value)
     {
         put(key, value, DefaultCharset.get());
     }
-    
+
     /**
      * Set a user metadata entry.
      * <p>
      * This method and its {@link RiakUserMetadata#get(java.lang.String, java.nio.charset.Charset)  }
      * counterpart use the supplied {@code Charset} to convert the {@code String}s.
      * </p>
-     * @param key the key for the user metadata entry as a {@code String} encoded using the supplied {@code Charset}
+     *
+     * @param key   the key for the user metadata entry as a {@code String} encoded using the supplied {@code Charset}
      * @param value the value for the entry as a {@code String} encoded using the supplied {@code Charset}
      */
     public void put(String key, String value, Charset charset)
@@ -175,41 +184,42 @@ public class RiakUserMetadata
         BinaryValue wrappedValue = BinaryValue.unsafeCreate(value.getBytes(charset));
         meta.put(wrappedKey, wrappedValue);
     }
-    
+
     /**
      * Set a user metadata entry using raw bytes.
      * <p>
      * This method and its {@link RiakUserMetadata#get(com.basho.riak.client.core.util.BinaryValue)}
      * counterpart all access to the user metadata raw bytes
      * </p>
-     * @param key the key for the user metadata entry 
-     * @param value the value for the entry 
+     *
+     * @param key   the key for the user metadata entry
+     * @param value the value for the entry
      */
     public void put(BinaryValue key, BinaryValue value)
     {
         meta.put(key, value);
     }
-    
+
     public void remove(BinaryValue key)
     {
         meta.remove(key);
     }
-    
+
     public void remove(String key, Charset charset)
     {
         BinaryValue wrappedKey = BinaryValue.unsafeCreate(key.getBytes(charset));
         remove(wrappedKey);
     }
-    
-    public void remove (String key)
+
+    public void remove(String key)
     {
         remove(key, DefaultCharset.get());
     }
-    
+
     // TODO: deal with charset. Should add to annotation
-    public RiakUserMetadata put(Map<String,String> metaMap)
+    public RiakUserMetadata put(Map<String, String> metaMap)
     {
-        for (Map.Entry<String,String> e : metaMap.entrySet())
+        for (Map.Entry<String, String> e : metaMap.entrySet())
         {
             BinaryValue wrappedKey = BinaryValue.unsafeCreate(e.getKey().getBytes());
             BinaryValue wrappedValue = BinaryValue.unsafeCreate(e.getValue().getBytes());
@@ -217,7 +227,7 @@ public class RiakUserMetadata
         }
         return this;
     }
-    
+
     /**
      * Clear all user metadata entries.
      */
@@ -225,9 +235,10 @@ public class RiakUserMetadata
     {
         meta.clear();
     }
-    
+
     /**
      * Get the number of user metadata entries.
+     *
      * @return the number of entries
      */
     public int size()
@@ -235,29 +246,37 @@ public class RiakUserMetadata
         return meta.size();
     }
 
-
     @Override
-    public boolean equals(Object o) {
-        if (this == o) {
+    public boolean equals(Object o)
+    {
+        if (this == o)
+        {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (o == null || getClass() != o.getClass())
+        {
             return false;
         }
 
         RiakUserMetadata that = (RiakUserMetadata) o;
-        return meta.equals(that.meta);
+
+        if (!meta.equals(that.meta))
+        {
+            return false;
+        }
+
+        return true;
     }
 
     @Override
-    public int hashCode() {
+    public int hashCode()
+    {
         return meta.hashCode();
     }
 
     @Override
-    public String toString() {
-        return "RiakUserMetadata{" +
-                "meta: " + meta +
-                '}';
+    public String toString()
+    {
+        return "RiakUserMetadata{" + "meta: " + meta + '}';
     }
 }

--- a/src/main/java/com/basho/riak/client/core/query/indexes/RiakIndexes.java
+++ b/src/main/java/com/basho/riak/client/core/query/indexes/RiakIndexes.java
@@ -197,4 +197,29 @@ public class RiakIndexes implements Iterable<RiakIndex<?>>
 		{
 				return indexes.values().iterator();
 		}
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        RiakIndexes that = (RiakIndexes) o;
+        return indexes.equals(that.indexes);
+    }
+
+    @Override
+    public int hashCode() {
+        return indexes.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "RiakIndexes{" +
+                "indexes: " + indexes +
+                '}';
+    }
 }

--- a/src/main/java/com/basho/riak/client/core/query/links/RiakLink.java
+++ b/src/main/java/com/basho/riak/client/core/query/links/RiakLink.java
@@ -21,9 +21,9 @@ import com.basho.riak.client.core.util.DefaultCharset;
 import java.nio.charset.Charset;
 
 /**
- * Models a link from one object to another in Riak. 
- * <p> 
- * Links are metadata that establish one-way relationships between objects in Riak. 
+ * Models a link from one object to another in Riak.
+ * <p>
+ * Links are metadata that establish one-way relationships between objects in Riak.
  * They can be used to loosely model graph like relationships between objects in Riak.
  * </p>
  * <p>
@@ -38,7 +38,6 @@ import java.nio.charset.Charset;
  */
 public class RiakLink
 {
-
     private final BinaryValue bucket;
     private final BinaryValue key;
     private final BinaryValue tag;
@@ -49,9 +48,10 @@ public class RiakLink
      * The values are stored internally as bytes. The default {@code Charset} will
      * be used to convert the supplied {@code String}s
      * <p>
+     *
      * @param bucket the bucket name
-     * @param key the key
-     * @param tag the link tag
+     * @param key    the key
+     * @param tag    the link tag
      */
     public RiakLink(String bucket, String key, String tag)
     {
@@ -64,9 +64,10 @@ public class RiakLink
      * The values are stored internally as bytes. The supplied {@code Charset} will
      * be used to convert the supplied {@code String}s
      * </p>
-     * @param bucket the bucket
-     * @param key the key
-     * @param tag the link tag
+     *
+     * @param bucket  the bucket
+     * @param key     the key
+     * @param tag     the link tag
      * @param charset the character asSet for the supplied {@code String}s
      */
     public RiakLink(String bucket, String key, String tag, Charset charset)
@@ -75,12 +76,13 @@ public class RiakLink
         this.key = BinaryValue.unsafeCreate(key.getBytes(charset));
         this.tag = BinaryValue.unsafeCreate(tag.getBytes(charset));
     }
-    
+
     /**
      * Create a RiakLink from the specified parameters.
+     *
      * @param bucket the bucket name
-     * @param key the key
-     * @param tag the link tag
+     * @param key    the key
+     * @param tag    the link tag
      */
     public RiakLink(BinaryValue bucket, BinaryValue key, BinaryValue tag)
     {
@@ -88,7 +90,7 @@ public class RiakLink
         this.key = key;
         this.tag = tag;
     }
-    
+
     /**
      * Create a RiakLink that is a copy of another RiakLink.
      *
@@ -107,76 +109,83 @@ public class RiakLink
      * The bucket is stored internally as bytes. The default {@code Charset}
      * is used to convert to a {@code String}
      * </p>
+     *
      * @return the bucket as a {@code String} encoded using the default {@code Charset}
      */
     public String getBucket()
     {
         return bucket.toString();
     }
-    
+
     /**
      * Get the bucket for this RiakLink as a String
      * </p>
      * The bucket is stored internally as bytes. The supplied {@code Charset}
      * is used to convert to a {@code String}
      * </p>
+     *
      * @return the bucket as a {@code String} encoded using the supplied {@code Charset}
      */
     public String getBucket(Charset charset)
     {
         return bucket.toString(charset);
     }
-    
+
     /**
      * Get the bucket as a wrapped byte array
+     *
      * @return the bucket name in a {@link BinaryValue}
      */
     public BinaryValue getBucketAsBytes()
     {
         return bucket;
     }
-    
+
     /**
      * Get the key for this RiakLink as a String
      * </p>
      * The key is stored internally as bytes. The default {@code Charset}
      * is used to convert to a {@code String}
      * </p>
+     *
      * @return the key as a {@code String} encoded using the default {@code Charset}
      */
     public String getKey()
     {
         return key.toString();
     }
-    
+
     /**
      * Get the key for this RiakLink as a String
      * </p>
      * The key is stored internally as bytes. The supplied {@code Charset}
      * is used to convert to a {@code String}
      * </p>
+     *
      * @return the key as a {@code String} encoded using the supplied {@code Charset}
      */
     public String getKey(Charset charset)
     {
         return key.toString(charset);
     }
-    
+
     /**
      * Return the key as a wrapped byte array
+     *
      * @return the key in a {@link BinaryValue}
      */
     public BinaryValue getKeyAsBytes()
     {
         return key;
     }
-    
+
     /**
      * Get the tag for this RiakLink as a String
      * </p>
      * The tag is stored internally as bytes. The default {@code Charset}
      * is used to convert to a {@code String}
      * </p>
+     *
      * @return the tag as a {@code String} encoded using the default {@code Charset}
      */
     public String getTag()
@@ -190,22 +199,24 @@ public class RiakLink
      * The tag is stored internally as bytes. The supplied {@code Charset}
      * is used to convert to a {@code String}
      * </p>
+     *
      * @return the tag as a {@code String} encoded using the supplied {@code Charset}
      */
     public String getTag(Charset charset)
     {
         return tag.toString(charset);
     }
-    
+
     /**
      * Get the tag as bytes
+     *
      * @return the tag in a {@link BinaryValue}
      */
     public BinaryValue getTagAsBytes()
     {
         return tag;
     }
-    
+
     @Override
     public int hashCode()
     {
@@ -271,7 +282,7 @@ public class RiakLink
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see java.lang.Object#toString()
      */
     @Override

--- a/src/main/java/com/basho/riak/client/core/query/links/RiakLinks.java
+++ b/src/main/java/com/basho/riak/client/core/query/links/RiakLinks.java
@@ -15,45 +15,45 @@
  */
 package com.basho.riak.client.core.query.links;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * A thread safe container for {@link RiakLink} objects.
- * 
+ * <p>
  * <br/><b>Thread Safety:</b><br/> This is a thread safe container.
+ *
  * @author Brian Roach <roach at basho dot com>
- * @since 2.0
  * @see RiakLink
+ * @since 2.0
  */
 public class RiakLinks implements Iterable<RiakLink>
 {
-    private final Set<RiakLink> links = 
-         Collections.newSetFromMap(new ConcurrentHashMap<RiakLink, Boolean>());
-    
+    private final Set<RiakLink> links = Collections.newSetFromMap(new ConcurrentHashMap<RiakLink, Boolean>());
+
     /**
      * Reports if there are any {@code RiakLink} objects present
+     *
      * @return {@code true} if there are links present, {@code false} otherwise
      */
     public boolean isEmpty()
     {
         return links.isEmpty();
     }
-    
+
     /**
      * Returns the number of links present
+     *
      * @return the number of links present
      */
     public int size()
     {
         return links.size();
     }
+
     /**
      * Determine if a specific {@code RiakLink} is present.
+     *
      * @param link The {@code RiakLink} to check for.
      * @return {@code true} if the link is present, {@code false} otherwise
      */
@@ -61,10 +61,10 @@ public class RiakLinks implements Iterable<RiakLink>
     {
         return links.contains(link);
     }
-    
+
     /**
-     * Add {@link RiakLink}s 
-     * 
+     * Add {@link RiakLink}s
+     *
      * @param links a Collection of RiakLink objects to add
      * @return a reference to this object
      */
@@ -73,9 +73,10 @@ public class RiakLinks implements Iterable<RiakLink>
         this.links.addAll(links);
         return this;
     }
-        
+
     /**
-     * Adds a {@link RiakLink} 
+     * Adds a {@link RiakLink}
+     *
      * @param link a {@code RiakLink} to be added
      * @return a reference to this object
      */
@@ -86,7 +87,8 @@ public class RiakLinks implements Iterable<RiakLink>
     }
 
     /**
-     * Remove a {@code RiakLink} 
+     * Remove a {@code RiakLink}
+     *
      * @param link the {@code RiakLink} to remove
      * @return {@code true} if the link was present and was removed, {@code false} otherwise
      */
@@ -94,7 +96,7 @@ public class RiakLinks implements Iterable<RiakLink>
     {
         return links.remove(link);
     }
-    
+
     /**
      * Remove all links
      */
@@ -102,21 +104,23 @@ public class RiakLinks implements Iterable<RiakLink>
     {
         links.clear();
     }
-    
+
     /**
      * Return all the links.
      * <p>
      * Changes to the returned set do not modify this container.
      * </p>
+     *
      * @return the set of RiakLink objects
      */
     public Set<RiakLink> getLinks()
     {
         return new HashSet<RiakLink>(links);
     }
-    
+
     /**
-     * Return an iterator 
+     * Return an iterator
+     *
      * @return an {@code Iterator} that returns the links in this container
      */
     @Override
@@ -126,11 +130,14 @@ public class RiakLinks implements Iterable<RiakLink>
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) {
+    public boolean equals(Object o)
+    {
+        if (this == o)
+        {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (o == null || getClass() != o.getClass())
+        {
             return false;
         }
 
@@ -139,14 +146,14 @@ public class RiakLinks implements Iterable<RiakLink>
     }
 
     @Override
-    public int hashCode() {
+    public int hashCode()
+    {
         return links.hashCode();
     }
 
     @Override
-    public String toString() {
-        return "RiakLinks{" +
-                "links: " + links +
-                '}';
+    public String toString()
+    {
+        return "RiakLinks{" + "links: " + links + '}';
     }
 }

--- a/src/main/java/com/basho/riak/client/core/query/links/RiakLinks.java
+++ b/src/main/java/com/basho/riak/client/core/query/links/RiakLinks.java
@@ -125,6 +125,28 @@ public class RiakLinks implements Iterable<RiakLink>
         return links.iterator();
     }
 
-    
-    
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        RiakLinks riakLinks = (RiakLinks) o;
+        return links.equals(riakLinks.links);
+    }
+
+    @Override
+    public int hashCode() {
+        return links.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "RiakLinks{" +
+                "links: " + links +
+                '}';
+    }
 }

--- a/src/test/java/com/basho/riak/client/api/commands/StoreValueTest.java
+++ b/src/test/java/com/basho/riak/client/api/commands/StoreValueTest.java
@@ -15,12 +15,12 @@
  */
 package com.basho.riak.client.api.commands;
 
-import com.basho.riak.client.api.commands.kv.StoreValue.Option;
 import com.basho.riak.client.api.RiakClient;
-import com.basho.riak.client.api.commands.kv.StoreValue;
 import com.basho.riak.client.api.cap.BasicVClock;
 import com.basho.riak.client.api.cap.Quorum;
 import com.basho.riak.client.api.cap.VClock;
+import com.basho.riak.client.api.commands.kv.StoreValue;
+import com.basho.riak.client.api.commands.kv.StoreValue.Option;
 import com.basho.riak.client.core.FutureOperation;
 import com.basho.riak.client.core.RiakCluster;
 import com.basho.riak.client.core.RiakFuture;
@@ -28,11 +28,13 @@ import com.basho.riak.client.core.operations.StoreOperation;
 import com.basho.riak.client.core.query.Location;
 import com.basho.riak.client.core.query.Namespace;
 import com.basho.riak.client.core.query.RiakObject;
+import com.basho.riak.client.core.query.RiakObjectTest;
 import com.basho.riak.client.core.query.indexes.StringBinIndex;
 import com.basho.riak.client.core.query.links.RiakLink;
 import com.basho.riak.client.core.util.BinaryValue;
 import com.basho.riak.protobuf.RiakKvPB;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
@@ -45,112 +47,101 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import org.junit.Ignore;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-// TODO: Do something with this. You can't mock the responses because the parents aren't public
 
-@Ignore
 public class StoreValueTest
 {
+    @Mock
+    RiakCluster mockCluster;
+    @Mock
+    RiakFuture mockFuture;
+    @Mock
+    StoreOperation.Response mockResponse;
+    VClock vClock = new BasicVClock(new byte[]{'1'});
+    Location key = new Location(new Namespace("type", "bucket"), "key");
+    RiakClient client;
+    RiakObject riakObject;
 
-
-	@Mock RiakCluster mockCluster;
-	@Mock RiakFuture mockFuture;
-	@Mock StoreOperation.Response mockResponse;
-	VClock vClock = new BasicVClock(new byte[]{'1'});
-	Location key = new Location(new Namespace("type", "bucket"), "key");
-	RiakClient client;
-	RiakObject riakObject;
-
-	@Before
-	@SuppressWarnings("unchecked")
-	public void init() throws Exception
-	{
-		MockitoAnnotations.initMocks(this);
-		when(mockResponse.getObjectList()).thenReturn(new ArrayList<RiakObject>());
-		when(mockFuture.get()).thenReturn(mockResponse);
-		when(mockFuture.get(anyLong(), any(TimeUnit.class))).thenReturn(mockResponse);
-		when(mockFuture.isCancelled()).thenReturn(false);
-		when(mockFuture.isDone()).thenReturn(true);
-		when(mockCluster.execute(any(FutureOperation.class))).thenReturn(mockFuture);
-		client = new RiakClient(mockCluster);
-		riakObject = createRiakObject();
-	}
-
-	@Test
-	public void testStore() throws ExecutionException, InterruptedException
-	{
-
-		StoreValue storeValue = filledStoreValue(riakObject);
-		client.execute(storeValue);
-
-		ArgumentCaptor<StoreOperation> captor =
-			ArgumentCaptor.forClass(StoreOperation.class);
-		verify(mockCluster).execute(captor.capture());
-
-		StoreOperation operation = captor.getValue();
-		RiakKvPB.RpbPutReq.Builder builder =
-			(RiakKvPB.RpbPutReq.Builder) Whitebox.getInternalState(operation, "reqBuilder");
-
-		assertTrue(builder.hasVclock());
-		assertEquals(true, builder.getAsis());
-		assertEquals(1, builder.getDw());
-		assertEquals(true, builder.getIfNotModified());
-		assertEquals(true, builder.getIfNoneMatch());
-		assertEquals(1, builder.getPw());
-		assertEquals(1, builder.getNVal());
-		assertEquals(true, builder.getReturnBody());
-		assertEquals(true, builder.getReturnHead());
-		assertEquals(true, builder.getSloppyQuorum());
-		assertEquals(1000, builder.getTimeout());
-		assertEquals(1, builder.getW());
-
-	}
-
-	@Test
-	public void testEqualsWithRiakObject()
-	{
-		final RiakObject riakObject1 = createRiakObject();
-		final RiakObject riakObject2 = createRiakObject();
-
-
-		final StoreValue value1 = filledStoreValue(riakObject1);
-		final StoreValue value2 = filledStoreValue(riakObject2);
-		
-		assertEquals(value1, value2);
-	}
-
-	private RiakObject createRiakObject()
+    // TODO: Do something with this. You can't mock the responses because the parents aren't public
+    //@Before
+    @SuppressWarnings("unchecked")
+    @Ignore
+    public void init() throws Exception
     {
-		final RiakObject result = new RiakObject();
-		result.setValue(BinaryValue.create(new byte[]{'O', '_', 'o'}));
-		result.getIndexes().getIndex(StringBinIndex.named("foo")).add("bar");
-		result.getLinks().addLink(new RiakLink("bucket", "linkkey", "linktag"));
-		result.getUserMeta().put("foo", "bar");
-		result.setVTag("vtag");
-		result.setVClock(vClock);
-		return result;
-	}
+        MockitoAnnotations.initMocks(this);
+        when(mockResponse.getObjectList()).thenReturn(new ArrayList<RiakObject>());
+        when(mockFuture.get()).thenReturn(mockResponse);
+        when(mockFuture.get(anyLong(), any(TimeUnit.class))).thenReturn(mockResponse);
+        when(mockFuture.isCancelled()).thenReturn(false);
+        when(mockFuture.isDone()).thenReturn(true);
+        when(mockCluster.execute(any(FutureOperation.class))).thenReturn(mockFuture);
+        client = new RiakClient(mockCluster);
+        riakObject = RiakObjectTest.CreateFilledObject();
+    }
 
-	private StoreValue filledStoreValue(final RiakObject riakObject)
-	{
-		StoreValue.Builder store =
-			new StoreValue.Builder(riakObject).withLocation(key)
-				.withOption(Option.ASIS, true)
-				.withOption(Option.DW, new Quorum(1))
-				.withOption(Option.IF_NONE_MATCH, true)
-				.withOption(Option.IF_NOT_MODIFIED, true)
-				.withOption(Option.PW, new Quorum(1))
-				.withOption(Option.N_VAL, 1)
-				.withOption(Option.RETURN_BODY, true)
-				.withOption(Option.RETURN_HEAD, true)
-				.withOption(Option.SLOPPY_QUORUM, true)
-				.withOption(Option.TIMEOUT, 1000)
-				.withOption(Option.W, new Quorum(1));
-		return store.build();
-	}
+    @Test
+    // TODO: Do something with this. You can't mock the responses because the parents aren't public
+    @Ignore
+    public void testStore() throws ExecutionException, InterruptedException
+    {
+
+        StoreValue storeValue = filledStoreValue(riakObject);
+        client.execute(storeValue);
+
+        ArgumentCaptor<StoreOperation> captor = ArgumentCaptor.forClass(StoreOperation.class);
+        verify(mockCluster).execute(captor.capture());
+
+        StoreOperation operation = captor.getValue();
+        RiakKvPB.RpbPutReq.Builder builder = (RiakKvPB.RpbPutReq.Builder) Whitebox.getInternalState(operation,
+                                                                                                    "reqBuilder");
+
+        assertTrue(builder.hasVclock());
+        assertEquals(true, builder.getAsis());
+        assertEquals(1, builder.getDw());
+        assertEquals(true, builder.getIfNotModified());
+        assertEquals(true, builder.getIfNoneMatch());
+        assertEquals(1, builder.getPw());
+        assertEquals(1, builder.getNVal());
+        assertEquals(true, builder.getReturnBody());
+        assertEquals(true, builder.getReturnHead());
+        assertEquals(true, builder.getSloppyQuorum());
+        assertEquals(1000, builder.getTimeout());
+        assertEquals(1, builder.getW());
+
+    }
+
+    @Test
+    public void testEqualsWithRiakObject()
+    {
+        final RiakObject riakObject1 = RiakObjectTest.CreateFilledObject();
+        final RiakObject riakObject2 = RiakObjectTest.CreateFilledObject();
+
+
+        final StoreValue value1 = filledStoreValue(riakObject1);
+        final StoreValue value2 = filledStoreValue(riakObject2);
+
+        assertEquals(value1, value2);
+    }
+
+    private StoreValue filledStoreValue(final RiakObject riakObject)
+    {
+        StoreValue.Builder store =
+                new StoreValue.Builder(riakObject).withLocation(key)
+                        .withOption(Option.ASIS, true)
+                        .withOption(Option.DW, new Quorum(1))
+                        .withOption(Option.IF_NONE_MATCH, true)
+                        .withOption(Option.IF_NOT_MODIFIED, true)
+                        .withOption(Option.PW, new Quorum(1))
+                        .withOption(Option.N_VAL, 1)
+                        .withOption(Option.RETURN_BODY, true)
+                        .withOption(Option.RETURN_HEAD, true)
+                        .withOption(Option.SLOPPY_QUORUM, true)
+                        .withOption(Option.TIMEOUT, 1000)
+                        .withOption(Option.W, new Quorum(1));
+        return store.build();
+    }
 }

--- a/src/test/java/com/basho/riak/client/core/query/RiakObjectTest.java
+++ b/src/test/java/com/basho/riak/client/core/query/RiakObjectTest.java
@@ -1,0 +1,37 @@
+package com.basho.riak.client.core.query;
+
+import com.basho.riak.client.api.cap.BasicVClock;
+import com.basho.riak.client.api.cap.VClock;
+import com.basho.riak.client.api.commands.kv.StoreValue;
+import com.basho.riak.client.core.query.indexes.StringBinIndex;
+import com.basho.riak.client.core.query.links.RiakLink;
+import com.basho.riak.client.core.util.BinaryValue;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class RiakObjectTest
+{
+    static VClock vClock = new BasicVClock(new byte[]{'1'});
+
+    @Test
+    public void testEqualsWithRiakObject()
+    {
+        final RiakObject riakObject1 = CreateFilledObject();
+        final RiakObject riakObject2 = CreateFilledObject();
+
+        assertEquals(riakObject1, riakObject2);
+    }
+
+    public static RiakObject CreateFilledObject()
+    {
+        final RiakObject result = new RiakObject();
+        result.setValue(BinaryValue.create(new byte[]{'O', '_', 'o'}));
+        result.getIndexes().getIndex(StringBinIndex.named("foo")).add("bar");
+        result.getLinks().addLink(new RiakLink("bucket", "linkkey", "linktag"));
+        result.getUserMeta().put("foo", "bar");
+        result.setVTag("vtag");
+        result.setVClock(vClock);
+        return result;
+    }
+}


### PR DESCRIPTION
Superscedes #557, corrects formatting and adds another test.

> Added equals(), hashCode() and toString() methods to RiakObject.

Dependent classes RiakLinks, RiakUserMetadata and RiakObject also got those methods added to allow sensible comparison of any RiakObject. This allows checking parameters for equality in unit tests when mocking out RiakClient.

Thanks to @stela for the original PR. 
