### PR TITLE
Ready: Add the Yokozuna Index Creation timeout parameter for Riak 2.1+

### DIFF
--- a/src/main/java/com/basho/riak/client/core/operations/YzPutIndexOperation.java
+++ b/src/main/java/com/basho/riak/client/core/operations/YzPutIndexOperation.java
@@ -96,6 +96,21 @@ public class YzPutIndexOperation extends FutureOperation<Void, Void, YokozunaInd
             this.reqBuilder.setIndex(indexBuilder);
         }
 
+        /**
+         * Set the Riak-side timeout value, available in <b>Riak 2.1</b> and later.
+         * <p>
+         * By default, riak has a 45s timeout for Yokozuna index creation.
+         * Setting this value will override that default for this operation.
+         * </p>
+         * @param timeout the timeout in milliseconds to be sent to riak.
+         * @return a reference to this object.
+         */
+        public Builder withTimeout(int timeout)
+        {
+            reqBuilder.setTimeout(timeout);
+            return this;
+        }
+
         public YzPutIndexOperation build()
         {
             return new YzPutIndexOperation(this);

--- a/src/test/java/com/basho/riak/client/core/operations/itest/ISearchTestBase.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/ISearchTestBase.java
@@ -92,7 +92,7 @@ public class ISearchTestBase extends ITestBase
             throws ExecutionException, InterruptedException
     {
         YokozunaIndex index = new YokozunaIndex(indexName);
-        StoreIndex ssi = new StoreIndex.Builder(index).withTimeout(45).build();
+        StoreIndex ssi = new StoreIndex.Builder(index).withTimeout(45000).build();
 
         final RiakFuture<Void, YokozunaIndex> indexCreateFuture = client.executeAsync(ssi);
         indexCreateFuture.await();

--- a/src/test/java/com/basho/riak/client/core/operations/itest/ISearchTestBase.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/ISearchTestBase.java
@@ -25,6 +25,8 @@ import static org.junit.Assert.assertTrue;
  */
 public class ISearchTestBase extends ITestBase
 {
+    public static final int DEFAULT_STORE_INDEX_TIMEOUT = 45000;
+
     public static void setupSearchEnvironment(String bucketName, String indexName) throws ExecutionException, InterruptedException
     {
         final RiakClient client = new RiakClient(cluster);
@@ -40,7 +42,7 @@ public class ISearchTestBase extends ITestBase
         {
             Namespace yokoNamespace = getYokoNamespace(bucketName);
 
-            setupYokoIndexAndBucketProps(client, yokoNamespace, indexName);
+            setupYokoIndexAndBucketProps(client, yokoNamespace, indexName, DEFAULT_STORE_INDEX_TIMEOUT);
             setupData(client, yokoNamespace);
         }
 
@@ -88,11 +90,14 @@ public class ISearchTestBase extends ITestBase
         assertFutureSuccess(future);
     }
 
-    private static void setupYokoIndexAndBucketProps(RiakClient client, Namespace namespace, String indexName)
+    private static void setupYokoIndexAndBucketProps(RiakClient client,
+                                                     Namespace namespace,
+                                                     String indexName,
+                                                     int indexCreateTimeout)
             throws ExecutionException, InterruptedException
     {
         YokozunaIndex index = new YokozunaIndex(indexName);
-        StoreIndex ssi = new StoreIndex.Builder(index).withTimeout(45000).build();
+        StoreIndex ssi = new StoreIndex.Builder(index).withTimeout(indexCreateTimeout).build();
 
         final RiakFuture<Void, YokozunaIndex> indexCreateFuture = client.executeAsync(ssi);
         indexCreateFuture.await();

--- a/src/test/java/com/basho/riak/client/core/operations/itest/ISearchTestBase.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/ISearchTestBase.java
@@ -92,7 +92,7 @@ public class ISearchTestBase extends ITestBase
             throws ExecutionException, InterruptedException
     {
         YokozunaIndex index = new YokozunaIndex(indexName);
-        StoreIndex ssi = new StoreIndex.Builder(index).build();
+        StoreIndex ssi = new StoreIndex.Builder(index).withTimeout(45).build();
 
         final RiakFuture<Void, YokozunaIndex> indexCreateFuture = client.executeAsync(ssi);
         indexCreateFuture.await();

--- a/src/test/java/com/basho/riak/client/core/operations/itest/ITestYzAdminOperations.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/ITestYzAdminOperations.java
@@ -15,35 +15,53 @@
  */
 package com.basho.riak.client.core.operations.itest;
 
-import com.basho.riak.client.core.operations.YzDeleteIndexOperation;
-import com.basho.riak.client.core.operations.YzFetchIndexOperation;
-import com.basho.riak.client.core.operations.YzGetSchemaOperation;
-import com.basho.riak.client.core.operations.YzPutIndexOperation;
-import com.basho.riak.client.core.operations.YzPutSchemaOperation;
+import com.basho.riak.client.core.RiakFuture;
+import com.basho.riak.client.core.netty.RiakResponseException;
+import com.basho.riak.client.core.operations.*;
 import com.basho.riak.client.core.query.search.YokozunaIndex;
 import com.basho.riak.client.core.query.search.YokozunaSchema;
-import java.util.List;
-import java.util.concurrent.ExecutionException;
-import static org.junit.Assert.*;
+import org.junit.AfterClass;
 import org.junit.Assume;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.Assert.*;
+
 /**
- *
  * @author Brian Roach <roach at basho dot com>
  * @since 2.0
  */
 public class ITestYzAdminOperations extends ITestBase
 {
 
-    public static final String indexName = "test_index_ITestYzAdminOperations";
-    public static final String otherIndexName = "test_index5_ITestYzAdminOperations";
+    private static final String fetchIndex = "fetch_index_ITestYzAdminOperations";
+    private static final String deleteIndex = "delete_index_ITestYzAdminOperations";
+    private static final String timeoutIndex = "timeout_index_ITestYzAdminOperations";
+
+    @AfterClass
+    public static void Cleanup() throws ExecutionException, InterruptedException
+    {
+        DeleteIndex(fetchIndex);
+        DeleteIndex(deleteIndex);
+        DeleteIndex(timeoutIndex);
+    }
+
+    private static boolean DeleteIndex(String name) throws ExecutionException, InterruptedException
+    {
+        YzDeleteIndexOperation delOp = new YzDeleteIndexOperation.Builder(name).build();
+        cluster.execute(delOp);
+
+        delOp.get();
+        return delOp.isSuccess();
+    }
 
     // This is asSet to ignore as I've found a problem with this schema being accepted as
     // valid but then causing problems later if you try to create an index. Need to talk to Z.
-    // After that I can expand the unit tests. As is though, they show the networky 
-    // bits work. 
+    // After that I can expand the unit tests. As is though, they show the networky
+    // bits work.
     @Ignore
     @Test
     public void testStoreandFetchSchema() throws InterruptedException, ExecutionException
@@ -68,95 +86,96 @@ public class ITestYzAdminOperations extends ITestBase
             + "</types>"
             + "</schema>");
         
-        
+
         YzPutSchemaOperation putOp = new YzPutSchemaOperation.Builder(yzSchema).build();
         cluster.execute(putOp);
         putOp.get();
-        
-        YzGetSchemaOperation getOp =
-            new YzGetSchemaOperation.Builder("test_schema").build();
-        
+
+        YzGetSchemaOperation getOp = new YzGetSchemaOperation.Builder("test_schema").build();
+
         cluster.execute(getOp);
         YokozunaSchema yzSchema2 = getOp.get().getSchema();
-        
+
         assertEquals(yzSchema.getContent(), yzSchema2.getContent());
-        
-        
     }
-    
+
     @Test
     public void fetchAndStoreDefaultSchema() throws InterruptedException, ExecutionException
     {
         Assume.assumeTrue(testYokozuna);
-        YzGetSchemaOperation getOp =
-            new YzGetSchemaOperation.Builder("_yz_default").build();
-        
+        YzGetSchemaOperation getOp = new YzGetSchemaOperation.Builder("_yz_default").build();
+
         cluster.execute(getOp);
         YokozunaSchema yzSchema = getOp.get().getSchema();
-        
+
         assertNotNull(yzSchema.getName());
         assertNotNull(yzSchema.getContent());
-        
+
         YzPutSchemaOperation putOp = new YzPutSchemaOperation.Builder(yzSchema).build();
         cluster.execute(putOp);
         putOp.get();
-        
     }
-    
+
     @Test
     public void testStoreAndFetchIndex() throws InterruptedException, ExecutionException
     {
         Assume.assumeTrue(testYokozuna);
-        YokozunaIndex index = new YokozunaIndex(indexName).withNVal(2);
+        YokozunaIndex index = new YokozunaIndex(fetchIndex).withNVal(2);
         YzPutIndexOperation putOp = new YzPutIndexOperation.Builder(index).build();
-        
+
         cluster.execute(putOp);
         putOp.get();
-        
-        assertTrue("Index not created", assureIndexExists(indexName));
-        
-        
-        YzFetchIndexOperation fetchOp = 
-            new YzFetchIndexOperation.Builder().withIndexName(indexName)
-                .build();
-        
+
+        assertTrue("Index not created", assureIndexExists(fetchIndex));
+
+
+        YzFetchIndexOperation fetchOp = new YzFetchIndexOperation.Builder().withIndexName(fetchIndex).build();
+
         cluster.execute(fetchOp);
         fetchOp.await();
         if (!fetchOp.isSuccess())
         {
             assertTrue(fetchOp.cause().toString(), fetchOp.isSuccess());
         }
-        
+
         List<YokozunaIndex> indexList = fetchOp.get().getIndexes();
-        
+
         assertFalse(indexList.isEmpty());
         index = indexList.get(0);
         assertEquals(index.getSchema(), "_yz_default");
-        assertEquals((Integer)2, index.getNVal());
-        
-        YzDeleteIndexOperation delOp = new YzDeleteIndexOperation.Builder(indexName).build();
-        cluster.execute(delOp);
-        delOp.await();
-        assertTrue(delOp.isSuccess());
+        assertEquals((Integer) 2, index.getNVal());
     }
-    
+
     @Test
     public void testDeleteIndex() throws InterruptedException, ExecutionException
     {
         Assume.assumeTrue(testYokozuna);
-        YokozunaIndex index = new YokozunaIndex(otherIndexName);
+        YokozunaIndex index = new YokozunaIndex(deleteIndex);
         YzPutIndexOperation putOp = new YzPutIndexOperation.Builder(index).build();
-        
+
         cluster.execute(putOp);
         putOp.get();
-        
-        assertTrue("Index not created", assureIndexExists(otherIndexName));
-        
-        YzDeleteIndexOperation delOp = 
-            new YzDeleteIndexOperation.Builder(otherIndexName).build();
-        cluster.execute(delOp);
-        delOp.get();
-        
+
+        assertTrue("Index not created", assureIndexExists(deleteIndex));
     }
-    
+
+    @Test
+    public void testCreateIndexTimeout() throws InterruptedException, ExecutionException
+    {
+        Assume.assumeTrue(testYokozuna);
+
+        YokozunaIndex index = new YokozunaIndex(timeoutIndex);
+
+        YzPutIndexOperation putOp = new YzPutIndexOperation.Builder(index).withTimeout(1).build();
+
+        final RiakFuture<Void, YokozunaIndex> future = cluster.execute(putOp);
+
+        future.await();
+
+        final Throwable ex = future.cause();
+        assertNotNull(ex);
+        assertEquals(RiakResponseException.class, ex.getClass());
+        assertTrue(ex.getMessage().contains(timeoutIndex));
+        assertTrue(ex.getMessage().contains("1 ms timeout"));
+    }
 }


### PR DESCRIPTION
Fixes #613 (CLIENTS-826).
