### PR TITLE
Disallow 0 as a timeseries timeout value

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ before_script:
   - tools/devrel/riak-cluster-config "docker exec $RIAK_FLAVOR riak-admin" 8098 false false
 
 script:
-  - if [ $RIAK_FLAVOR == "riak-kv" ]; then mvn -Pitest,default -Dcom.basho.riak.yokozuna=false verify; else true; fi
-  - if [ $RIAK_FLAVOR == "riak-ts" ]; then mvn -Pitest,default -Dcom.basho.riak.yokozuna=false -Dcom.basho.riak.timeseries=true verify; else true; fi
+  - if [ $RIAK_FLAVOR == "riak-kv" ]; then mvn -Pitest,default -Dcom.basho.riak.yokozuna=false verify; else echo "Not riak-kv flavor"; fi
+  - if [ $RIAK_FLAVOR == "riak-ts" ]; then ; else echo "Not riak-ts flavor"; fi
 after_script:
   - docker rm -f $RIAK_FLAVOR
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_script:
 
 script:
   - if [ $RIAK_FLAVOR == "riak-kv" ]; then mvn -Pitest,default -Dcom.basho.riak.yokozuna=false verify; else echo "Not riak-kv flavor"; fi
-  - if [ $RIAK_FLAVOR == "riak-ts" ]; then ; else echo "Not riak-ts flavor"; fi
+  - if [ $RIAK_FLAVOR == "riak-ts" ]; then mvn -Pitest,default -Dcom.basho.riak.yokozuna=false -Dcom.basho.riak.timeseries=true verify; else echo "Not riak-ts flavor"; fi
 after_script:
   - docker rm -f $RIAK_FLAVOR
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,30 @@
 sudo: required
 dist: trusty
-
 language: java
 jdk: oraclejdk8
-
 services:
-  - docker
-
+- docker
 cache:
   directories:
-    - "$HOME/.m2"
-
+  - "$HOME/.m2"
 before_script:
-  - docker run --name $RIAK_FLAVOR -d -p 8087:8087 -p 8098:8098 basho/riak-ts
-  - docker exec $RIAK_FLAVOR riak-admin wait-for-service riak_kv
-  - tools/devrel/riak-cluster-config "docker exec $RIAK_FLAVOR riak-admin" 8098 false false
-
+- docker run --name $RIAK_FLAVOR -d -p 8087:8087 -p 8098:8098 basho/riak-ts
+- docker exec $RIAK_FLAVOR riak-admin wait-for-service riak_kv
+- tools/devrel/riak-cluster-config "docker exec $RIAK_FLAVOR riak-admin" 8098 false
+  false
 script:
-  - if [ $RIAK_FLAVOR == "riak-kv" ]; then mvn -Pitest,default -Dcom.basho.riak.yokozuna=false verify; else echo "Not riak-kv flavor"; fi
-  - if [ $RIAK_FLAVOR == "riak-ts" ]; then mvn -Pitest,default -Dcom.basho.riak.yokozuna=false -Dcom.basho.riak.timeseries=true verify; else echo "Not riak-ts flavor"; fi
+- if [ $RIAK_FLAVOR == "riak-kv" ]; then mvn -Pitest,default -Dcom.basho.riak.yokozuna=false
+  verify; else echo "Not riak-kv flavor"; fi
+- if [ $RIAK_FLAVOR == "riak-ts" ]; then mvn -Pitest,default -Dcom.basho.riak.yokozuna=false
+  -Dcom.basho.riak.timeseries=true verify; else echo "Not riak-ts flavor"; fi
 after_script:
-  - docker rm -f $RIAK_FLAVOR
-
+- docker rm -f $RIAK_FLAVOR
 env:
   matrix:
-    - RIAK_FLAVOR=riak-ts
-    - RIAK_FLAVOR=riak-kv
+  - RIAK_FLAVOR=riak-ts
+  - RIAK_FLAVOR=riak-kv
   global:
