### PR TITLE
Add new shortcut commands for the $bucket and $key indices

### DIFF
--- a/src/main/java/com/basho/riak/client/api/commands/indexes/BucketIndexQuery.java
+++ b/src/main/java/com/basho/riak/client/api/commands/indexes/BucketIndexQuery.java
@@ -1,0 +1,47 @@
+package com.basho.riak.client.api.commands.indexes;
+
+import com.basho.riak.client.core.operations.SecondaryIndexQueryOperation;
+import com.basho.riak.client.core.query.Namespace;
+import com.basho.riak.client.core.util.BinaryValue;
+
+/**
+ * Performs a 2i query across the special $bucket index, for a known bucket, and returns the keys in that bucket.
+ * <script src="https://google-code-prettify.googlecode.com/svn/loader/run_prettify.js"></script>
+ * <p>
+ * A BucketIndexQuery is used when you want to fetch all the keys for a bucket. Only a namespace is needed.
+ * </p>
+ * <pre class="prettyprint">
+ * {@code
+ * Namespace ns = new Namespace("my_type", "my_bucket");
+ * BucketIndexQuery q = new BucketIndexQuery.Builder(ns).build();
+ * RawIndexquery.Response resp = client.execute(q);}</pre>
+ *
+ * @author Alex Moore <amoore at basho dot com>
+ * @since 2.0.7
+ */
+public class BucketIndexQuery extends RawIndexQuery
+{
+    private BucketIndexQuery(Init<BinaryValue, Builder> builder)
+    {
+        super(builder);
+    }
+
+    public static class Builder extends SecondaryIndexQuery.Init<BinaryValue, Builder>
+    {
+        public Builder(Namespace namespace)
+        {
+            super(namespace, "$bucket", namespace.getBucketName());
+        }
+
+        @Override
+        protected Builder self()
+        {
+            return this;
+        }
+
+        public BucketIndexQuery build()
+        {
+            return new BucketIndexQuery(this);
+        }
+    }
+}

--- a/src/main/java/com/basho/riak/client/api/commands/indexes/KeyIndexQuery.java
+++ b/src/main/java/com/basho/riak/client/api/commands/indexes/KeyIndexQuery.java
@@ -1,0 +1,56 @@
+package com.basho.riak.client.api.commands.indexes;
+
+import com.basho.riak.client.core.operations.SecondaryIndexQueryOperation;
+import com.basho.riak.client.core.query.Namespace;
+import com.basho.riak.client.core.util.BinaryValue;
+import com.basho.riak.client.core.util.DefaultCharset;
+
+/**
+ * Performs a 2i query across the special $key index, for a known bucket & range of keys,
+ * and returns the keys within that range in that bucket.
+ * <script src="https://google-code-prettify.googlecode.com/svn/loader/run_prettify.js"></script>
+ * <p>
+ * A KeyIndexQuery is used when you want to fetch a range of keys for a bucket. A namespace and a key range is needed.
+ * </p>
+ * <pre class="prettyprint">
+ * {@code
+ * Namespace ns = new Namespace("my_type", "my_bucket");
+ * KeyIndexQuery q = new KeyIndexQuery.Builder(ns, "foo10", "foo19").build();
+ * RawIndexquery.Response resp = client.execute(q);}</pre>
+ *
+ * @author Alex Moore <amoore at basho dot com>
+ * @since 2.0.7
+ */
+public class KeyIndexQuery extends RawIndexQuery
+{
+    private KeyIndexQuery(Init<BinaryValue, Builder> builder)
+    {
+        super(builder);
+    }
+
+    public static class Builder extends Init<BinaryValue, Builder>
+    {
+        public Builder(Namespace namespace, String start, String end)
+        {
+            this(namespace,
+                 BinaryValue.unsafeCreate(start.getBytes(DefaultCharset.get())),
+                 BinaryValue.unsafeCreate(end.getBytes(DefaultCharset.get())));
+        }
+
+        public Builder(Namespace namespace, BinaryValue start, BinaryValue end)
+        {
+            super(namespace, "$key", start, end);
+        }
+
+        @Override
+        protected Builder self()
+        {
+            return this;
+        }
+
+        public KeyIndexQuery build()
+        {
+            return new KeyIndexQuery(this);
+        }
+    }
+}