-    - RIAK_HOSTS=localhost:8087
+  - RIAK_HOSTS=localhost:8087
+notifications:
+  slack:
+    secure: CQHpKSbvzvGOKfQ8GdYdK0Huaz0y2xLbwhUWNH/xkrxO/OuqvYvZn7SlJRCLIYobj+zSiwsQRrz9G19gXGZMaDCwtdVVgEnddzm15bLjsUsrWU0FgRufJuATre+AVFByngvhAmdDIvcxVVhobIYo+F6m/8/OWRGhnQvvWOVtnMA=

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ before_script:
   - tools/devrel/riak-cluster-config "docker exec $RIAK_FLAVOR riak-admin" 8098 false false
 
 script:
-  - $RIAK_FLAVOR == "riak-kv" && mvn -Pitest,default -Dcom.basho.riak.yokozuna=false verify
-  - $RIAK_FLAVOR == "riak-ts" && mvn -Pitest,default -Dcom.basho.riak.yokozuna=false -Dcom.basho.riak.timeseries=true verify
+  - [[ $RIAK_FLAVOR == "riak-kv" ]] && mvn -Pitest,default -Dcom.basho.riak.yokozuna=false verify
+  - [[ $RIAK_FLAVOR == "riak-ts" ]] && mvn -Pitest,default -Dcom.basho.riak.yokozuna=false -Dcom.basho.riak.timeseries=true verify
 
 after_script:
   - docker rm -f $RIAK_FLAVOR

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,8 @@ before_script:
   - tools/devrel/riak-cluster-config "docker exec $RIAK_FLAVOR riak-admin" 8098 false false
 
 script:
-  - [ $RIAK_FLAVOR == "riak-kv" ] && mvn -Pitest,default -Dcom.basho.riak.yokozuna=false verify
-  - [ $RIAK_FLAVOR == "riak-ts" ] && mvn -Pitest,default -Dcom.basho.riak.yokozuna=false -Dcom.basho.riak.timeseries=true verify
-
+  - if [ $RIAK_FLAVOR == "riak-kv" ]; then mvn -Pitest,default -Dcom.basho.riak.yokozuna=false verify end; fi
+  - if [ $RIAK_FLAVOR == "riak-ts" ]; then mvn -Pitest,default -Dcom.basho.riak.yokozuna=false -Dcom.basho.riak.timeseries=true verify; fi
 after_script:
   - docker rm -f $RIAK_FLAVOR
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
   - tools/devrel/riak-cluster-config "docker exec $RIAK_FLAVOR riak-admin" 8098 false false
 
 script:
-  - mvn -Pitest,default -Dcom.basho.riak.timeseries=true verify
+  - mvn -Pitest,default -Dcom.basho.riak.search=false -Dcom.basho.riak.timeseries=true verify
 
 after_script:
   - docker rm -f $RIAK_FLAVOR

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ before_script:
   - tools/devrel/riak-cluster-config "docker exec $RIAK_FLAVOR riak-admin" 8098 false false
 
 script:
-  - [[ $RIAK_FLAVOR == "riak-kv" ]] && mvn -Pitest,default -Dcom.basho.riak.yokozuna=false verify
-  - [[ $RIAK_FLAVOR == "riak-ts" ]] && mvn -Pitest,default -Dcom.basho.riak.yokozuna=false -Dcom.basho.riak.timeseries=true verify
+  - [ $RIAK_FLAVOR == "riak-kv" ] && mvn -Pitest,default -Dcom.basho.riak.yokozuna=false verify
+  - [ $RIAK_FLAVOR == "riak-ts" ] && mvn -Pitest,default -Dcom.basho.riak.yokozuna=false -Dcom.basho.riak.timeseries=true verify
 
 after_script:
   - docker rm -f $RIAK_FLAVOR

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ before_script:
   - tools/devrel/riak-cluster-config "docker exec $RIAK_FLAVOR riak-admin" 8098 false false
 
 script:
-  - mvn -Pitest,default -Dcom.basho.riak.search=false -Dcom.basho.riak.timeseries=true verify
+  - $RIAK_FLAVOR == "riak-kv" && mvn -Pitest,default -Dcom.basho.riak.yokozuna=false verify
+  - $RIAK_FLAVOR == "riak-ts" && mvn -Pitest,default -Dcom.basho.riak.yokozuna=false -Dcom.basho.riak.timeseries=true verify
 
 after_script:
   - docker rm -f $RIAK_FLAVOR

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ before_script:
   - tools/devrel/riak-cluster-config "docker exec $RIAK_FLAVOR riak-admin" 8098 false false
 
 script:
-  - if [ $RIAK_FLAVOR == "riak-kv" ]; then mvn -Pitest,default -Dcom.basho.riak.yokozuna=false verify end; fi
-  - if [ $RIAK_FLAVOR == "riak-ts" ]; then mvn -Pitest,default -Dcom.basho.riak.yokozuna=false -Dcom.basho.riak.timeseries=true verify; fi
+  - if [ $RIAK_FLAVOR == "riak-kv" ]; then mvn -Pitest,default -Dcom.basho.riak.yokozuna=false verify; else true; fi
+  - if [ $RIAK_FLAVOR == "riak-ts" ]; then mvn -Pitest,default -Dcom.basho.riak.yokozuna=false -Dcom.basho.riak.timeseries=true verify; else true; fi
 after_script:
   - docker rm -f $RIAK_FLAVOR
 

--- a/src/main/java/com/basho/riak/client/api/commands/timeseries/Delete.java
+++ b/src/main/java/com/basho/riak/client/api/commands/timeseries/Delete.java
@@ -78,16 +78,20 @@ public class Delete extends RiakCommand<Void, String>
 
         /**
          * Set the Riak-side timeout value.
-         *
-         * @param timeout The timeout, in milliseconds.
+         * <p>
+         * By default, Riak has a 60s timeout for operations. Setting
+         * this value will override that default for this operation.
+         * </p>
+         * @param timeout the timeout in milliseconds to be sent to riak.
          * @return a reference to this object.
          */
         public Builder withTimeout(int timeout)
         {
-            if (timeout < 0)
+            if (timeout < 1)
             {
-                throw new IllegalArgumentException("Timeout must be positive, or 0 for no timeout.");
+                throw new IllegalArgumentException("Timeout must be a positive integer");
             }
+
             this.timeout = timeout;
             return this;
         }

--- a/src/main/java/com/basho/riak/client/api/commands/timeseries/Fetch.java
+++ b/src/main/java/com/basho/riak/client/api/commands/timeseries/Fetch.java
@@ -79,16 +79,20 @@ public class Fetch extends RiakCommand<QueryResult, String>
 
         /**
          * Set the Riak-side timeout value.
-         *
-         * @param timeout The timeout, in milliseconds.
+         * <p>
+         * By default, Riak has a 60s timeout for operations. Setting
+         * this value will override that default for this operation.
+         * </p>
+         * @param timeout the timeout in milliseconds to be sent to riak.
          * @return a reference to this object.
          */
         public Builder withTimeout(int timeout)
         {
-            if (timeout < 0)
+            if (timeout < 1)
             {
-                throw new IllegalArgumentException("Timeout must be positive, or 0 for no timeout.");
+                throw new IllegalArgumentException("Timeout must be a positive integer");
             }
+
             this.timeout = timeout;
             return this;
         }

--- a/src/main/java/com/basho/riak/client/api/commands/timeseries/ListKeys.java
+++ b/src/main/java/com/basho/riak/client/api/commands/timeseries/ListKeys.java
@@ -83,7 +83,7 @@ public class ListKeys extends RiakCommand<QueryResult, String>
         /**
          * Set the Riak-side timeout value.
          * <p>
-         * By default, riak has a 60s timeout for operations. Setting
+         * By default, Riak has a 60s timeout for operations. Setting
          * this value will override that default for this operation.
          * </p>
          * @param timeout the timeout in milliseconds to be sent to riak.
@@ -91,6 +91,11 @@ public class ListKeys extends RiakCommand<QueryResult, String>
          */
         public Builder withTimeout(int timeout)
         {
+            if (timeout < 1)
+            {
+                throw new IllegalArgumentException("Timeout must be a positive integer");
+            }
+
             this.timeout = timeout;
             return this;
         }