--- a/src/main/java/com/basho/riak/client/core/query/Namespace.java
+++ b/src/main/java/com/basho/riak/client/core/query/Namespace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Basho Technologies Inc. 
+ * Copyright 2014 Basho Technologies Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,10 +25,10 @@ import java.nio.charset.Charset;
  * Encapsulates a Riak bucket type and bucket name.
  * <p>
  * Riak 2.0 introduced bucket types, which form a namespace in Riak when combined with
- * a bucket name. This class encapsulates those two items for use with operations. 
+ * a bucket name. This class encapsulates those two items for use with operations.
  * </p>
  * <p>
- * Buckets in Riak are automatically created for a type if they do not yet exist. 
+ * Buckets in Riak are automatically created for a type if they do not yet exist.
  * Bucket types, on the other hand, are not. Anything other than the {@literal default}
  * bucket type must be explicitly created using the {@literal riak_admin} command line tool.
  * </p>
@@ -43,21 +43,19 @@ import java.nio.charset.Charset;
  */
 public class Namespace
 {
-
-    
     /**
      * The default bucket type in Riak.
-     * The Riak default bucket type. 
+     * The Riak default bucket type.
      * The type is {@value #DEFAULT_BUCKET_TYPE}
      */
     public static final String DEFAULT_BUCKET_TYPE = "default";
     private static final BinaryValue DEFAULT_TYPE = BinaryValue.createFromUtf8(DEFAULT_BUCKET_TYPE);
-    
+
     private final BinaryValue type;
     private final BinaryValue bucket;
-    
+
     /**
-     * Construct a new Namespace with the provided bucket type and name. 
+     * Construct a new Namespace with the provided bucket type and name.
      * @param bucketType The bucket type in Riak. This must be UTF-8 encoded.
      * @param bucketName The bucket in Riak.
      */
@@ -74,11 +72,11 @@ public class Namespace
         this.bucket = bucketName;
         this.type = bucketType;
     }
-    
+
     /**
-     * Construct a new Namespace with the provided bucket type and name. 
+     * Construct a new Namespace with the provided bucket type and name.
      * <p>
-     * The supplied bucket type will be converted to bytes using UTF-8. 
+     * The supplied bucket type will be converted to bytes using UTF-8.
      * </p>
      * <p>
      * The supplied bucket name is converted to bytes using the supplied charset.
@@ -101,15 +99,15 @@ public class Namespace
         {
             throw new IllegalArgumentException("Charset cannot be null");
         }
-        
+
         this.bucket = BinaryValue.create(bucketName, charset);
         this.type = BinaryValue.createFromUtf8(bucketType);
     }
-    
+
     /**
-     * Construct a new Namespace with the provided bucket type and name. 
+     * Construct a new Namespace with the provided bucket type and name.
      * <p>
-     * The bucket type will be converted to bytes using UTF-8. 
+     * The bucket type will be converted to bytes using UTF-8.
      * </p>
      * <p>
      * The supplied bucketName is converted to bytes using the default charset.
@@ -121,7 +119,7 @@ public class Namespace
     {
         this(bucketType, bucketName, DefaultCharset.get());
     }
-    
+
     /**
      * Construct a new Namespace with the provided bucket name and the default bucket type.
      * <p>
@@ -135,7 +133,7 @@ public class Namespace
     {
         this(DEFAULT_TYPE, bucketName);
     }
-    
+
     /**
      * Construct a Namespace with the provided bucket name and the default bucket type.
      * <p>
@@ -153,7 +151,7 @@ public class Namespace
     {
         this(DEFAULT_BUCKET_TYPE, bucketName, charset);
     }
-    
+
     /**
      * Construct a Namespace with the provided bucket name and the default bucket type.
      * <p>
@@ -170,7 +168,7 @@ public class Namespace
     {
         this(bucketName, DefaultCharset.get());
     }
-    
+
     /**
      * Returns the bucket type for this Namespace.
      * @return the Riak bucket type.
@@ -179,7 +177,7 @@ public class Namespace
     {
         return type;
     }
-    
+
     /**
      * Get the bucket type for this Namespace as a String.
      * <p>
@@ -191,7 +189,7 @@ public class Namespace
     {
         return type.toString();
     }
-    
+
     /**
      * Get the bucket type for this Namespace as a String.
      * <p>
@@ -204,7 +202,7 @@ public class Namespace
     {
         return type.toString(charset);
     }
-    
+
     /**
      * Returns the bucket name for this Namespace.
      * @return the Riak bucket name.
@@ -213,7 +211,7 @@ public class Namespace
     {
         return bucket;
     }
-    
+
     /**
      * Get the bucket name for this Namespace as a String.
      * <p>
@@ -225,7 +223,7 @@ public class Namespace
     {
         return bucket.toString();
     }
-    
+
      /**
      * Get the bucket name for this Namespace as a String.
      * <p>
@@ -238,7 +236,7 @@ public class Namespace
     {
         return bucket.toString(charset);
     }
-    
+
     @Override
     public int hashCode()
     {
@@ -270,11 +268,11 @@ public class Namespace
         }
         return true;
     }
-    
+
     @Override
     public String toString()
     {
         return "{type: " + type + ", bucket: " + bucket + "}";
     }
-    
+
 }

--- a/src/test/java/com/basho/riak/client/api/commands/indexes/itest/ITestRawIndexQuery.java
+++ b/src/test/java/com/basho/riak/client/api/commands/indexes/itest/ITestRawIndexQuery.java
@@ -22,6 +22,8 @@ import com.basho.riak.client.api.annotations.RiakIndex;
 import com.basho.riak.client.api.annotations.RiakKey;
 import com.basho.riak.client.api.annotations.RiakVClock;
 import com.basho.riak.client.api.cap.VClock;
+import com.basho.riak.client.api.commands.indexes.BucketIndexQuery;
+import com.basho.riak.client.api.commands.indexes.KeyIndexQuery;
 import com.basho.riak.client.api.commands.indexes.RawIndexQuery;
 import com.basho.riak.client.api.commands.indexes.SecondaryIndexQuery.Type;
 import com.basho.riak.client.api.commands.kv.StoreValue;
@@ -32,8 +34,7 @@ import com.basho.riak.client.core.query.Location;
 import com.basho.riak.client.core.query.Namespace;
 import com.basho.riak.client.core.query.RiakObject;
 import com.basho.riak.client.core.util.BinaryValue;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.*;
 
 import java.util.concurrent.ExecutionException;
 
@@ -45,6 +46,33 @@ import static org.junit.Assert.*;
  */
 public class ITestRawIndexQuery extends ITestAutoCleanupBase
 {
+    private static String sharedBucket = "ITestRawIndexQuery";
+    private static Namespace sharedNamespace = new Namespace(Namespace.DEFAULT_BUCKET_TYPE, sharedBucket);
+
+    @BeforeClass
+    public static void Setup() throws ExecutionException, InterruptedException
+    {
+        for (long i = 0; i < 100; i++)
+        {
+            RiakObject obj = new RiakObject().setValue(BinaryValue.create("some_value"));
+
+            Location location = new Location(sharedNamespace, "my_key" + i);
+            StoreOperation storeOp =
+                    new StoreOperation.Builder(location)
+                            .withContent(obj)
+                            .build();
+
+            cluster.execute(storeOp);
+            storeOp.get();
+        }
+    }
+
+    @AfterClass
+    public static void Teardown() throws ExecutionException, InterruptedException
+    {
+        resetAndEmptyBucket(BinaryValue.create(sharedBucket));
+    }
+
     @Test
     public void simpleTest() throws InterruptedException, ExecutionException
     {
@@ -53,32 +81,31 @@ public class ITestRawIndexQuery extends ITestAutoCleanupBase
         setBucketNameToTestName();
 
         RiakClient client = new RiakClient(cluster);
-        
+
         BinaryValue indexKey = BinaryValue.create("index_test_index_key");
-        
+
         IndexedPojo ip = new IndexedPojo();
         ip.key = "index_test_object_key";
         ip.bucketName = bucketName.toString();
         ip.indexKey = indexKey.getValue();
         ip.value = "My Object Value!";
-        
+
         StoreValue sv = new StoreValue.Builder(ip).build();
         RiakFuture<StoreValue.Response, Location> svFuture = client.executeAsync(sv);
-        
+
         svFuture.await();
         assertTrue(svFuture.isSuccess());
-        
+
         Namespace ns = new Namespace(Namespace.DEFAULT_BUCKET_TYPE, bucketName.toString());
-        
+
         RawIndexQuery biq  =
             new RawIndexQuery.Builder(ns, "test_index", Type._BIN, indexKey).withKeyAndIndex(true).build();
         RawIndexQuery.Response iResp = client.execute(biq);
-        
+
         assertTrue(iResp.hasEntries());
         RawIndexQuery.Response.Entry first = iResp.getEntries().iterator().next();
         assertEquals(ip.key, first.getRiakObjectLocation().getKey().toString());
         assertArrayEquals(ip.indexKey, first.getIndexKey().getValue());
-        
     }
 
     @Test
@@ -86,86 +113,75 @@ public class ITestRawIndexQuery extends ITestAutoCleanupBase
     {
         Assume.assumeTrue(test2i);
 
-        setBucketNameToTestName();
-
         RiakClient client = new RiakClient(cluster);
-        
-        Namespace ns = new Namespace(Namespace.DEFAULT_BUCKET_TYPE, bucketName.toString());
-        
-        for (long i = 0; i < 100; i++)
-        {
-            RiakObject obj = new RiakObject().setValue(BinaryValue.create("some_value"));
 
-            Location location = new Location(ns, "my_key" + i);
-            StoreOperation storeOp =
-                    new StoreOperation.Builder(location)
-                            .withContent(obj)
-                            .build();
-
-            cluster.execute(storeOp);
-            storeOp.get();
-        }
-        
         RawIndexQuery biq  =
-            new RawIndexQuery.Builder(ns, "$key", Type._KEY, BinaryValue.create("my_key10"), BinaryValue.create("my_key19"))
+            new RawIndexQuery.Builder(sharedNamespace, "$key", Type._KEY, BinaryValue.create("my_key10"), BinaryValue.create("my_key19"))
                 .withKeyAndIndex(true).build();
         RawIndexQuery.Response iResp = client.execute(biq);
         assertTrue(iResp.hasEntries());
         assertEquals(iResp.getEntries().size(), 10);
-        
-        
     }
-    
+
+    @Test
+    public void testKeyIndexQuery() throws InterruptedException, ExecutionException
+    {
+        Assume.assumeTrue(test2i);
+
+        RiakClient client = new RiakClient(cluster);
+
+        KeyIndexQuery kq = new KeyIndexQuery.Builder(sharedNamespace, "my_key10", "my_key19").build();
+
+        final RawIndexQuery.Response kqResp = client.execute(kq);
+        assertTrue(kqResp.hasEntries());
+        assertEquals(10, kqResp.getEntries().size());
+    }
+
     @Test
     public void testBucketIndexHack() throws InterruptedException, ExecutionException
     {
         Assume.assumeTrue(test2i);
 
-        setBucketNameToTestName();
-
         RiakClient client = new RiakClient(cluster);
-        
-        Namespace ns = new Namespace(Namespace.DEFAULT_BUCKET_TYPE, bucketName.toString());
-        
-        for (long i = 0; i < 100; i++)
-        {
-            RiakObject obj = new RiakObject().setValue(BinaryValue.create("some_value"));
 
-            Location location = new Location(ns, "my_key" + i);
-            StoreOperation storeOp =
-                    new StoreOperation.Builder(location)
-                            .withContent(obj)
-                            .build();
-
-            cluster.execute(storeOp);
-            storeOp.get();
-        }
-        
         RawIndexQuery biq  =
-            new RawIndexQuery.Builder(ns, "$bucket", Type._BUCKET, bucketName)
+            new RawIndexQuery.Builder(sharedNamespace, "$bucket", Type._BUCKET, BinaryValue.create(sharedBucket))
                 .withKeyAndIndex(true).build();
-        
+
         RawIndexQuery.Response iResp = client.execute(biq);
         assertTrue(iResp.hasEntries());
         assertEquals(100, iResp.getEntries().size());
-        
     }
-    
-    
+
+    @Test
+    public void testBucketIndexQuery() throws InterruptedException, ExecutionException
+    {
+        Assume.assumeTrue(test2i);
+
+        RiakClient client = new RiakClient(cluster);
+
+        BucketIndexQuery bq = new BucketIndexQuery.Builder(sharedNamespace).build();
+
+        final RawIndexQuery.Response bqResp = client.execute(bq);
+        assertTrue(bqResp.hasEntries());
+        assertEquals(100, bqResp.getEntries().size());
+    }
+
+
     public static class IndexedPojo
     {
         @RiakKey
         public String key;
-        
+
         @RiakBucketName
         public String bucketName;
-        
+
         @RiakIndex(name="test_index_bin")
         byte[] indexKey;
-        
+
         @RiakVClock
         VClock vclock;
-        
+
         public String value;
     }
 }


### PR DESCRIPTION
Addresses #622 (CLIENTS-879) in a cleaner way, just provides shortcut commands/builders for the $bucket and $key indices. 