--- a/src/main/java/com/basho/riak/client/core/codec/TermToBinaryCodec.java
+++ b/src/main/java/com/basho/riak/client/core/codec/TermToBinaryCodec.java
@@ -41,7 +41,14 @@ public class TermToBinaryCodec
         }
         os.write_nil(); // NB: finishes the list
 
-        os.write_long(timeout);
+        if(timeout != 0)
+        {
+            os.write_long(timeout);
+        }
+        else
+        {
+            os.write_atom(UNDEFINED);
+        }
 
         return os;
     }

--- a/src/main/java/com/basho/riak/client/core/operations/ts/DeleteOperation.java
+++ b/src/main/java/com/basho/riak/client/core/operations/ts/DeleteOperation.java
@@ -95,13 +95,23 @@ public class DeleteOperation extends PBFutureOperation<Void, RiakTsPB.TsDelResp,
             this.keyValues = keyValues;
         }
 
+        /**
+         * Set the Riak-side timeout value.
+         * <p>
+         * By default, Riak has a 60s timeout for operations. Setting
+         * this value will override that default for this operation.
+         * </p>
+         * @param timeout the timeout in milliseconds to be sent to riak.
+         * @return a reference to this object.
+         */
         public Builder withTimeout(int timeout)
         {
-            if (timeout < 0)
+            if (timeout < 1)
             {
-                throw new IllegalArgumentException("Timeout must be positive, or 0 for no timeout.");
+                throw new IllegalArgumentException("Timeout must be a positive integer");
             }
-            this.reqBuilder.setTimeout(timeout);
+
+            reqBuilder.setTimeout(timeout);
             return this;
         }
 

--- a/src/main/java/com/basho/riak/client/core/operations/ts/FetchOperation.java
+++ b/src/main/java/com/basho/riak/client/core/operations/ts/FetchOperation.java
@@ -66,7 +66,7 @@ public class FetchOperation extends TTBFutureOperation<QueryResult, String>
     {
         private final String tableName;
         private final Iterable<Cell> keyValues;
-        private int timeout = 0;
+        private int timeout;
 
         public Builder(String tableName, Iterable<Cell> keyValues)
         {
@@ -84,8 +84,22 @@ public class FetchOperation extends TTBFutureOperation<QueryResult, String>
             this.keyValues = keyValues;
         }
 
+        /**
+         * Set the Riak-side timeout value.
+         * <p>
+         * By default, Riak has a 60s timeout for operations. Setting
+         * this value will override that default for this operation.
+         * </p>
+         * @param timeout the timeout in milliseconds to be sent to riak.
+         * @return a reference to this object.
+         */
         public Builder withTimeout(int timeout)
         {
+            if (timeout < 1)
+            {
+                throw new IllegalArgumentException("Timeout must be a positive integer");
+            }
+
             this.timeout = timeout;
             return this;
         }

--- a/src/main/java/com/basho/riak/client/core/operations/ts/ListKeysOperation.java
+++ b/src/main/java/com/basho/riak/client/core/operations/ts/ListKeysOperation.java
@@ -79,12 +79,22 @@ public class ListKeysOperation extends PBFutureOperation<QueryResult, RiakTsPB.T
             this.tableName = tableName;
         }
 
+        /**
+         * Set the Riak-side timeout value.
+         * <p>
+         * By default, Riak has a 60s timeout for operations. Setting
+         * this value will override that default for this operation.
+         * </p>
+         * @param timeout the timeout in milliseconds to be sent to riak.
+         * @return a reference to this object.
+         */
         public Builder withTimeout(int timeout)
         {
-            if (timeout <= 0)
+            if (timeout < 1)
             {
-                throw new IllegalArgumentException("Timeout can not be zero or less");
+                throw new IllegalArgumentException("Timeout must be a positive integer");
             }
+
             reqBuilder.setTimeout(timeout);
             return this;
         }

--- a/src/test/java/com/basho/riak/client/api/commands/indexes/itest/ITestFullBucketRead.java
+++ b/src/test/java/com/basho/riak/client/api/commands/indexes/itest/ITestFullBucketRead.java
@@ -41,6 +41,7 @@ public class ITestFullBucketRead extends ITestBase
     public static void BeforeClass() throws ExecutionException, InterruptedException
     {
         Assume.assumeTrue(testTimeSeries);
+        Assume.assumeTrue(testCoveragePlan);
         setupData();
     }
 

--- a/src/test/java/com/basho/riak/client/api/commands/itest/ITestSearchMapReduce.java
+++ b/src/test/java/com/basho/riak/client/api/commands/itest/ITestSearchMapReduce.java
@@ -44,6 +44,10 @@ public class ITestSearchMapReduce extends ISearchTestBase
     @BeforeClass
     public static void Setup() throws ExecutionException, InterruptedException
     {
+        Assume.assumeTrue(testYokozuna);
+        Assume.assumeTrue(testBucketType);
+        Assume.assumeFalse(security);
+
         setupSearchEnvironment(mrBucketName, indexName);
     }
 
@@ -56,10 +60,6 @@ public class ITestSearchMapReduce extends ISearchTestBase
     @Test
     public void searchMR() throws InterruptedException, ExecutionException
     {
-        Assume.assumeTrue(testYokozuna);
-        Assume.assumeTrue(testBucketType);
-        Assume.assumeFalse(security);
-
         SearchMapReduce smr = new SearchMapReduce.Builder()
                 .withIndex(indexName)
                 .withQuery("doc_type_i:1 AND NOT leader_b:true")

--- a/src/test/java/com/basho/riak/client/core/operations/itest/ITestBase.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/ITestBase.java
@@ -63,6 +63,7 @@ public abstract class ITestBase
     protected static boolean testBucketType;
     protected static boolean testCrdt;
     protected static boolean testTimeSeries;
+    protected static boolean testCoveragePlan;
     protected static boolean legacyRiakSearch;
     protected static boolean security;
     protected static BinaryValue bucketName;
@@ -149,7 +150,10 @@ public abstract class ITestBase
         mapReduceBucketType = BinaryValue.create("mr");
 
         testCrdt = Boolean.parseBoolean(System.getProperty("com.basho.riak.crdt", "true"));
+
         testTimeSeries = Boolean.parseBoolean(System.getProperty("com.basho.riak.timeseries", "false"));
+
+        testCoveragePlan = Boolean.parseBoolean(System.getProperty("com.basho.riak.coveragePlan", "false"));
 
         /**
          * Riak PBC host

--- a/src/test/java/com/basho/riak/client/core/operations/itest/ITestCoveragePlan.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/ITestCoveragePlan.java
@@ -38,8 +38,10 @@ public class ITestCoveragePlan extends ITestAutoCleanupBase
 
     // TODO: Remove assumption as Riak KV with PEx and Coverage plan will be released
     @BeforeClass
-    public static void BeforeClass() {
+    public static void BeforeClass()
+    {
         Assume.assumeTrue(testTimeSeries);
+        Assume.assumeTrue(testCoveragePlan);
     }
 
     @Test

--- a/src/test/java/com/basho/riak/client/core/operations/itest/ITestDeleteOperation.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/ITestDeleteOperation.java
@@ -22,6 +22,8 @@ import com.basho.riak.client.core.query.Location;
 import com.basho.riak.client.core.query.Namespace;
 import com.basho.riak.client.core.query.RiakObject;
 import com.basho.riak.client.core.util.BinaryValue;
+
+import java.util.Random;
 import java.util.concurrent.ExecutionException;
 import static org.junit.Assert.*;
 import static org.junit.Assume.assumeTrue;
@@ -33,59 +35,66 @@ import org.junit.Test;
  */
 public class ITestDeleteOperation extends ITestAutoCleanupBase
 {
+    private static long keySeed = new Random().nextLong();
+
     @Test
     public void testDeleteObjectDefaultType() throws InterruptedException, ExecutionException
     {
         testDeleteObject(Namespace.DEFAULT_BUCKET_TYPE);
     }
-    
+
     @Test
     public void testDeleteObjectTestType() throws InterruptedException, ExecutionException
     {
         assumeTrue(testBucketType);
         testDeleteObject(bucketType.toString());
     }
-    
+
     private void testDeleteObject(String bucketType) throws InterruptedException, ExecutionException
     {
-        final BinaryValue key = BinaryValue.unsafeCreate("my_key".getBytes());
+        final BinaryValue key = generateKey();
         final String value = "{\"value\":\"value\"}";
-        
+
         RiakObject rObj = new RiakObject().setValue(BinaryValue.unsafeCreate(value.getBytes()));
-        
+
         Location location = new Location(new Namespace(bucketType, bucketName.toString()), key);
-        StoreOperation storeOp = 
+        StoreOperation storeOp =
             new StoreOperation.Builder(location)
                 .withContent(rObj)
-                .build(); 
-        
+                .build();
+
         cluster.execute(storeOp);
         storeOp.get();
-        
-        FetchOperation fetchOp = 
+
+        FetchOperation fetchOp =
             new FetchOperation.Builder(location).build();
-                
-        
+
+
         cluster.execute(fetchOp);
         FetchOperation.Response response = fetchOp.get();
+
         RiakObject rObj2 = response.getObjectList().get(0);
-        
+
         assertEquals(rObj.getValue(), rObj2.getValue());
-        
+
         DeleteOperation delOp =
             new DeleteOperation.Builder(location)
                 .withVclock(rObj2.getVClock()).build();
         cluster.execute(delOp);
         delOp.get();
-        
-        fetchOp = 
+
+        fetchOp =
             new FetchOperation.Builder(location).build();
-        
+
         cluster.execute(fetchOp);
         response = fetchOp.get();
         assertTrue(response.isNotFound());
         assertTrue(response.getObjectList().isEmpty());
-        
-        
+    }
+
+    private BinaryValue generateKey()
+    {
+        final String key = testName.getMethodName() + keySeed;
+        return BinaryValue.unsafeCreate(key.getBytes());
     }
 }

--- a/src/test/java/com/basho/riak/client/core/operations/itest/ITestStoreOperation.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/ITestStoreOperation.java
@@ -15,7 +15,6 @@
  */
 package com.basho.riak.client.core.operations.itest;
 
-import com.basho.riak.client.core.RiakFuture;
 import com.basho.riak.client.core.operations.FetchOperation;
 import com.basho.riak.client.core.operations.StoreBucketPropsOperation;
 import com.basho.riak.client.core.operations.StoreOperation;
@@ -37,101 +36,99 @@ public class ITestStoreOperation extends ITestAutoCleanupBase
 {
     final private BinaryValue key = BinaryValue.unsafeCreate("my_key".getBytes());
     final private String value = "{\"value\":\"some value\"}";
-
+    
     @Test
     public void testSimpleStoreDefaultType() throws InterruptedException, ExecutionException
     {
         testSimpleStore(Namespace.DEFAULT_BUCKET_TYPE);
     }
-
+    
     @Test
     public void testSimpleStoreTestType() throws InterruptedException, ExecutionException
     {
         assumeTrue(testBucketType);
         testSimpleStore(bucketType.toString());
     }
-
+    
     private void testSimpleStore(String bucketType) throws InterruptedException, ExecutionException
     {
-
+        
         RiakObject obj = new RiakObject().setValue(BinaryValue.create(value));
         Namespace ns = new Namespace(bucketType, bucketName.toString());
         Location location = new Location(ns, key);
-        StoreOperation storeOp =
+        StoreOperation storeOp = 
             new StoreOperation.Builder(location)
                 .withContent(obj)
                 .build();
-
-        final RiakFuture<StoreOperation.Response, Location> storeFuture = cluster.execute(storeOp);
+        
+        cluster.execute(storeOp);
         storeOp.get();
-        storeFuture.await();
-        assertTrue(storeFuture.isSuccess());
-
-        FetchOperation fetchOp =
+        
+        FetchOperation fetchOp = 
                 new FetchOperation.Builder(location).build();
-
+                
         cluster.execute(fetchOp);
         RiakObject obj2 = fetchOp.get().getObjectList().get(0);
-
+        
         assertEquals(obj.getValue(), obj2.getValue());
-
+               
     }
-
+    
     @Test
     public void testStoreWithVClockAndReturnbodyDefaultType() throws InterruptedException, ExecutionException
     {
         assumeTrue(testBucketType);
         testStoreWithVClockAndReturnbody(bucketType.toString());
     }
-
+    
     @Test
     public void testStoreWithVClockAndReturnbodyTestType() throws InterruptedException, ExecutionException
     {
         testStoreWithVClockAndReturnbody(Namespace.DEFAULT_BUCKET_TYPE);
     }
-
+    
     private void testStoreWithVClockAndReturnbody(String bucketType) throws InterruptedException, ExecutionException
     {
-        // Enable allow_multi, store a new item, then do a read/modify/write
+        // Enable allow_multi, store a new item, then do a read/modify/write 
         // using the vclock
-
+        
         Namespace ns = new Namespace(bucketType, bucketName.toString() + "_1");
-        StoreBucketPropsOperation op =
+        StoreBucketPropsOperation op = 
             new StoreBucketPropsOperation.Builder(ns)
                 .withAllowMulti(true)
                 .build();
         cluster.execute(op);
         op.get();
-
+        
         RiakObject obj = new RiakObject().setValue(BinaryValue.create(value));
         Location location = new Location(ns, key);
-
-        StoreOperation storeOp =
+       
+        StoreOperation storeOp = 
             new StoreOperation.Builder(location)
                 .withContent(obj)
                 .withReturnBody(true)
                 .build();
-
+        
         cluster.execute(storeOp);
         StoreOperation.Response response = storeOp.get();
         obj = response.getObjectList().get(0);
-
+        
         assertNotNull(obj.getVClock());
-
+        
         obj.setValue(BinaryValue.create("changed"));
 
         storeOp = new StoreOperation.Builder(location)
                 .withContent(obj)
                 .withReturnBody(true)
                 .build();
-
+        
         cluster.execute(storeOp);
         response = storeOp.get();
         obj = response.getObjectList().get(0);
-
+        
         assertEquals(obj.getValue().toString(), "changed");
-
+        
         resetAndEmptyBucket(ns);
     }
-
+    
 }

--- a/src/test/java/com/basho/riak/client/core/operations/itest/ITestStoreOperation.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/ITestStoreOperation.java
@@ -15,6 +15,7 @@
  */
 package com.basho.riak.client.core.operations.itest;
 
+import com.basho.riak.client.core.RiakFuture;
 import com.basho.riak.client.core.operations.FetchOperation;
 import com.basho.riak.client.core.operations.StoreBucketPropsOperation;
 import com.basho.riak.client.core.operations.StoreOperation;
@@ -36,99 +37,101 @@ public class ITestStoreOperation extends ITestAutoCleanupBase
 {
     final private BinaryValue key = BinaryValue.unsafeCreate("my_key".getBytes());
     final private String value = "{\"value\":\"some value\"}";
-    
+
     @Test
     public void testSimpleStoreDefaultType() throws InterruptedException, ExecutionException
     {
         testSimpleStore(Namespace.DEFAULT_BUCKET_TYPE);
     }
-    
+
     @Test
     public void testSimpleStoreTestType() throws InterruptedException, ExecutionException
     {
         assumeTrue(testBucketType);
         testSimpleStore(bucketType.toString());
     }
-    
+
     private void testSimpleStore(String bucketType) throws InterruptedException, ExecutionException
     {
-        
+
         RiakObject obj = new RiakObject().setValue(BinaryValue.create(value));
         Namespace ns = new Namespace(bucketType, bucketName.toString());
         Location location = new Location(ns, key);
-        StoreOperation storeOp = 
+        StoreOperation storeOp =
             new StoreOperation.Builder(location)
                 .withContent(obj)
                 .build();
-        
-        cluster.execute(storeOp);
+
+        final RiakFuture<StoreOperation.Response, Location> storeFuture = cluster.execute(storeOp);
         storeOp.get();
-        
-        FetchOperation fetchOp = 
+        storeFuture.await();
+        assertTrue(storeFuture.isSuccess());
+
+        FetchOperation fetchOp =
                 new FetchOperation.Builder(location).build();
-                
+
         cluster.execute(fetchOp);
         RiakObject obj2 = fetchOp.get().getObjectList().get(0);
-        
+
         assertEquals(obj.getValue(), obj2.getValue());
-               
+
     }
-    
+
     @Test
     public void testStoreWithVClockAndReturnbodyDefaultType() throws InterruptedException, ExecutionException
     {
         assumeTrue(testBucketType);
         testStoreWithVClockAndReturnbody(bucketType.toString());
     }
-    
+
     @Test
     public void testStoreWithVClockAndReturnbodyTestType() throws InterruptedException, ExecutionException
     {
         testStoreWithVClockAndReturnbody(Namespace.DEFAULT_BUCKET_TYPE);
     }
-    
+
     private void testStoreWithVClockAndReturnbody(String bucketType) throws InterruptedException, ExecutionException
     {
-        // Enable allow_multi, store a new item, then do a read/modify/write 
+        // Enable allow_multi, store a new item, then do a read/modify/write
         // using the vclock
-        
+
         Namespace ns = new Namespace(bucketType, bucketName.toString() + "_1");
-        StoreBucketPropsOperation op = 
+        StoreBucketPropsOperation op =
             new StoreBucketPropsOperation.Builder(ns)
                 .withAllowMulti(true)
                 .build();
         cluster.execute(op);
         op.get();
-        
+
         RiakObject obj = new RiakObject().setValue(BinaryValue.create(value));
         Location location = new Location(ns, key);
-       
-        StoreOperation storeOp = 
+
+        StoreOperation storeOp =
             new StoreOperation.Builder(location)
                 .withContent(obj)
                 .withReturnBody(true)
                 .build();
-        
+
         cluster.execute(storeOp);
         StoreOperation.Response response = storeOp.get();
         obj = response.getObjectList().get(0);
-        
+
         assertNotNull(obj.getVClock());
-        
+
         obj.setValue(BinaryValue.create("changed"));
 
         storeOp = new StoreOperation.Builder(location)
                 .withContent(obj)
                 .withReturnBody(true)
                 .build();
-        
+
         cluster.execute(storeOp);
         response = storeOp.get();
         obj = response.getObjectList().get(0);
-        
+
         assertEquals(obj.getValue().toString(), "changed");
-        
+
         resetAndEmptyBucket(ns);
     }
-    
+
 }

--- a/src/test/java/com/basho/riak/client/core/operations/itest/ts/ITestCoveragePlan.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/ts/ITestCoveragePlan.java
@@ -2,6 +2,7 @@ package com.basho.riak.client.core.operations.itest.ts;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assume.assumeTrue;
 
 import java.net.UnknownHostException;
 import java.util.ArrayList;
@@ -38,7 +39,13 @@ public class ITestCoveragePlan extends ITestTsBase
     private static long to = from + period;
 
     @BeforeClass
-    public static void createData() throws ExecutionException, InterruptedException
+    public static void BeforeClass() throws ExecutionException, InterruptedException
+    {
+        assumeTrue(testCoveragePlan);
+        createData();
+    }
+
+    private static void createData() throws ExecutionException, InterruptedException
     {
         List<Row> rows1 = new ArrayList<Row>();
         for (long time = from; time <= to; time += quantum)
@@ -74,7 +81,6 @@ public class ITestCoveragePlan extends ITestTsBase
     @Test
     public void queryWithCoveragePlan() throws ExecutionException, InterruptedException, UnknownHostException
     {
-
         final RiakClient client = new RiakClient(cluster);
         String queryOneRowOnly = "select * from " + tableName + " where time >= " + (from - 100) + " and time < " + (from + 100)
                 + " and user = 'user1' and geohash = 'hash1'";


### PR DESCRIPTION
Client-side fix for https://github.com/basho/riak_kv/issues/1464.

We were sending a "0" as the default timeout value on TTB TS Fetch requests, should have been the atom `undefined`.   Also disallowing 0 as a valid value in all the TS command / operation builders.
