### PR TITLE
Add HyperLogLog Data Type

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ com.basho.riak.yokozuna | true | Riak KV 2.0 Solr/Yokozuna Search Tests
 com.basho.riak.2i | true | Riak KV Secondary Index Tests
 com.basho.riak.mr | true | Riak KV MapReduce Tests
 com.basho.riak.crdt | true | Riak KV 2.0 Data Type Tests
+com.basho.riak.hlldt | true | Riak KV 2.2 HyperLogLog Data Type Tests
 com.basho.riak.lifecycle | true | Java Client Node/Cluster Lifecycle Tests
 com.basho.riak.timeseries | false | Riak TS TimeSeries Tests
 com.basho.riak.riakSearch | false | Riak KV 1.0 Legacy Search Tests

--- a/src/main/java/com/basho/riak/client/api/commands/buckets/StoreBucketProperties.java
+++ b/src/main/java/com/basho/riak/client/api/commands/buckets/StoreBucketProperties.java
@@ -64,6 +64,7 @@ public final class StoreBucketProperties extends RiakCommand<Void, Namespace>
     private final Integer nval;
     private final Boolean legacySearch;
     private final String searchIndex;
+    private final Integer hllPrecision;
 
     StoreBucketProperties(Builder builder)
     {
@@ -90,6 +91,7 @@ public final class StoreBucketProperties extends RiakCommand<Void, Namespace>
         this.nval = builder.nval;
         this.legacySearch = builder.legacySearch;
         this.searchIndex = builder.searchIndex;
+        this.hllPrecision = builder.hllPrecision;
     }
 
     @Override
@@ -232,6 +234,11 @@ public final class StoreBucketProperties extends RiakCommand<Void, Namespace>
             builder.withSearchIndex(searchIndex);
         }
 
+        if (hllPrecision != null)
+        {
+            builder.withHllPrecision(hllPrecision);
+        }
+
         return builder.build();
     }
 
@@ -260,6 +267,7 @@ public final class StoreBucketProperties extends RiakCommand<Void, Namespace>
         private Integer nval;
         private Boolean legacySearch;
         private String searchIndex;
+        private Integer hllPrecision;
 
         public Builder(Namespace namespace)
         {
@@ -574,6 +582,25 @@ public final class StoreBucketProperties extends RiakCommand<Void, Namespace>
                 throw new IllegalArgumentException("Index name cannot be null or zero length");
             }
             this.searchIndex = indexName;
+            return this;
+        }
+
+        /**
+         * Set the HyperLogLog Precision.
+         *
+         * @param precision the number of bits to use in the HyperLogLog precision.
+         *                  Valid values are [4 - 16] inclusive, default is 14 on new buckets.
+         *                  <b>NOTE:</b> When changing precision, it may only be reduced from
+         *                  it's current value, and never increased.
+         * @return a reference to this object.
+         */
+        public Builder withHllPrecision(int precision)
+        {
+            if (precision < 4 || precision > 16)
+            {
+                throw new IllegalArgumentException("Precision must be between 4 and 16, inclusive.");
+            }
+            this.hllPrecision = precision;
             return this;
         }
 

--- a/src/main/java/com/basho/riak/client/api/commands/datatypes/FetchHll.java
+++ b/src/main/java/com/basho/riak/client/api/commands/datatypes/FetchHll.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 Basho Technologies Inc
+ * Copyright 2016 Basho Technologies Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/basho/riak/client/api/commands/datatypes/FetchHll.java
+++ b/src/main/java/com/basho/riak/client/api/commands/datatypes/FetchHll.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2013 Basho Technologies Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.basho.riak.client.api.commands.datatypes;
+
+import com.basho.riak.client.api.commands.CoreFutureAdapter;
+import com.basho.riak.client.core.RiakCluster;
+import com.basho.riak.client.core.RiakFuture;
+import com.basho.riak.client.core.operations.DtFetchOperation;
+import com.basho.riak.client.core.query.Location;
+import com.basho.riak.client.core.query.crdt.types.RiakDatatype;
+import com.basho.riak.client.core.query.crdt.types.RiakHll;
+
+/**
+ * Command used to fetch a HyperLogLog datatype from Riak.
+ * <script src="https://google-code-prettify.googlecode.com/svn/loader/run_prettify.js"></script>
+ * <p>
+ * <pre class="prettyprint">
+ * {@code
+ *     Namespace ns = new Namespace("my_type", "my_bucket");
+ *     Location loc = new Location(ns, "my_key");
+ *     FetchHll fhll = new FetchHll.Builder(loc).build();
+ *     FetchHll.Response resp = client.execute(fhll);
+ *     RiakHll rHll = resp.getDatatype();
+ *     long hllCardinality = rHll.view();
+ * }
+ * </pre>
+ * @author Alex Moore <amoore at basho dot com>
+ * @since 2.1
+ */
+public final class FetchHll extends FetchDatatype<RiakHll, FetchHll.Response, Location>
+{
+    private FetchHll(Builder builder)
+    {
+        super(builder);
+    }
+
+    @Override
+    protected final RiakFuture<FetchHll.Response, Location> executeAsync(RiakCluster cluster)
+    {
+        RiakFuture<DtFetchOperation.Response, Location> coreFuture =
+            cluster.execute(buildCoreOperation());
+
+        CoreFutureAdapter<FetchHll.Response, Location, DtFetchOperation.Response, Location> future =
+            new CoreFutureAdapter<FetchHll.Response, Location, DtFetchOperation.Response, Location>(coreFuture)
+            {
+                @Override
+                protected FetchHll.Response convertResponse(DtFetchOperation.Response coreResponse)
+                {
+                    RiakDatatype element = coreResponse.getCrdtElement();
+
+                    Context context = null;
+                    if (coreResponse.hasContext())
+                    {
+                        context = new Context(coreResponse.getContext());
+                    }
+
+                    RiakHll datatype = extractDatatype(element);
+
+                    return new Response(datatype, context);
+                }
+
+                @Override
+                protected Location convertQueryInfo(Location coreQueryInfo)
+                {
+                    return coreQueryInfo;
+                }
+            };
+        coreFuture.addListener(future);
+        return future;
+    }
+
+    @Override
+    public RiakHll extractDatatype(RiakDatatype element)
+    {
+        return element.getAsHLL();
+    }
+
+    /**
+     * Builder used to construct a FetchHll command.
+     */
+    public static class Builder extends FetchDatatype.Builder<Builder>
+    {
+        /**
+         * Construct a builder for a FetchHll command.
+         * @param location the location of the HyperLogLog in Riak.
+         */
+        public Builder(Location location)
+        {
+            super(location);
+        }
+
+        @Override
+        protected Builder self()
+        {
+            return this;
+        }
+
+        /**
+         * Construct a FetchHll command.
+         * @return a new FetchHll Command.
+         */
+        public FetchHll build()
+        {
+            return new FetchHll(this);
+        }
+    }
+
+    /**
+     * Response from a FetchHll command.
+     * <p>
+     * Encapsulates a RiakHll returned from the FetchHll command.
+     * <pre>
+     * {@code
+     * ...
+     *     RiakHll rHll = response.getDatatype();
+     *     long hllCardinality = rHll.view();
+     * }
+     * </pre>
+     * </p>
+     */
+    public static class Response extends FetchDatatype.Response<RiakHll>
+    {
+        Response(RiakHll hll, Context context)
+        {
+            super(hll, context);
+        }
+    }
+}

--- a/src/main/java/com/basho/riak/client/api/commands/datatypes/FetchHll.java
+++ b/src/main/java/com/basho/riak/client/api/commands/datatypes/FetchHll.java
@@ -86,7 +86,7 @@ public final class FetchHll extends FetchDatatype<RiakHll, FetchHll.Response, Lo
     @Override
     public RiakHll extractDatatype(RiakDatatype element)
     {
-        return element.getAsHLL();
+        return element.getAsHll();
     }
 
     /**

--- a/src/main/java/com/basho/riak/client/api/commands/datatypes/HllUpdate.java
+++ b/src/main/java/com/basho/riak/client/api/commands/datatypes/HllUpdate.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2013 Basho Technologies Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.basho.riak.client.api.commands.datatypes;
+
+import com.basho.riak.client.core.query.crdt.ops.HllOp;
+import com.basho.riak.client.core.util.BinaryValue;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * An update to a Riak HyperLogLog datatype.
+ * <p>
+ * When building an {@link UpdateHll}
+ * this class is used to encapsulate the update to be performed on a
+ * Riak HyperLogLog datatype.
+ * </p>
+ * @author Dave Rusek <drusek at basho dot com>
+ * @since 2.0
+ */
+public class HllUpdate implements DatatypeUpdate
+{
+    private final Set<BinaryValue> adds = new HashSet<>();
+
+    /**
+     * Constructs an empty HllUpdate.
+     */
+    public HllUpdate()
+    {
+    }
+
+    /**
+     * Add the provided element to the HyperLogLog in Riak.
+     * @param element the element to be added.
+     * @return a reference to this object.
+     */
+    public HllUpdate addBinary(BinaryValue element)
+    {
+        this.adds.add(element);
+        return this;
+    }
+
+    /**
+     * Add the provided element to the HyperLogLog in Riak.
+     * @param element the element to be added.
+     * @return a reference to this object.
+     */
+    public HllUpdate add(String element)
+    {
+        this.adds.add(BinaryValue.create(element));
+        return this;
+    }
+
+    /**
+     * Add the provided elements to the HyperLogLog in Riak.
+     * @param elements the elements to be added.
+     * @return a reference to this object.
+     */
+    public HllUpdate addAllBinary(Collection<BinaryValue> elements)
+    {
+        if(elements == null)
+        {
+            throw new IllegalArgumentException("Elements cannot be null");
+        }
+
+        for (BinaryValue element : elements)
+        {
+            this.adds.add(element);
+        }
+
+        return this;
+    }
+
+    /**
+     * Add the provided elements to the HyperLogLog in Riak.
+     * @param elements the elements to be added.
+     * @return a reference to this object.
+     */
+    public HllUpdate addAll(Collection<String> elements)
+    {
+        if(elements == null)
+        {
+            throw new IllegalArgumentException("Elements cannot be null");
+        }
+
+        for (String element : elements)
+        {
+            this.adds.add(BinaryValue.create(element));
+        }
+
+        return this;
+    }
+
+    /**
+     * Get the set of element additions contained in this update.
+     * @return the set of additions.
+     */
+    public Set<BinaryValue> getElementAdds()
+    {
+        return adds;
+    }
+
+    /**
+     * Returns the core update.
+     * @return the update used by the client core.
+     */
+    @Override
+    public HllOp getOp()
+    {
+        return new HllOp(adds);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "Element Adds: " + adds;
+    }
+}

--- a/src/main/java/com/basho/riak/client/api/commands/datatypes/HllUpdate.java
+++ b/src/main/java/com/basho/riak/client/api/commands/datatypes/HllUpdate.java
@@ -72,7 +72,7 @@ public class HllUpdate implements DatatypeUpdate
      */
     public HllUpdate addAllBinary(Collection<BinaryValue> elements)
     {
-        if(elements == null)
+        if (elements == null)
         {
             throw new IllegalArgumentException("Elements cannot be null");
         }
@@ -92,7 +92,7 @@ public class HllUpdate implements DatatypeUpdate
      */
     public HllUpdate addAll(Collection<String> elements)
     {
-        if(elements == null)
+        if (elements == null)
         {
             throw new IllegalArgumentException("Elements cannot be null");
         }

--- a/src/main/java/com/basho/riak/client/api/commands/datatypes/HllUpdate.java
+++ b/src/main/java/com/basho/riak/client/api/commands/datatypes/HllUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 Basho Technologies Inc
+ * Copyright 2016 Basho Technologies Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,8 +29,8 @@ import java.util.Set;
  * this class is used to encapsulate the update to be performed on a
  * Riak HyperLogLog datatype.
  * </p>
- * @author Dave Rusek <drusek at basho dot com>
- * @since 2.0
+ * @author Alex Moore <amoore at basho dot com>
+ * @since 2.1
  */
 public class HllUpdate implements DatatypeUpdate
 {

--- a/src/main/java/com/basho/riak/client/api/commands/datatypes/UpdateHll.java
+++ b/src/main/java/com/basho/riak/client/api/commands/datatypes/UpdateHll.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 Basho Technologies Inc
+ * Copyright 2016 Basho Technologies Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/basho/riak/client/api/commands/datatypes/UpdateHll.java
+++ b/src/main/java/com/basho/riak/client/api/commands/datatypes/UpdateHll.java
@@ -140,6 +140,17 @@ public class UpdateHll extends UpdateDatatype<RiakHll, UpdateHll.Response, Locat
         }
 
         /**
+         * Contexts are not used with the Hyperloglog data type
+         * @param unused Unused parameter
+         * @return a copy of this object
+         */
+        @Override
+        public Builder withContext(Context unused)
+        {
+            return this;
+        }
+
+        /**
          * Construct a new UpdateHll command.
          * @return a new UpdateHll command.
          */
@@ -164,6 +175,26 @@ public class UpdateHll extends UpdateDatatype<RiakHll, UpdateHll.Response, Locat
         private Response(Context context, RiakHll datatype, BinaryValue generatedKey)
         {
             super(context, datatype, generatedKey);
+        }
+
+        /**
+         * Contexts are not used with the Hyperloglog data type
+         * @return false
+         */
+        @Override
+        public boolean hasContext()
+        {
+            return false;
+        }
+
+        /**
+         * Contexts are not used with the Hyperloglog data type
+         * @return null
+         */
+        @Override
+        public Context getContext()
+        {
+            return null;
         }
     }
 }

--- a/src/main/java/com/basho/riak/client/api/commands/datatypes/UpdateHll.java
+++ b/src/main/java/com/basho/riak/client/api/commands/datatypes/UpdateHll.java
@@ -74,7 +74,7 @@ public class UpdateHll extends UpdateDatatype<RiakHll, UpdateHll.Response, Locat
                     if (coreResponse.hasCrdtElement())
                     {
                         RiakDatatype element = coreResponse.getCrdtElement();
-                        hll = element.getAsHLL();
+                        hll = element.getAsHll();
                     }
                     BinaryValue returnedKey = coreResponse.hasGeneratedKey()
                         ? coreResponse.getGeneratedKey()

--- a/src/main/java/com/basho/riak/client/api/commands/datatypes/UpdateHll.java
+++ b/src/main/java/com/basho/riak/client/api/commands/datatypes/UpdateHll.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2013 Basho Technologies Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.basho.riak.client.api.commands.datatypes;
+
+import com.basho.riak.client.api.commands.CoreFutureAdapter;
+import com.basho.riak.client.core.RiakCluster;
+import com.basho.riak.client.core.RiakFuture;
+import com.basho.riak.client.core.operations.DtUpdateOperation;
+import com.basho.riak.client.core.query.Location;
+import com.basho.riak.client.core.query.Namespace;
+import com.basho.riak.client.core.query.crdt.types.RiakDatatype;
+import com.basho.riak.client.core.query.crdt.types.RiakHll;
+import com.basho.riak.client.core.util.BinaryValue;
+
+/**
+ * Command used to update or create a HyperLogLog datatype in Riak.
+ * <script src="https://google-code-prettify.googlecode.com/svn/loader/run_prettify.js"></script>
+ * <p>
+ * To update or create a HyperLogLog in Riak you construct a {@link HllUpdate} and use
+ * this command to send it to Riak.
+ * <pre class="prettyprint">
+ * {@code
+ *     Namespace ns = new Namespace("my_type", "my_bucket");
+ *     Location loc = new Location(ns, "my_key");
+ *     HllUpdate update = new HllUpdate().add("some_new_value");
+ *
+ *     UpdateHll us = new UpdateHll.Builder(loc, update).withReturnDatatype(true).build();
+ *     UpdateHll.Response resp = client.execute(us);
+ *     RiakHll = resp.getDatatype();
+ * }
+ * </pre>
+ * </p>
+ *
+ * @author Alex Moore <amoore at basho dot com>
+ * @since 2.1
+ */
+public class UpdateHll extends UpdateDatatype<RiakHll, UpdateHll.Response, Location>
+{
+    private final HllUpdate update;
+
+    private UpdateHll(Builder builder)
+    {
+        super(builder);
+        this.update = builder.update;
+    }
+
+    @Override
+    protected RiakFuture<Response, Location> executeAsync(RiakCluster cluster)
+    {
+        RiakFuture<DtUpdateOperation.Response, Location> coreFuture =
+            cluster.execute(buildCoreOperation(update));
+
+        CoreFutureAdapter<Response, Location, DtUpdateOperation.Response, Location> future =
+            new CoreFutureAdapter<Response, Location, DtUpdateOperation.Response, Location>(coreFuture)
+            {
+                @Override
+                protected Response convertResponse(DtUpdateOperation.Response coreResponse)
+                {
+                    RiakHll hll = null;
+                    if (coreResponse.hasCrdtElement())
+                    {
+                        RiakDatatype element = coreResponse.getCrdtElement();
+                        hll = element.getAsHLL();
+                    }
+                    BinaryValue returnedKey = coreResponse.hasGeneratedKey()
+                        ? coreResponse.getGeneratedKey()
+                        : null;
+                    Context returnedCtx = null;
+                    if (coreResponse.hasContext())
+                    {
+                        returnedCtx = new Context(coreResponse.getContext());
+                    }
+                    return new Response(returnedCtx, hll, returnedKey);
+                }
+
+                @Override
+                protected Location convertQueryInfo(Location coreQueryInfo)
+                {
+                    return coreQueryInfo;
+                }
+            };
+        coreFuture.addListener(future);
+        return future;
+    }
+
+    /**
+     * Builder used to construct an UpdateHll command.
+     */
+    public static class Builder extends UpdateDatatype.Builder<Builder>
+    {
+        private final HllUpdate update;
+
+        /**
+         * Construct a Builder for an UpdateHll command.
+         * @param location the location of the HyperLogLog in Riak.
+         * @param update the update to apply to the HyperLogLog.
+         */
+        public Builder(Location location, HllUpdate update)
+        {
+            super(location);
+            if (update == null)
+            {
+                throw new IllegalArgumentException("Update cannot be null");
+            }
+            this.update = update;
+        }
+
+        /**
+         * Constructs a builder for an UpdateHll command with only a Namespace.
+         * <p>
+         * By providing only a Namespace with the update, Riak will create the
+         * HyperLogLog, generate the key, and return it in the response.
+         * </p>
+         * @param namespace the namespace to create the datatype.
+         * @param update the update to apply
+         * @see Response#getGeneratedKey()
+         */
+        public Builder(Namespace namespace, HllUpdate update)
+        {
+            super(namespace);
+            if (update == null)
+            {
+                throw new IllegalArgumentException("Update cannot be null");
+            }
+            this.update = update;
+        }
+
+        /**
+         * Construct a new UpdateHll command.
+         * @return a new UpdateHll command.
+         */
+        @Override
+        public UpdateHll build()
+        {
+            return new UpdateHll(this);
+        }
+
+        @Override
+        protected Builder self()
+        {
+            return this;
+        }
+    }
+
+    /**
+     * A response from an UpdateHll command.
+     */
+    public static class Response extends UpdateDatatype.Response<RiakHll>
+    {
+        private Response(Context context, RiakHll datatype, BinaryValue generatedKey)
+        {
+            super(context, datatype, generatedKey);
+        }
+    }
+}

--- a/src/main/java/com/basho/riak/client/core/converters/BucketPropertiesConverter.java
+++ b/src/main/java/com/basho/riak/client/core/converters/BucketPropertiesConverter.java
@@ -92,6 +92,11 @@ public class BucketPropertiesConverter
                 builder.withBackend(pbProps.getBackend().toStringUtf8());
             }
 
+            if (pbProps.hasHllPrecision())
+            {
+                builder.withHllPrecision(pbProps.getHllPrecision());
+            }
+
             return builder.build();
     }
 
@@ -187,6 +192,10 @@ public class BucketPropertiesConverter
         if (bucketProperties.hasSearchIndex())
         {
             propsBuilder.setSearchIndex(ByteString.copyFromUtf8(bucketProperties.getSearchIndex()));
+        }
+        if (bucketProperties.hasHllPrecision())
+        {
+            propsBuilder.setHllPrecision(bucketProperties.getHllPrecision());
         }
 
         return propsBuilder.build();

--- a/src/main/java/com/basho/riak/client/core/converters/CrdtResponseConverter.java
+++ b/src/main/java/com/basho/riak/client/core/converters/CrdtResponseConverter.java
@@ -92,7 +92,7 @@ public class CrdtResponseConverter
         {
             element = parseMap(response.getMapValueList());
         }
-        else if(response.hasHllValue())
+        else if (response.hasHllValue())
         {
             element = parseHll(response.getHllValue());
         }

--- a/src/main/java/com/basho/riak/client/core/converters/CrdtResponseConverter.java
+++ b/src/main/java/com/basho/riak/client/core/converters/CrdtResponseConverter.java
@@ -15,12 +15,7 @@
  */
 package com.basho.riak.client.core.converters;
 
-import com.basho.riak.client.core.query.crdt.types.RiakFlag;
-import com.basho.riak.client.core.query.crdt.types.RiakRegister;
-import com.basho.riak.client.core.query.crdt.types.RiakMap;
-import com.basho.riak.client.core.query.crdt.types.RiakCounter;
-import com.basho.riak.client.core.query.crdt.types.RiakDatatype;
-import com.basho.riak.client.core.query.crdt.types.RiakSet;
+import com.basho.riak.client.core.query.crdt.types.*;
 import com.basho.riak.client.core.util.BinaryValue;
 import com.basho.riak.protobuf.RiakDtPB;
 import com.google.protobuf.ByteString;
@@ -30,6 +25,11 @@ import java.util.List;
 
 public class CrdtResponseConverter
 {
+    private RiakDatatype parseHll(long hllValue)
+    {
+        return new RiakHll(hllValue);
+    }
+
     private RiakDatatype parseSet(List<ByteString> setValues)
     {
         List<BinaryValue> entries = new ArrayList<>(setValues.size());
@@ -92,6 +92,10 @@ public class CrdtResponseConverter
         {
             element = parseMap(response.getMapValueList());
         }
+        else if(response.hasHllValue())
+        {
+            element = parseHll(response.getHllValue());
+        }
 
         return element;
     }
@@ -109,6 +113,9 @@ public class CrdtResponseConverter
                 break;
             case SET:
                 element = parseSet(response.getValue().getSetValueList());
+                break;
+            case HLL:
+                element = parseHll(response.getValue().getHllValue());
                 break;
             default:
                 throw new IllegalStateException("No known datatype returned");

--- a/src/main/java/com/basho/riak/client/core/operations/DtUpdateOperation.java
+++ b/src/main/java/com/basho/riak/client/core/operations/DtUpdateOperation.java
@@ -15,12 +15,7 @@
  */
 package com.basho.riak.client.core.operations;
 
-import com.basho.riak.client.core.query.crdt.ops.CounterOp;
-import com.basho.riak.client.core.query.crdt.ops.RegisterOp;
-import com.basho.riak.client.core.query.crdt.ops.MapOp;
-import com.basho.riak.client.core.query.crdt.ops.CrdtOp;
-import com.basho.riak.client.core.query.crdt.ops.FlagOp;
-import com.basho.riak.client.core.query.crdt.ops.SetOp;
+import com.basho.riak.client.core.query.crdt.ops.*;
 import com.basho.riak.client.core.FutureOperation;
 import com.basho.riak.client.core.RiakMessage;
 import com.basho.riak.client.core.converters.CrdtResponseConverter;
@@ -298,6 +293,18 @@ public class DtUpdateOperation extends FutureOperation<DtUpdateOperation.Respons
             return setOpBuilder.build();
         }
 
+        RiakDtPB.HllOp getHllOp(HllOp op)
+        {
+            RiakDtPB.HllOp.Builder hllOpBuilder = RiakDtPB.HllOp.newBuilder();
+
+            for (BinaryValue element : op.getElements())
+            {
+                hllOpBuilder.addAdds(ByteString.copyFrom(element.unsafeGetValue()));
+            }
+
+            return hllOpBuilder.build();
+        }
+
         RiakDtPB.MapUpdate.FlagOp getFlagOp(FlagOp op)
         {
             return op.getEnabled()
@@ -404,6 +411,10 @@ public class DtUpdateOperation extends FutureOperation<DtUpdateOperation.Respons
             {
                 withOp((SetOp) op);
             }
+            else if (op instanceof HllOp)
+            {
+                withOp((HllOp) op);
+            }
 
             return this;
         }
@@ -428,6 +439,13 @@ public class DtUpdateOperation extends FutureOperation<DtUpdateOperation.Respons
             reqBuilder.setOp(RiakDtPB.DtOp.newBuilder()
                 .setSetOp(getSetOp(op)));
 
+            return this;
+        }
+
+        private Builder withOp(HllOp op)
+        {
+            reqBuilder.setOp(RiakDtPB.DtOp.newBuilder()
+                .setHllOp(getHllOp(op)));
             return this;
         }
     }

--- a/src/main/java/com/basho/riak/client/core/operations/StoreBucketPropsOperation.java
+++ b/src/main/java/com/basho/riak/client/core/operations/StoreBucketPropsOperation.java
@@ -395,6 +395,25 @@ public class StoreBucketPropsOperation extends FutureOperation<Void, Void, Names
             return self();
         }
 
+        /**
+         * Set the HyperLogLog Precision.
+         *
+         * @param precision the number of bits to use in the HyperLogLog precision.
+         *                  Valid values are [4 - 16] inclusive, default is 14 on new buckets.
+         *                  <b>NOTE:</b> When changing precision, it may only be reduced from
+         *                  it's current value, and never increased.
+         * @return a reference to this object.
+         */
+        public T withHllPrecision(int precision)
+        {
+            if (precision < 4 || precision > 16)
+            {
+                throw new IllegalArgumentException("Precision must be between 4 and 16, inclusive.");
+            }
+            propsBuilder.setHllPrecision(precision);
+            return self();
+        }
+
         private void verifyErlangFunc(Function f)
         {
             if (null == f || f.isJavascript())

--- a/src/main/java/com/basho/riak/client/core/query/BucketProperties.java
+++ b/src/main/java/com/basho/riak/client/core/query/BucketProperties.java
@@ -55,6 +55,7 @@ public class BucketProperties
     private final Boolean allowSiblings;
     private final Boolean search;
     private final String yokozunaIndex;
+    private final Integer hllPrecision;
 
     private BucketProperties(Builder builder)
     {
@@ -80,6 +81,7 @@ public class BucketProperties
         this.w = builder.w;
         this.yokozunaIndex = builder.yokozunaIndex;
         this.youngVClock = builder.youngVClock;
+        this.hllPrecision = builder.hllPrecision;
     }
 
     /**
@@ -533,6 +535,26 @@ public class BucketProperties
         return yokozunaIndex;
     }
 
+    /**
+     * Determine if an hllPrecision value has been set.
+     *
+     * @return true if set, false otherwise.
+     */
+    public boolean hasHllPrecision()
+    {
+        return hllPrecision != null;
+    }
+
+    /**
+     * Get the HyperLogLog Precision.
+     *
+     * @return the hllPrecision value or null if not set.
+     */
+    public Integer getHllPrecision()
+    {
+        return hllPrecision;
+    }
+
     @Override
     public String toString()
     {
@@ -542,101 +564,147 @@ public class BucketProperties
             + "vclockProps=[oldVClock=%s, youngVClock=%s, bigVClock=%s, smallVClock=%s],"
             + "precommitHooks=%s, postcommitHooks=%s, "
             + ", chashKeyFunction=%s, linkWalkFunction=%s, search=%s,"
-            + "yokozunaIndex=%s]",
+            + "yokozunaIndex=%s, hllPrecision=%s]",
                              allowSiblings, lastWriteWins, nVal, backend, rw, dw,
                              w, r, pr, pw, oldVClock, youngVClock, bigVClock, smallVClock,
                              precommitHooks, postcommitHooks,
                              chashKeyFunction, linkwalkFunction, search,
-                             yokozunaIndex);
+                             yokozunaIndex, hllPrecision);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass())
+        {
+            return false;
+        }
+
+        BucketProperties that = (BucketProperties) o;
+
+        if (linkwalkFunction != null ? !linkwalkFunction.equals(that.linkwalkFunction) : that.linkwalkFunction != null)
+        {
+            return false;
+        }
+        if (chashKeyFunction != null ? !chashKeyFunction.equals(that.chashKeyFunction) : that.chashKeyFunction != null)
+        {
+            return false;
+        }
+        if (rw != null ? !rw.equals(that.rw) : that.rw != null)
+        {
+            return false;
+        }
+        if (dw != null ? !dw.equals(that.dw) : that.dw != null)
+        {
+            return false;
+        }
+        if (w != null ? !w.equals(that.w) : that.w != null)
+        {
+            return false;
+        }
+        if (r != null ? !r.equals(that.r) : that.r != null)
+        {
+            return false;
+        }
+        if (pr != null ? !pr.equals(that.pr) : that.pr != null)
+        {
+            return false;
+        }
+        if (pw != null ? !pw.equals(that.pw) : that.pw != null)
+        {
+            return false;
+        }
+        if (notFoundOk != null ? !notFoundOk.equals(that.notFoundOk) : that.notFoundOk != null)
+        {
+            return false;
+        }
+        if (basicQuorum != null ? !basicQuorum.equals(that.basicQuorum) : that.basicQuorum != null)
+        {
+            return false;
+        }
+        if (precommitHooks != null ? !precommitHooks.equals(that.precommitHooks) : that.precommitHooks != null)
+        {
+            return false;
+        }
+        if (postcommitHooks != null ? !postcommitHooks.equals(that.postcommitHooks) : that.postcommitHooks != null)
+        {
+            return false;
+        }
+        if (oldVClock != null ? !oldVClock.equals(that.oldVClock) : that.oldVClock != null)
+        {
+            return false;
+        }
+        if (youngVClock != null ? !youngVClock.equals(that.youngVClock) : that.youngVClock != null)
+        {
+            return false;
+        }
+        if (bigVClock != null ? !bigVClock.equals(that.bigVClock) : that.bigVClock != null)
+        {
+            return false;
+        }
+        if (smallVClock != null ? !smallVClock.equals(that.smallVClock) : that.smallVClock != null)
+        {
+            return false;
+        }
+        if (backend != null ? !backend.equals(that.backend) : that.backend != null)
+        {
+            return false;
+        }
+        if (nVal != null ? !nVal.equals(that.nVal) : that.nVal != null)
+        {
+            return false;
+        }
+        if (lastWriteWins != null ? !lastWriteWins.equals(that.lastWriteWins) : that.lastWriteWins != null)
+        {
+            return false;
+        }
+        if (allowSiblings != null ? !allowSiblings.equals(that.allowSiblings) : that.allowSiblings != null)
+        {
+            return false;
+        }
+        if (search != null ? !search.equals(that.search) : that.search != null)
+        {
+            return false;
+        }
+        if (yokozunaIndex != null ? !yokozunaIndex.equals(that.yokozunaIndex) : that.yokozunaIndex != null)
+        {
+            return false;
+        }
+        return hllPrecision != null ? hllPrecision.equals(that.hllPrecision) : that.hllPrecision == null;
+
     }
 
     @Override
     public int hashCode()
     {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((null == linkwalkFunction) ? 0 : linkwalkFunction.hashCode());
-        result = prime * result + ((null == chashKeyFunction) ? 0 : chashKeyFunction.hashCode());
-        result = prime * result + ((null == rw) ? 0 : rw.hashCode());
-        result = prime * result + ((null == dw) ? 0 : dw.hashCode());
-        result = prime * result + ((null == w) ? 0 : w.hashCode());
-        result = prime * result + ((null == r) ? 0 : r.hashCode());
-        result = prime * result + ((null == pr) ? 0 : pr.hashCode());
-        result = prime * result + ((null == pw) ? 0 : pw.hashCode());
-        result = prime * result + ((null == notFoundOk) ? 0 : notFoundOk.hashCode());
-        result = prime * result + ((null == basicQuorum) ? 0 : basicQuorum.hashCode());
-        result = prime * result + precommitHooks.hashCode();
-        result = prime * result + postcommitHooks.hashCode();
-        result = prime * result + (null == oldVClock ? 0 : oldVClock.hashCode());
-        result = prime * result + (null == youngVClock ? 0 : youngVClock.hashCode());
-        result = prime * result + (null == bigVClock ? 0 : bigVClock.hashCode());
-        result = prime * result + (null == smallVClock ? 0 : smallVClock.hashCode());
-        result = prime * result + (null == backend ? 0 : backend.hashCode());
-        result = prime * result + (null == nVal ? 0 : nVal.hashCode());
-        result = prime * result + (null == lastWriteWins ? 0 : lastWriteWins.hashCode());
-        result = prime * result + (null == allowSiblings ? 0 : allowSiblings.hashCode());
-        result = prime * result + (null == yokozunaIndex ? 0 : yokozunaIndex.hashCode());
-        result = prime * result + (null == search ? 0 : search.hashCode());
+        int result = linkwalkFunction != null ? linkwalkFunction.hashCode() : 0;
+        result = 31 * result + (chashKeyFunction != null ? chashKeyFunction.hashCode() : 0);
+        result = 31 * result + (rw != null ? rw.hashCode() : 0);
+        result = 31 * result + (dw != null ? dw.hashCode() : 0);
+        result = 31 * result + (w != null ? w.hashCode() : 0);
+        result = 31 * result + (r != null ? r.hashCode() : 0);
+        result = 31 * result + (pr != null ? pr.hashCode() : 0);
+        result = 31 * result + (pw != null ? pw.hashCode() : 0);
+        result = 31 * result + (notFoundOk != null ? notFoundOk.hashCode() : 0);
+        result = 31 * result + (basicQuorum != null ? basicQuorum.hashCode() : 0);
+        result = 31 * result + (precommitHooks != null ? precommitHooks.hashCode() : 0);
+        result = 31 * result + (postcommitHooks != null ? postcommitHooks.hashCode() : 0);
+        result = 31 * result + (oldVClock != null ? oldVClock.hashCode() : 0);
+        result = 31 * result + (youngVClock != null ? youngVClock.hashCode() : 0);
+        result = 31 * result + (bigVClock != null ? bigVClock.hashCode() : 0);
+        result = 31 * result + (smallVClock != null ? smallVClock.hashCode() : 0);
+        result = 31 * result + (backend != null ? backend.hashCode() : 0);
+        result = 31 * result + (nVal != null ? nVal.hashCode() : 0);
+        result = 31 * result + (lastWriteWins != null ? lastWriteWins.hashCode() : 0);
+        result = 31 * result + (allowSiblings != null ? allowSiblings.hashCode() : 0);
+        result = 31 * result + (search != null ? search.hashCode() : 0);
+        result = 31 * result + (yokozunaIndex != null ? yokozunaIndex.hashCode() : 0);
+        result = 31 * result + (hllPrecision != null ? hllPrecision.hashCode() : 0);
         return result;
-    }
-
-    @Override
-    public boolean equals(Object obj)
-    {
-        if (this == obj)
-        {
-            return true;
-        }
-        if (null == obj)
-        {
-            return false;
-        }
-        if (!(obj instanceof BucketProperties))
-        {
-            return false;
-        }
-
-        BucketProperties other = (BucketProperties) obj;
-        if ((linkwalkFunction == other.linkwalkFunction
-            || (linkwalkFunction != null && linkwalkFunction.equals(other.linkwalkFunction)))
-            && (chashKeyFunction == other.chashKeyFunction
-            || (chashKeyFunction != null && chashKeyFunction.equals(other.chashKeyFunction)))
-            && (rw == other.rw || (rw != null && rw.equals(other.rw)))
-            && (dw == other.dw || (dw != null && dw.equals(other.rw)))
-            && (w == other.w || (w != null && w.equals(other.w)))
-            && (r == other.r || (r != null && r.equals(other.r)))
-            && (pr == other.pr || (pr != null && pr.equals(other.pr)))
-            && (pw == other.pw || (pw != null && pw.equals(other.pw)))
-            && (notFoundOk == other.notFoundOk
-            || (notFoundOk != null && notFoundOk.equals(other.notFoundOk)))
-            && (basicQuorum == other.basicQuorum
-            || (basicQuorum != null && basicQuorum.equals(other.basicQuorum)))
-            && (precommitHooks.equals(other.precommitHooks))
-            && (postcommitHooks.equals(other.postcommitHooks))
-            && (oldVClock == other.oldVClock
-            || (oldVClock != null && oldVClock.equals(other.oldVClock)))
-            && (youngVClock == other.youngVClock
-            || (youngVClock != null && youngVClock.equals(other.youngVClock)))
-            && (bigVClock == other.bigVClock
-            || (bigVClock != null && bigVClock.equals(other.bigVClock)))
-            && (smallVClock == other.smallVClock
-            || (smallVClock != null && smallVClock.equals(other.smallVClock)))
-            && ((null == backend && other.backend == null) || backend.equals(other.backend))
-            && (nVal == other.nVal || (nVal != null && nVal.equals(other.nVal)))
-            && (lastWriteWins == other.lastWriteWins
-            || (lastWriteWins != null && lastWriteWins.equals(other.lastWriteWins)))
-            && (allowSiblings == other.allowSiblings
-            || (allowSiblings != null && allowSiblings.equals(other.allowSiblings)))
-            && ((null == yokozunaIndex && null == other.yokozunaIndex)
-            || yokozunaIndex.equals(other.yokozunaIndex))
-            && (search == other.search || (search != null && search.equals(other.search))))
-        {
-            return true;
-        }
-        else
-        {
-            return false;
-        }
     }
 
     public static class Builder
@@ -663,6 +731,7 @@ public class BucketProperties
         private Boolean allowSiblings;
         private Boolean search;
         private String yokozunaIndex;
+        private Integer hllPrecision;
 
         public Builder()
         {
@@ -1053,6 +1122,25 @@ public class BucketProperties
                 throw new IllegalArgumentException("Index name cannot be null or zero length");
             }
             this.yokozunaIndex = indexName;
+            return this;
+        }
+
+        /**
+         * Set the HyperLogLog Precision.
+         *
+         * @param precision the number of bits to use in the HyperLogLog precision.
+         *                  Valid values are [4 - 16] inclusive, default is 14 on new buckets.
+         *                  <b>NOTE:</b> When changing precision, it may only be reduced from
+         *                  it's current value, and never increased.
+         * @return a reference to this object.
+         */
+        public Builder withHllPrecision(int precision)
+        {
+            if (precision < 4 || precision > 16)
+            {
+                throw new IllegalArgumentException("Precision must be between 4 and 16, inclusive.");
+            }
+            this.hllPrecision = precision;
             return this;
         }
 

--- a/src/main/java/com/basho/riak/client/core/query/crdt/ops/HllOp.java
+++ b/src/main/java/com/basho/riak/client/core/query/crdt/ops/HllOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 Basho Technologies Inc
+ * Copyright 2016 Basho Technologies Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/basho/riak/client/core/query/crdt/ops/HllOp.java
+++ b/src/main/java/com/basho/riak/client/core/query/crdt/ops/HllOp.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2013 Basho Technologies Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.basho.riak.client.core.query.crdt.ops;
+
+import com.basho.riak.client.core.util.BinaryValue;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+public class HllOp implements CrdtOp
+{
+    private final Set<BinaryValue> elements = new HashSet<>();
+
+    public HllOp() {}
+
+    public HllOp(Collection<BinaryValue> elements)
+    {
+        this.elements.addAll(elements);
+    }
+
+    public HllOp add(BinaryValue element)
+    {
+        this.elements.add(element);
+        return this;
+    }
+
+    public HllOp addAll(Collection<BinaryValue> elements)
+    {
+        this.elements.addAll(elements);
+        return this;
+    }
+
+    public Set<BinaryValue> getElements()
+    {
+        return elements;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "{Elements: " + elements + "}";
+    }
+}

--- a/src/main/java/com/basho/riak/client/core/query/crdt/types/RiakDatatype.java
+++ b/src/main/java/com/basho/riak/client/core/query/crdt/types/RiakDatatype.java
@@ -76,6 +76,16 @@ public abstract class RiakDatatype
     }
 
     /**
+     * Determine if this datatype is a HyperLogLog.
+     *
+     * @return true if a flag, false otherwise.
+     */
+    public boolean isHLL()
+    {
+        return this instanceof RiakHll;
+    }
+
+    /**
      * Get this datatype as a map.
      *
      * @return a RiakMap
@@ -148,5 +158,20 @@ public abstract class RiakDatatype
             throw new IllegalStateException("This is not an instance of a CrdtFlag");
         }
         return (RiakFlag) this;
+    }
+
+    /**
+     * Get this datatype as a flag.
+     *
+     * @return a RiakFlag
+     * @throws IllegalStateException if this is not a flag.
+     */
+    public RiakHll getAsHLL()
+    {
+        if (!isHLL())
+        {
+            throw new IllegalStateException("This is not an instance of a RiakHll");
+        }
+        return (RiakHll) this;
     }
 }

--- a/src/main/java/com/basho/riak/client/core/query/crdt/types/RiakDatatype.java
+++ b/src/main/java/com/basho/riak/client/core/query/crdt/types/RiakDatatype.java
@@ -80,7 +80,7 @@ public abstract class RiakDatatype
      *
      * @return true if a flag, false otherwise.
      */
-    public boolean isHLL()
+    public boolean isHll()
     {
         return this instanceof RiakHll;
     }
@@ -166,9 +166,9 @@ public abstract class RiakDatatype
      * @return a RiakFlag
      * @throws IllegalStateException if this is not a flag.
      */
-    public RiakHll getAsHLL()
+    public RiakHll getAsHll()
     {
-        if (!isHLL())
+        if (!isHll())
         {
             throw new IllegalStateException("This is not an instance of a RiakHll");
         }

--- a/src/main/java/com/basho/riak/client/core/query/crdt/types/RiakHll.java
+++ b/src/main/java/com/basho/riak/client/core/query/crdt/types/RiakHll.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 Basho Technologies Inc
+ * Copyright 2016 Basho Technologies Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/basho/riak/client/core/query/crdt/types/RiakHll.java
+++ b/src/main/java/com/basho/riak/client/core/query/crdt/types/RiakHll.java
@@ -44,6 +44,16 @@ public class RiakHll extends RiakDatatype
         return this.cardinality;
     }
 
+    /**
+     * Get the cardinality of the HyperLogLog as a long.
+     *
+     * @return the estimated cardinality for this HyperLogLog.
+     */
+    public long getCardinality()
+    {
+        return this.cardinality;
+    }
+
     @Override
     public String toString()
     {

--- a/src/main/java/com/basho/riak/client/core/query/crdt/types/RiakHll.java
+++ b/src/main/java/com/basho/riak/client/core/query/crdt/types/RiakHll.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2013 Basho Technologies Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.basho.riak.client.core.query.crdt.types;
+
+/**
+ * Representation of the Riak HyperLogLog datatype.
+ * <p>
+ * Contains the estimated cardinality of the HLL.
+ * </p>
+ *
+ * @author Alex Moore <amoore at basho dot com>
+ * @since 2.1
+ */
+public class RiakHll extends RiakDatatype
+{
+    private final long cardinality;
+
+    public RiakHll(long cardinality)
+    {
+        this.cardinality = cardinality;
+    }
+
+    /**
+     * Get the cardinality of the HyperLogLog as a Long.
+     *
+     * @return the estimated cardinality for this HyperLogLog.
+     */
+    @Override
+    public Long view()
+    {
+        return this.cardinality;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "RiakHll{" + "cardinality=" + Long.toUnsignedString(cardinality) + '}';
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass())
+        {
+            return false;
+        }
+
+        RiakHll that = (RiakHll) o;
+
+        return cardinality == that.cardinality;
+
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return (int) (cardinality ^ (cardinality >>> 32));
+    }
+}

--- a/src/main/java/com/basho/riak/client/core/query/crdt/types/RiakHll.java
+++ b/src/main/java/com/basho/riak/client/core/query/crdt/types/RiakHll.java
@@ -18,7 +18,7 @@ package com.basho.riak.client.core.query.crdt.types;
 /**
  * Representation of the Riak HyperLogLog datatype.
  * <p>
- * Contains the estimated cardinality of the HLL.
+ * Contains the estimated cardinality of the Hll.
  * </p>
  *
  * @author Alex Moore <amoore at basho dot com>

--- a/src/main/java/com/basho/riak/protobuf/RiakDtPB.java
+++ b/src/main/java/com/basho/riak/protobuf/RiakDtPB.java
@@ -3354,6 +3354,25 @@ public final class RiakDtPB {
      */
     com.basho.riak.protobuf.RiakDtPB.MapEntryOrBuilder getMapValueOrBuilder(
         int index);
+
+    /**
+     * <code>optional uint64 hll_value = 4;</code>
+     *
+     * <pre>
+     * We return an estimated cardinality of the Hyperloglog set
+     * on fetch.
+     * </pre>
+     */
+    boolean hasHllValue();
+    /**
+     * <code>optional uint64 hll_value = 4;</code>
+     *
+     * <pre>
+     * We return an estimated cardinality of the Hyperloglog set
+     * on fetch.
+     * </pre>
+     */
+    long getHllValue();
   }
   /**
    * Protobuf type {@code DtValue}
@@ -3431,6 +3450,11 @@ public final class RiakDtPB {
                 mutable_bitField0_ |= 0x00000004;
               }
               mapValue_.add(input.readMessage(com.basho.riak.protobuf.RiakDtPB.MapEntry.PARSER, extensionRegistry));
+              break;
+            }
+            case 32: {
+              bitField0_ |= 0x00000002;
+              hllValue_ = input.readUInt64();
               break;
             }
           }
@@ -3551,10 +3575,36 @@ public final class RiakDtPB {
       return mapValue_.get(index);
     }
 
+    public static final int HLL_VALUE_FIELD_NUMBER = 4;
+    private long hllValue_;
+    /**
+     * <code>optional uint64 hll_value = 4;</code>
+     *
+     * <pre>
+     * We return an estimated cardinality of the Hyperloglog set
+     * on fetch.
+     * </pre>
+     */
+    public boolean hasHllValue() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <code>optional uint64 hll_value = 4;</code>
+     *
+     * <pre>
+     * We return an estimated cardinality of the Hyperloglog set
+     * on fetch.
+     * </pre>
+     */
+    public long getHllValue() {
+      return hllValue_;
+    }
+
     private void initFields() {
       counterValue_ = 0L;
       setValue_ = java.util.Collections.emptyList();
       mapValue_ = java.util.Collections.emptyList();
+      hllValue_ = 0L;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -3584,6 +3634,9 @@ public final class RiakDtPB {
       for (int i = 0; i < mapValue_.size(); i++) {
         output.writeMessage(3, mapValue_.get(i));
       }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        output.writeUInt64(4, hllValue_);
+      }
       getUnknownFields().writeTo(output);
     }
 
@@ -3609,6 +3662,10 @@ public final class RiakDtPB {
       for (int i = 0; i < mapValue_.size(); i++) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(3, mapValue_.get(i));
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeUInt64Size(4, hllValue_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -3743,6 +3800,8 @@ public final class RiakDtPB {
         } else {
           mapValueBuilder_.clear();
         }
+        hllValue_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000008);
         return this;
       }
 
@@ -3789,6 +3848,10 @@ public final class RiakDtPB {
         } else {
           result.mapValue_ = mapValueBuilder_.build();
         }
+        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.hllValue_ = hllValue_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -3843,6 +3906,9 @@ public final class RiakDtPB {
               mapValueBuilder_.addAllMessages(other.mapValue_);
             }
           }
+        }
+        if (other.hasHllValue()) {
+          setHllValue(other.getHllValue());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -4220,6 +4286,58 @@ public final class RiakDtPB {
         return mapValueBuilder_;
       }
 
+      private long hllValue_ ;
+      /**
+       * <code>optional uint64 hll_value = 4;</code>
+       *
+       * <pre>
+       * We return an estimated cardinality of the Hyperloglog set
+       * on fetch.
+       * </pre>
+       */
+      public boolean hasHllValue() {
+        return ((bitField0_ & 0x00000008) == 0x00000008);
+      }
+      /**
+       * <code>optional uint64 hll_value = 4;</code>
+       *
+       * <pre>
+       * We return an estimated cardinality of the Hyperloglog set
+       * on fetch.
+       * </pre>
+       */
+      public long getHllValue() {
+        return hllValue_;
+      }
+      /**
+       * <code>optional uint64 hll_value = 4;</code>
+       *
+       * <pre>
+       * We return an estimated cardinality of the Hyperloglog set
+       * on fetch.
+       * </pre>
+       */
+      public Builder setHllValue(long value) {
+        bitField0_ |= 0x00000008;
+        hllValue_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional uint64 hll_value = 4;</code>
+       *
+       * <pre>
+       * We return an estimated cardinality of the Hyperloglog set
+       * on fetch.
+       * </pre>
+       */
+      public Builder clearHllValue() {
+        bitField0_ = (bitField0_ & ~0x00000008);
+        hllValue_ = 0L;
+        onChanged();
+        return this;
+      }
+
       // @@protoc_insertion_point(builder_scope:DtValue)
     }
 
@@ -4412,6 +4530,10 @@ public final class RiakDtPB {
        * <code>MAP = 3;</code>
        */
       MAP(2, 3),
+      /**
+       * <code>HLL = 4;</code>
+       */
+      HLL(3, 4),
       ;
 
       /**
@@ -4426,6 +4548,10 @@ public final class RiakDtPB {
        * <code>MAP = 3;</code>
        */
       public static final int MAP_VALUE = 3;
+      /**
+       * <code>HLL = 4;</code>
+       */
+      public static final int HLL_VALUE = 4;
 
       public final int getNumber() { return value; }
 
@@ -4434,6 +4560,7 @@ public final class RiakDtPB {
           case 1: return COUNTER;
           case 2: return SET;
           case 3: return MAP;
+          case 4: return HLL;
           default: return null;
         }
       }
@@ -6063,6 +6190,480 @@ public final class RiakDtPB {
     }
 
     // @@protoc_insertion_point(class_scope:SetOp)
+  }
+
+  public interface HllOpOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:HllOp)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>repeated bytes adds = 1;</code>
+     */
+    java.util.List<com.google.protobuf.ByteString> getAddsList();
+    /**
+     * <code>repeated bytes adds = 1;</code>
+     */
+    int getAddsCount();
+    /**
+     * <code>repeated bytes adds = 1;</code>
+     */
+    com.google.protobuf.ByteString getAdds(int index);
+  }
+  /**
+   * Protobuf type {@code HllOp}
+   *
+   * <pre>
+   * An operation to update a Hyperloglog Set, a top-level DT.
+   * You can only add to a HllSet.
+   * </pre>
+   */
+  public static final class HllOp extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:HllOp)
+      HllOpOrBuilder {
+    // Use HllOp.newBuilder() to construct.
+    private HllOp(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+      this.unknownFields = builder.getUnknownFields();
+    }
+    private HllOp(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+    private static final HllOp defaultInstance;
+    public static HllOp getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public HllOp getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private HllOp(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 10: {
+              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+                adds_ = new java.util.ArrayList<com.google.protobuf.ByteString>();
+                mutable_bitField0_ |= 0x00000001;
+              }
+              adds_.add(input.readBytes());
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+          adds_ = java.util.Collections.unmodifiableList(adds_);
+        }
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.basho.riak.protobuf.RiakDtPB.internal_static_HllOp_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.basho.riak.protobuf.RiakDtPB.internal_static_HllOp_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.basho.riak.protobuf.RiakDtPB.HllOp.class, com.basho.riak.protobuf.RiakDtPB.HllOp.Builder.class);
+    }
+
+    public static com.google.protobuf.Parser<HllOp> PARSER =
+        new com.google.protobuf.AbstractParser<HllOp>() {
+      public HllOp parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new HllOp(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<HllOp> getParserForType() {
+      return PARSER;
+    }
+
+    public static final int ADDS_FIELD_NUMBER = 1;
+    private java.util.List<com.google.protobuf.ByteString> adds_;
+    /**
+     * <code>repeated bytes adds = 1;</code>
+     */
+    public java.util.List<com.google.protobuf.ByteString>
+        getAddsList() {
+      return adds_;
+    }
+    /**
+     * <code>repeated bytes adds = 1;</code>
+     */
+    public int getAddsCount() {
+      return adds_.size();
+    }
+    /**
+     * <code>repeated bytes adds = 1;</code>
+     */
+    public com.google.protobuf.ByteString getAdds(int index) {
+      return adds_.get(index);
+    }
+
+    private void initFields() {
+      adds_ = java.util.Collections.emptyList();
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      for (int i = 0; i < adds_.size(); i++) {
+        output.writeBytes(1, adds_.get(i));
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      {
+        int dataSize = 0;
+        for (int i = 0; i < adds_.size(); i++) {
+          dataSize += com.google.protobuf.CodedOutputStream
+            .computeBytesSizeNoTag(adds_.get(i));
+        }
+        size += dataSize;
+        size += 1 * getAddsList().size();
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+
+    public static com.basho.riak.protobuf.RiakDtPB.HllOp parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.basho.riak.protobuf.RiakDtPB.HllOp parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.basho.riak.protobuf.RiakDtPB.HllOp parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.basho.riak.protobuf.RiakDtPB.HllOp parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.basho.riak.protobuf.RiakDtPB.HllOp parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static com.basho.riak.protobuf.RiakDtPB.HllOp parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static com.basho.riak.protobuf.RiakDtPB.HllOp parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static com.basho.riak.protobuf.RiakDtPB.HllOp parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static com.basho.riak.protobuf.RiakDtPB.HllOp parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static com.basho.riak.protobuf.RiakDtPB.HllOp parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(com.basho.riak.protobuf.RiakDtPB.HllOp prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code HllOp}
+     *
+     * <pre>
+     * An operation to update a Hyperloglog Set, a top-level DT.
+     * You can only add to a HllSet.
+     * </pre>
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:HllOp)
+        com.basho.riak.protobuf.RiakDtPB.HllOpOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.basho.riak.protobuf.RiakDtPB.internal_static_HllOp_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.basho.riak.protobuf.RiakDtPB.internal_static_HllOp_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.basho.riak.protobuf.RiakDtPB.HllOp.class, com.basho.riak.protobuf.RiakDtPB.HllOp.Builder.class);
+      }
+
+      // Construct using com.basho.riak.protobuf.RiakDtPB.HllOp.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
+
+      public Builder clear() {
+        super.clear();
+        adds_ = java.util.Collections.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000001);
+        return this;
+      }
+
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.basho.riak.protobuf.RiakDtPB.internal_static_HllOp_descriptor;
+      }
+
+      public com.basho.riak.protobuf.RiakDtPB.HllOp getDefaultInstanceForType() {
+        return com.basho.riak.protobuf.RiakDtPB.HllOp.getDefaultInstance();
+      }
+
+      public com.basho.riak.protobuf.RiakDtPB.HllOp build() {
+        com.basho.riak.protobuf.RiakDtPB.HllOp result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public com.basho.riak.protobuf.RiakDtPB.HllOp buildPartial() {
+        com.basho.riak.protobuf.RiakDtPB.HllOp result = new com.basho.riak.protobuf.RiakDtPB.HllOp(this);
+        int from_bitField0_ = bitField0_;
+        if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          adds_ = java.util.Collections.unmodifiableList(adds_);
+          bitField0_ = (bitField0_ & ~0x00000001);
+        }
+        result.adds_ = adds_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.basho.riak.protobuf.RiakDtPB.HllOp) {
+          return mergeFrom((com.basho.riak.protobuf.RiakDtPB.HllOp)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.basho.riak.protobuf.RiakDtPB.HllOp other) {
+        if (other == com.basho.riak.protobuf.RiakDtPB.HllOp.getDefaultInstance()) return this;
+        if (!other.adds_.isEmpty()) {
+          if (adds_.isEmpty()) {
+            adds_ = other.adds_;
+            bitField0_ = (bitField0_ & ~0x00000001);
+          } else {
+            ensureAddsIsMutable();
+            adds_.addAll(other.adds_);
+          }
+          onChanged();
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.basho.riak.protobuf.RiakDtPB.HllOp parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.basho.riak.protobuf.RiakDtPB.HllOp) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private java.util.List<com.google.protobuf.ByteString> adds_ = java.util.Collections.emptyList();
+      private void ensureAddsIsMutable() {
+        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+          adds_ = new java.util.ArrayList<com.google.protobuf.ByteString>(adds_);
+          bitField0_ |= 0x00000001;
+         }
+      }
+      /**
+       * <code>repeated bytes adds = 1;</code>
+       */
+      public java.util.List<com.google.protobuf.ByteString>
+          getAddsList() {
+        return java.util.Collections.unmodifiableList(adds_);
+      }
+      /**
+       * <code>repeated bytes adds = 1;</code>
+       */
+      public int getAddsCount() {
+        return adds_.size();
+      }
+      /**
+       * <code>repeated bytes adds = 1;</code>
+       */
+      public com.google.protobuf.ByteString getAdds(int index) {
+        return adds_.get(index);
+      }
+      /**
+       * <code>repeated bytes adds = 1;</code>
+       */
+      public Builder setAdds(
+          int index, com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureAddsIsMutable();
+        adds_.set(index, value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated bytes adds = 1;</code>
+       */
+      public Builder addAdds(com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureAddsIsMutable();
+        adds_.add(value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated bytes adds = 1;</code>
+       */
+      public Builder addAllAdds(
+          java.lang.Iterable<? extends com.google.protobuf.ByteString> values) {
+        ensureAddsIsMutable();
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, adds_);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated bytes adds = 1;</code>
+       */
+      public Builder clearAdds() {
+        adds_ = java.util.Collections.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000001);
+        onChanged();
+        return this;
+      }
+
+      // @@protoc_insertion_point(builder_scope:HllOp)
+    }
+
+    static {
+      defaultInstance = new HllOp(true);
+      defaultInstance.initFields();
+    }
+
+    // @@protoc_insertion_point(class_scope:HllOp)
   }
 
   public interface MapUpdateOrBuilder extends
@@ -8746,6 +9347,34 @@ public final class RiakDtPB {
      * <code>optional .MapOp map_op = 3;</code>
      */
     com.basho.riak.protobuf.RiakDtPB.MapOpOrBuilder getMapOpOrBuilder();
+
+    /**
+     * <code>optional .HllOp hll_op = 4;</code>
+     *
+     * <pre>
+     * Adding values to a hyperloglog (set) is just like adding values
+     * to a set.
+     * </pre>
+     */
+    boolean hasHllOp();
+    /**
+     * <code>optional .HllOp hll_op = 4;</code>
+     *
+     * <pre>
+     * Adding values to a hyperloglog (set) is just like adding values
+     * to a set.
+     * </pre>
+     */
+    com.basho.riak.protobuf.RiakDtPB.HllOp getHllOp();
+    /**
+     * <code>optional .HllOp hll_op = 4;</code>
+     *
+     * <pre>
+     * Adding values to a hyperloglog (set) is just like adding values
+     * to a set.
+     * </pre>
+     */
+    com.basho.riak.protobuf.RiakDtPB.HllOpOrBuilder getHllOpOrBuilder();
   }
   /**
    * Protobuf type {@code DtOp}
@@ -8841,6 +9470,19 @@ public final class RiakDtPB {
                 mapOp_ = subBuilder.buildPartial();
               }
               bitField0_ |= 0x00000004;
+              break;
+            }
+            case 34: {
+              com.basho.riak.protobuf.RiakDtPB.HllOp.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000008) == 0x00000008)) {
+                subBuilder = hllOp_.toBuilder();
+              }
+              hllOp_ = input.readMessage(com.basho.riak.protobuf.RiakDtPB.HllOp.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(hllOp_);
+                hllOp_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000008;
               break;
             }
           }
@@ -8946,10 +9588,47 @@ public final class RiakDtPB {
       return mapOp_;
     }
 
+    public static final int HLL_OP_FIELD_NUMBER = 4;
+    private com.basho.riak.protobuf.RiakDtPB.HllOp hllOp_;
+    /**
+     * <code>optional .HllOp hll_op = 4;</code>
+     *
+     * <pre>
+     * Adding values to a hyperloglog (set) is just like adding values
+     * to a set.
+     * </pre>
+     */
+    public boolean hasHllOp() {
+      return ((bitField0_ & 0x00000008) == 0x00000008);
+    }
+    /**
+     * <code>optional .HllOp hll_op = 4;</code>
+     *
+     * <pre>
+     * Adding values to a hyperloglog (set) is just like adding values
+     * to a set.
+     * </pre>
+     */
+    public com.basho.riak.protobuf.RiakDtPB.HllOp getHllOp() {
+      return hllOp_;
+    }
+    /**
+     * <code>optional .HllOp hll_op = 4;</code>
+     *
+     * <pre>
+     * Adding values to a hyperloglog (set) is just like adding values
+     * to a set.
+     * </pre>
+     */
+    public com.basho.riak.protobuf.RiakDtPB.HllOpOrBuilder getHllOpOrBuilder() {
+      return hllOp_;
+    }
+
     private void initFields() {
       counterOp_ = com.basho.riak.protobuf.RiakDtPB.CounterOp.getDefaultInstance();
       setOp_ = com.basho.riak.protobuf.RiakDtPB.SetOp.getDefaultInstance();
       mapOp_ = com.basho.riak.protobuf.RiakDtPB.MapOp.getDefaultInstance();
+      hllOp_ = com.basho.riak.protobuf.RiakDtPB.HllOp.getDefaultInstance();
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -8979,6 +9658,9 @@ public final class RiakDtPB {
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         output.writeMessage(3, mapOp_);
       }
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        output.writeMessage(4, hllOp_);
+      }
       getUnknownFields().writeTo(output);
     }
 
@@ -8999,6 +9681,10 @@ public final class RiakDtPB {
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(3, mapOp_);
+      }
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(4, hllOp_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -9117,6 +9803,7 @@ public final class RiakDtPB {
           getCounterOpFieldBuilder();
           getSetOpFieldBuilder();
           getMapOpFieldBuilder();
+          getHllOpFieldBuilder();
         }
       }
       private static Builder create() {
@@ -9143,6 +9830,12 @@ public final class RiakDtPB {
           mapOpBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000004);
+        if (hllOpBuilder_ == null) {
+          hllOp_ = com.basho.riak.protobuf.RiakDtPB.HllOp.getDefaultInstance();
+        } else {
+          hllOpBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000008);
         return this;
       }
 
@@ -9195,6 +9888,14 @@ public final class RiakDtPB {
         } else {
           result.mapOp_ = mapOpBuilder_.build();
         }
+        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+          to_bitField0_ |= 0x00000008;
+        }
+        if (hllOpBuilder_ == null) {
+          result.hllOp_ = hllOp_;
+        } else {
+          result.hllOp_ = hllOpBuilder_.build();
+        }
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -9220,6 +9921,9 @@ public final class RiakDtPB {
         if (other.hasMapOp()) {
           mergeMapOp(other.getMapOp());
         }
+        if (other.hasHllOp()) {
+          mergeHllOp(other.getHllOp());
+        }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
       }
@@ -9227,6 +9931,7 @@ public final class RiakDtPB {
       public final boolean isInitialized() {
         if (hasMapOp()) {
           if (!getMapOp().isInitialized()) {
+
             return false;
           }
         }
@@ -9598,6 +10303,167 @@ public final class RiakDtPB {
           mapOp_ = null;
         }
         return mapOpBuilder_;
+      }
+
+      private com.basho.riak.protobuf.RiakDtPB.HllOp hllOp_ = com.basho.riak.protobuf.RiakDtPB.HllOp.getDefaultInstance();
+      private com.google.protobuf.SingleFieldBuilder<
+          com.basho.riak.protobuf.RiakDtPB.HllOp, com.basho.riak.protobuf.RiakDtPB.HllOp.Builder, com.basho.riak.protobuf.RiakDtPB.HllOpOrBuilder> hllOpBuilder_;
+      /**
+       * <code>optional .HllOp hll_op = 4;</code>
+       *
+       * <pre>
+       * Adding values to a hyperloglog (set) is just like adding values
+       * to a set.
+       * </pre>
+       */
+      public boolean hasHllOp() {
+        return ((bitField0_ & 0x00000008) == 0x00000008);
+      }
+      /**
+       * <code>optional .HllOp hll_op = 4;</code>
+       *
+       * <pre>
+       * Adding values to a hyperloglog (set) is just like adding values
+       * to a set.
+       * </pre>
+       */
+      public com.basho.riak.protobuf.RiakDtPB.HllOp getHllOp() {
+        if (hllOpBuilder_ == null) {
+          return hllOp_;
+        } else {
+          return hllOpBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>optional .HllOp hll_op = 4;</code>
+       *
+       * <pre>
+       * Adding values to a hyperloglog (set) is just like adding values
+       * to a set.
+       * </pre>
+       */
+      public Builder setHllOp(com.basho.riak.protobuf.RiakDtPB.HllOp value) {
+        if (hllOpBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          hllOp_ = value;
+          onChanged();
+        } else {
+          hllOpBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000008;
+        return this;
+      }
+      /**
+       * <code>optional .HllOp hll_op = 4;</code>
+       *
+       * <pre>
+       * Adding values to a hyperloglog (set) is just like adding values
+       * to a set.
+       * </pre>
+       */
+      public Builder setHllOp(
+          com.basho.riak.protobuf.RiakDtPB.HllOp.Builder builderForValue) {
+        if (hllOpBuilder_ == null) {
+          hllOp_ = builderForValue.build();
+          onChanged();
+        } else {
+          hllOpBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000008;
+        return this;
+      }
+      /**
+       * <code>optional .HllOp hll_op = 4;</code>
+       *
+       * <pre>
+       * Adding values to a hyperloglog (set) is just like adding values
+       * to a set.
+       * </pre>
+       */
+      public Builder mergeHllOp(com.basho.riak.protobuf.RiakDtPB.HllOp value) {
+        if (hllOpBuilder_ == null) {
+          if (((bitField0_ & 0x00000008) == 0x00000008) &&
+              hllOp_ != com.basho.riak.protobuf.RiakDtPB.HllOp.getDefaultInstance()) {
+            hllOp_ =
+              com.basho.riak.protobuf.RiakDtPB.HllOp.newBuilder(hllOp_).mergeFrom(value).buildPartial();
+          } else {
+            hllOp_ = value;
+          }
+          onChanged();
+        } else {
+          hllOpBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00000008;
+        return this;
+      }
+      /**
+       * <code>optional .HllOp hll_op = 4;</code>
+       *
+       * <pre>
+       * Adding values to a hyperloglog (set) is just like adding values
+       * to a set.
+       * </pre>
+       */
+      public Builder clearHllOp() {
+        if (hllOpBuilder_ == null) {
+          hllOp_ = com.basho.riak.protobuf.RiakDtPB.HllOp.getDefaultInstance();
+          onChanged();
+        } else {
+          hllOpBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000008);
+        return this;
+      }
+      /**
+       * <code>optional .HllOp hll_op = 4;</code>
+       *
+       * <pre>
+       * Adding values to a hyperloglog (set) is just like adding values
+       * to a set.
+       * </pre>
+       */
+      public com.basho.riak.protobuf.RiakDtPB.HllOp.Builder getHllOpBuilder() {
+        bitField0_ |= 0x00000008;
+        onChanged();
+        return getHllOpFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>optional .HllOp hll_op = 4;</code>
+       *
+       * <pre>
+       * Adding values to a hyperloglog (set) is just like adding values
+       * to a set.
+       * </pre>
+       */
+      public com.basho.riak.protobuf.RiakDtPB.HllOpOrBuilder getHllOpOrBuilder() {
+        if (hllOpBuilder_ != null) {
+          return hllOpBuilder_.getMessageOrBuilder();
+        } else {
+          return hllOp_;
+        }
+      }
+      /**
+       * <code>optional .HllOp hll_op = 4;</code>
+       *
+       * <pre>
+       * Adding values to a hyperloglog (set) is just like adding values
+       * to a set.
+       * </pre>
+       */
+      private com.google.protobuf.SingleFieldBuilder<
+          com.basho.riak.protobuf.RiakDtPB.HllOp, com.basho.riak.protobuf.RiakDtPB.HllOp.Builder, com.basho.riak.protobuf.RiakDtPB.HllOpOrBuilder>
+          getHllOpFieldBuilder() {
+        if (hllOpBuilder_ == null) {
+          hllOpBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+              com.basho.riak.protobuf.RiakDtPB.HllOp, com.basho.riak.protobuf.RiakDtPB.HllOp.Builder, com.basho.riak.protobuf.RiakDtPB.HllOpOrBuilder>(
+                  getHllOp(),
+                  getParentForChildren(),
+                  isClean());
+          hllOp_ = null;
+        }
+        return hllOpBuilder_;
       }
 
       // @@protoc_insertion_point(builder_scope:DtOp)
@@ -11506,6 +12372,15 @@ public final class RiakDtPB {
      */
     com.basho.riak.protobuf.RiakDtPB.MapEntryOrBuilder getMapValueOrBuilder(
         int index);
+
+    /**
+     * <code>optional uint64 hll_value = 6;</code>
+     */
+    boolean hasHllValue();
+    /**
+     * <code>optional uint64 hll_value = 6;</code>
+     */
+    long getHllValue();
   }
   /**
    * Protobuf type {@code DtUpdateResp}
@@ -11594,6 +12469,11 @@ public final class RiakDtPB {
                 mutable_bitField0_ |= 0x00000010;
               }
               mapValue_.add(input.readMessage(com.basho.riak.protobuf.RiakDtPB.MapEntry.PARSER, extensionRegistry));
+              break;
+            }
+            case 48: {
+              bitField0_ |= 0x00000008;
+              hllValue_ = input.readUInt64();
               break;
             }
           }
@@ -11760,12 +12640,28 @@ public final class RiakDtPB {
       return mapValue_.get(index);
     }
 
+    public static final int HLL_VALUE_FIELD_NUMBER = 6;
+    private long hllValue_;
+    /**
+     * <code>optional uint64 hll_value = 6;</code>
+     */
+    public boolean hasHllValue() {
+      return ((bitField0_ & 0x00000008) == 0x00000008);
+    }
+    /**
+     * <code>optional uint64 hll_value = 6;</code>
+     */
+    public long getHllValue() {
+      return hllValue_;
+    }
+
     private void initFields() {
       key_ = com.google.protobuf.ByteString.EMPTY;
       context_ = com.google.protobuf.ByteString.EMPTY;
       counterValue_ = 0L;
       setValue_ = java.util.Collections.emptyList();
       mapValue_ = java.util.Collections.emptyList();
+      hllValue_ = 0L;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -11801,6 +12697,9 @@ public final class RiakDtPB {
       for (int i = 0; i < mapValue_.size(); i++) {
         output.writeMessage(5, mapValue_.get(i));
       }
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        output.writeUInt64(6, hllValue_);
+      }
       getUnknownFields().writeTo(output);
     }
 
@@ -11834,6 +12733,10 @@ public final class RiakDtPB {
       for (int i = 0; i < mapValue_.size(); i++) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(5, mapValue_.get(i));
+      }
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeUInt64Size(6, hllValue_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -11973,6 +12876,8 @@ public final class RiakDtPB {
         } else {
           mapValueBuilder_.clear();
         }
+        hllValue_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000020);
         return this;
       }
 
@@ -12027,6 +12932,10 @@ public final class RiakDtPB {
         } else {
           result.mapValue_ = mapValueBuilder_.build();
         }
+        if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
+          to_bitField0_ |= 0x00000008;
+        }
+        result.hllValue_ = hllValue_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -12088,6 +12997,9 @@ public final class RiakDtPB {
             }
           }
         }
+        if (other.hasHllValue()) {
+          setHllValue(other.getHllValue());
+        }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
       }
@@ -12095,6 +13007,7 @@ public final class RiakDtPB {
       public final boolean isInitialized() {
         for (int i = 0; i < getMapValueCount(); i++) {
           if (!getMapValue(i).isInitialized()) {
+
             return false;
           }
         }
@@ -12566,6 +13479,38 @@ public final class RiakDtPB {
         return mapValueBuilder_;
       }
 
+      private long hllValue_ ;
+      /**
+       * <code>optional uint64 hll_value = 6;</code>
+       */
+      public boolean hasHllValue() {
+        return ((bitField0_ & 0x00000020) == 0x00000020);
+      }
+      /**
+       * <code>optional uint64 hll_value = 6;</code>
+       */
+      public long getHllValue() {
+        return hllValue_;
+      }
+      /**
+       * <code>optional uint64 hll_value = 6;</code>
+       */
+      public Builder setHllValue(long value) {
+        bitField0_ |= 0x00000020;
+        hllValue_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional uint64 hll_value = 6;</code>
+       */
+      public Builder clearHllValue() {
+        bitField0_ = (bitField0_ & ~0x00000020);
+        hllValue_ = 0L;
+        onChanged();
+        return this;
+      }
+
       // @@protoc_insertion_point(builder_scope:DtUpdateResp)
     }
 
@@ -12613,6 +13558,11 @@ public final class RiakDtPB {
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_SetOp_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_HllOp_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_HllOp_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_MapUpdate_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
@@ -12658,34 +13608,36 @@ public final class RiakDtPB {
       " \002(\014\022\t\n\001r\030\004 \001(\r\022\n\n\002pr\030\005 \001(\r\022\024\n\014basic_quo",
       "rum\030\006 \001(\010\022\023\n\013notfound_ok\030\007 \001(\010\022\017\n\007timeou" +
       "t\030\010 \001(\r\022\025\n\rsloppy_quorum\030\t \001(\010\022\r\n\005n_val\030" +
-      "\n \001(\r\022\035\n\017include_context\030\013 \001(\010:\004true\"Q\n\007" +
+      "\n \001(\r\022\035\n\017include_context\030\013 \001(\010:\004true\"d\n\007" +
       "DtValue\022\025\n\rcounter_value\030\001 \001(\022\022\021\n\tset_va" +
-      "lue\030\002 \003(\014\022\034\n\tmap_value\030\003 \003(\0132\t.MapEntry\"" +
-      "\207\001\n\013DtFetchResp\022\017\n\007context\030\001 \001(\014\022#\n\004type" +
-      "\030\002 \002(\0162\025.DtFetchResp.DataType\022\027\n\005value\030\003" +
-      " \001(\0132\010.DtValue\")\n\010DataType\022\013\n\007COUNTER\020\001\022" +
-      "\007\n\003SET\020\002\022\007\n\003MAP\020\003\"\036\n\tCounterOp\022\021\n\tincrem" +
-      "ent\030\001 \001(\022\"&\n\005SetOp\022\014\n\004adds\030\001 \003(\014\022\017\n\007remo",
-      "ves\030\002 \003(\014\"\321\001\n\tMapUpdate\022\030\n\005field\030\001 \002(\0132\t" +
-      ".MapField\022\036\n\ncounter_op\030\002 \001(\0132\n.CounterO" +
-      "p\022\026\n\006set_op\030\003 \001(\0132\006.SetOp\022\023\n\013register_op" +
-      "\030\004 \001(\014\022\"\n\007flag_op\030\005 \001(\0162\021.MapUpdate.Flag" +
-      "Op\022\026\n\006map_op\030\006 \001(\0132\006.MapOp\"!\n\006FlagOp\022\n\n\006" +
-      "ENABLE\020\001\022\013\n\007DISABLE\020\002\"@\n\005MapOp\022\032\n\007remove" +
-      "s\030\001 \003(\0132\t.MapField\022\033\n\007updates\030\002 \003(\0132\n.Ma" +
-      "pUpdate\"V\n\004DtOp\022\036\n\ncounter_op\030\001 \001(\0132\n.Co" +
-      "unterOp\022\026\n\006set_op\030\002 \001(\0132\006.SetOp\022\026\n\006map_o" +
-      "p\030\003 \001(\0132\006.MapOp\"\361\001\n\013DtUpdateReq\022\016\n\006bucke",
-      "t\030\001 \002(\014\022\013\n\003key\030\002 \001(\014\022\014\n\004type\030\003 \002(\014\022\017\n\007co" +
-      "ntext\030\004 \001(\014\022\021\n\002op\030\005 \002(\0132\005.DtOp\022\t\n\001w\030\006 \001(" +
-      "\r\022\n\n\002dw\030\007 \001(\r\022\n\n\002pw\030\010 \001(\r\022\032\n\013return_body" +
-      "\030\t \001(\010:\005false\022\017\n\007timeout\030\n \001(\r\022\025\n\rsloppy" +
-      "_quorum\030\013 \001(\010\022\r\n\005n_val\030\014 \001(\r\022\035\n\017include_" +
-      "context\030\r \001(\010:\004true\"t\n\014DtUpdateResp\022\013\n\003k" +
-      "ey\030\001 \001(\014\022\017\n\007context\030\002 \001(\014\022\025\n\rcounter_val" +
-      "ue\030\003 \001(\022\022\021\n\tset_value\030\004 \003(\014\022\034\n\tmap_value" +
-      "\030\005 \003(\0132\t.MapEntryB#\n\027com.basho.riak.prot" +
-      "obufB\010RiakDtPB"
+      "lue\030\002 \003(\014\022\034\n\tmap_value\030\003 \003(\0132\t.MapEntry\022" +
+      "\021\n\thll_value\030\004 \001(\004\"\220\001\n\013DtFetchResp\022\017\n\007co" +
+      "ntext\030\001 \001(\014\022#\n\004type\030\002 \002(\0162\025.DtFetchResp." +
+      "DataType\022\027\n\005value\030\003 \001(\0132\010.DtValue\"2\n\010Dat" +
+      "aType\022\013\n\007COUNTER\020\001\022\007\n\003SET\020\002\022\007\n\003MAP\020\003\022\007\n\003" +
+      "HLL\020\004\"\036\n\tCounterOp\022\021\n\tincrement\030\001 \001(\022\"&\n",
+      "\005SetOp\022\014\n\004adds\030\001 \003(\014\022\017\n\007removes\030\002 \003(\014\"\025\n" +
+      "\005HllOp\022\014\n\004adds\030\001 \003(\014\"\321\001\n\tMapUpdate\022\030\n\005fi" +
+      "eld\030\001 \002(\0132\t.MapField\022\036\n\ncounter_op\030\002 \001(\013" +
+      "2\n.CounterOp\022\026\n\006set_op\030\003 \001(\0132\006.SetOp\022\023\n\013" +
+      "register_op\030\004 \001(\014\022\"\n\007flag_op\030\005 \001(\0162\021.Map" +
+      "Update.FlagOp\022\026\n\006map_op\030\006 \001(\0132\006.MapOp\"!\n" +
+      "\006FlagOp\022\n\n\006ENABLE\020\001\022\013\n\007DISABLE\020\002\"@\n\005MapO" +
+      "p\022\032\n\007removes\030\001 \003(\0132\t.MapField\022\033\n\007updates" +
+      "\030\002 \003(\0132\n.MapUpdate\"n\n\004DtOp\022\036\n\ncounter_op" +
+      "\030\001 \001(\0132\n.CounterOp\022\026\n\006set_op\030\002 \001(\0132\006.Set",
+      "Op\022\026\n\006map_op\030\003 \001(\0132\006.MapOp\022\026\n\006hll_op\030\004 \001" +
+      "(\0132\006.HllOp\"\361\001\n\013DtUpdateReq\022\016\n\006bucket\030\001 \002" +
+      "(\014\022\013\n\003key\030\002 \001(\014\022\014\n\004type\030\003 \002(\014\022\017\n\007context" +
+      "\030\004 \001(\014\022\021\n\002op\030\005 \002(\0132\005.DtOp\022\t\n\001w\030\006 \001(\r\022\n\n\002" +
+      "dw\030\007 \001(\r\022\n\n\002pw\030\010 \001(\r\022\032\n\013return_body\030\t \001(" +
+      "\010:\005false\022\017\n\007timeout\030\n \001(\r\022\025\n\rsloppy_quor" +
+      "um\030\013 \001(\010\022\r\n\005n_val\030\014 \001(\r\022\035\n\017include_conte" +
+      "xt\030\r \001(\010:\004true\"\207\001\n\014DtUpdateResp\022\013\n\003key\030\001" +
+      " \001(\014\022\017\n\007context\030\002 \001(\014\022\025\n\rcounter_value\030\003" +
+      " \001(\022\022\021\n\tset_value\030\004 \003(\014\022\034\n\tmap_value\030\005 \003",
+      "(\0132\t.MapEntry\022\021\n\thll_value\030\006 \001(\004B#\n\027com." +
+      "basho.riak.protobufB\010RiakDtPB"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -12722,7 +13674,7 @@ public final class RiakDtPB {
     internal_static_DtValue_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_DtValue_descriptor,
-        new java.lang.String[] { "CounterValue", "SetValue", "MapValue", });
+        new java.lang.String[] { "CounterValue", "SetValue", "MapValue", "HllValue", });
     internal_static_DtFetchResp_descriptor =
       getDescriptor().getMessageTypes().get(4);
     internal_static_DtFetchResp_fieldAccessorTable = new
@@ -12741,36 +13693,42 @@ public final class RiakDtPB {
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_SetOp_descriptor,
         new java.lang.String[] { "Adds", "Removes", });
-    internal_static_MapUpdate_descriptor =
+    internal_static_HllOp_descriptor =
       getDescriptor().getMessageTypes().get(7);
+    internal_static_HllOp_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_HllOp_descriptor,
+        new java.lang.String[] { "Adds", });
+    internal_static_MapUpdate_descriptor =
+      getDescriptor().getMessageTypes().get(8);
     internal_static_MapUpdate_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_MapUpdate_descriptor,
         new java.lang.String[] { "Field", "CounterOp", "SetOp", "RegisterOp", "FlagOp", "MapOp", });
     internal_static_MapOp_descriptor =
-      getDescriptor().getMessageTypes().get(8);
+      getDescriptor().getMessageTypes().get(9);
     internal_static_MapOp_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_MapOp_descriptor,
         new java.lang.String[] { "Removes", "Updates", });
     internal_static_DtOp_descriptor =
-      getDescriptor().getMessageTypes().get(9);
+      getDescriptor().getMessageTypes().get(10);
     internal_static_DtOp_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_DtOp_descriptor,
-        new java.lang.String[] { "CounterOp", "SetOp", "MapOp", });
+        new java.lang.String[] { "CounterOp", "SetOp", "MapOp", "HllOp", });
     internal_static_DtUpdateReq_descriptor =
-      getDescriptor().getMessageTypes().get(10);
+      getDescriptor().getMessageTypes().get(11);
     internal_static_DtUpdateReq_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_DtUpdateReq_descriptor,
         new java.lang.String[] { "Bucket", "Key", "Type", "Context", "Op", "W", "Dw", "Pw", "ReturnBody", "Timeout", "SloppyQuorum", "NVal", "IncludeContext", });
     internal_static_DtUpdateResp_descriptor =
-      getDescriptor().getMessageTypes().get(11);
+      getDescriptor().getMessageTypes().get(12);
     internal_static_DtUpdateResp_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_DtUpdateResp_descriptor,
-        new java.lang.String[] { "Key", "Context", "CounterValue", "SetValue", "MapValue", });
+        new java.lang.String[] { "Key", "Context", "CounterValue", "SetValue", "MapValue", "HllValue", });
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/src/main/java/com/basho/riak/protobuf/RiakPB.java
+++ b/src/main/java/com/basho/riak/protobuf/RiakPB.java
@@ -10402,7 +10402,7 @@ public final class RiakPB {
     internal_static_RpbBucketProps_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_RpbBucketProps_descriptor,
-        new java.lang.String[] { "NVal", "AllowMult", "LastWriteWins", "Precommit", "HasPrecommit", "Postcommit", "HasPostcommit", "ChashKeyfun", "Linkfun", "OldVclock", "YoungVclock", "BigVclock", "SmallVclock", "Pr", "R", "W", "Pw", "Dw", "Rw", "BasicQuorum", "NotfoundOk", "Backend", "Search", "Repl", "SearchIndex", "Datatype", "Consistent", "WriteOnce", `"HllPrecision", });
+        new java.lang.String[] { "NVal", "AllowMult", "LastWriteWins", "Precommit", "HasPrecommit", "Postcommit", "HasPostcommit", "ChashKeyfun", "Linkfun", "OldVclock", "YoungVclock", "BigVclock", "SmallVclock", "Pr", "R", "W", "Pw", "Dw", "Rw", "BasicQuorum", "NotfoundOk", "Backend", "Search", "Repl", "SearchIndex", "Datatype", "Consistent", "WriteOnce", "HllPrecision", });
     internal_static_RpbAuthReq_descriptor =
       getDescriptor().getMessageTypes().get(12);
     internal_static_RpbAuthReq_fieldAccessorTable = new

--- a/src/main/java/com/basho/riak/protobuf/RiakPB.java
+++ b/src/main/java/com/basho/riak/protobuf/RiakPB.java
@@ -6211,6 +6211,23 @@ public final class RiakPB {
      * </pre>
      */
     boolean getWriteOnce();
+
+    /**
+     * <code>optional uint32 hll_precision = 29;</code>
+     *
+     * <pre>
+     * Hyperlolog DT Precision
+     * </pre>
+     */
+    boolean hasHllPrecision();
+    /**
+     * <code>optional uint32 hll_precision = 29;</code>
+     *
+     * <pre>
+     * Hyperlolog DT Precision
+     * </pre>
+     */
+    int getHllPrecision();
   }
   /**
    * Protobuf type {@code RpbBucketProps}
@@ -6434,6 +6451,11 @@ public final class RiakPB {
             case 224: {
               bitField0_ |= 0x02000000;
               writeOnce_ = input.readBool();
+              break;
+            }
+            case 232: {
+              bitField0_ |= 0x04000000;
+              hllPrecision_ = input.readUInt32();
               break;
             }
           }
@@ -7125,6 +7147,29 @@ public final class RiakPB {
       return writeOnce_;
     }
 
+    public static final int HLL_PRECISION_FIELD_NUMBER = 29;
+    private int hllPrecision_;
+    /**
+     * <code>optional uint32 hll_precision = 29;</code>
+     *
+     * <pre>
+     * Hyperlolog DT Precision
+     * </pre>
+     */
+    public boolean hasHllPrecision() {
+      return ((bitField0_ & 0x04000000) == 0x04000000);
+    }
+    /**
+     * <code>optional uint32 hll_precision = 29;</code>
+     *
+     * <pre>
+     * Hyperlolog DT Precision
+     * </pre>
+     */
+    public int getHllPrecision() {
+      return hllPrecision_;
+    }
+
     private void initFields() {
       nVal_ = 0;
       allowMult_ = false;
@@ -7154,6 +7199,7 @@ public final class RiakPB {
       datatype_ = com.google.protobuf.ByteString.EMPTY;
       consistent_ = false;
       writeOnce_ = false;
+      hllPrecision_ = 0;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -7276,6 +7322,9 @@ public final class RiakPB {
       if (((bitField0_ & 0x02000000) == 0x02000000)) {
         output.writeBool(28, writeOnce_);
       }
+      if (((bitField0_ & 0x04000000) == 0x04000000)) {
+        output.writeUInt32(29, hllPrecision_);
+      }
       getUnknownFields().writeTo(output);
     }
 
@@ -7396,6 +7445,10 @@ public final class RiakPB {
       if (((bitField0_ & 0x02000000) == 0x02000000)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBoolSize(28, writeOnce_);
+      }
+      if (((bitField0_ & 0x04000000) == 0x04000000)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeUInt32Size(29, hllPrecision_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -7594,6 +7647,8 @@ public final class RiakPB {
         bitField0_ = (bitField0_ & ~0x04000000);
         writeOnce_ = false;
         bitField0_ = (bitField0_ & ~0x08000000);
+        hllPrecision_ = 0;
+        bitField0_ = (bitField0_ & ~0x10000000);
         return this;
       }
 
@@ -7752,6 +7807,10 @@ public final class RiakPB {
           to_bitField0_ |= 0x02000000;
         }
         result.writeOnce_ = writeOnce_;
+        if (((from_bitField0_ & 0x10000000) == 0x10000000)) {
+          to_bitField0_ |= 0x04000000;
+        }
+        result.hllPrecision_ = hllPrecision_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -7897,6 +7956,9 @@ public final class RiakPB {
         }
         if (other.hasWriteOnce()) {
           setWriteOnce(other.getWriteOnce());
+        }
+        if (other.hasHllPrecision()) {
+          setHllPrecision(other.getHllPrecision());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -9585,6 +9647,54 @@ public final class RiakPB {
         return this;
       }
 
+      private int hllPrecision_ ;
+      /**
+       * <code>optional uint32 hll_precision = 29;</code>
+       *
+       * <pre>
+       * Hyperlolog DT Precision
+       * </pre>
+       */
+      public boolean hasHllPrecision() {
+        return ((bitField0_ & 0x10000000) == 0x10000000);
+      }
+      /**
+       * <code>optional uint32 hll_precision = 29;</code>
+       *
+       * <pre>
+       * Hyperlolog DT Precision
+       * </pre>
+       */
+      public int getHllPrecision() {
+        return hllPrecision_;
+      }
+      /**
+       * <code>optional uint32 hll_precision = 29;</code>
+       *
+       * <pre>
+       * Hyperlolog DT Precision
+       * </pre>
+       */
+      public Builder setHllPrecision(int value) {
+        bitField0_ |= 0x10000000;
+        hllPrecision_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional uint32 hll_precision = 29;</code>
+       *
+       * <pre>
+       * Hyperlolog DT Precision
+       * </pre>
+       */
+      public Builder clearHllPrecision() {
+        bitField0_ = (bitField0_ & ~0x10000000);
+        hllPrecision_ = 0;
+        onChanged();
+        return this;
+      }
+
       // @@protoc_insertion_point(builder_scope:RpbBucketProps)
     }
 
@@ -10187,7 +10297,7 @@ public final class RiakPB {
       " \002(\0132\017.RpbBucketProps\"-\n\tRpbModFun\022\016\n\006mo" +
       "dule\030\001 \002(\014\022\020\n\010function\030\002 \002(\014\"9\n\rRpbCommi" +
       "tHook\022\032\n\006modfun\030\001 \001(\0132\n.RpbModFun\022\014\n\004nam" +
-      "e\030\002 \001(\014\"\260\005\n\016RpbBucketProps\022\r\n\005n_val\030\001 \001(" +
+      "e\030\002 \001(\014\"\307\005\n\016RpbBucketProps\022\r\n\005n_val\030\001 \001(" +
       "\r\022\022\n\nallow_mult\030\002 \001(\010\022\027\n\017last_write_wins" +
       "\030\003 \001(\010\022!\n\tprecommit\030\004 \003(\0132\016.RpbCommitHoo" +
       "k\022\034\n\rhas_precommit\030\005 \001(\010:\005false\022\"\n\npostc" +
@@ -10202,11 +10312,12 @@ public final class RiakPB {
       "\n\007backend\030\026 \001(\014\022\016\n\006search\030\027 \001(\010\022)\n\004repl\030" +
       "\030 \001(\0162\033.RpbBucketProps.RpbReplMode\022\024\n\014se" +
       "arch_index\030\031 \001(\014\022\020\n\010datatype\030\032 \001(\014\022\022\n\nco",
-      "nsistent\030\033 \001(\010\022\022\n\nwrite_once\030\034 \001(\010\">\n\013Rp" +
-      "bReplMode\022\t\n\005FALSE\020\000\022\014\n\010REALTIME\020\001\022\014\n\010FU" +
-      "LLSYNC\020\002\022\010\n\004TRUE\020\003\",\n\nRpbAuthReq\022\014\n\004user" +
-      "\030\001 \002(\014\022\020\n\010password\030\002 \002(\014B!\n\027com.basho.ri" +
-      "ak.protobufB\006RiakPB"
+      "nsistent\030\033 \001(\010\022\022\n\nwrite_once\030\034 \001(\010\022\025\n\rhl" +
+      "l_precision\030\035 \001(\r\">\n\013RpbReplMode\022\t\n\005FALS" +
+      "E\020\000\022\014\n\010REALTIME\020\001\022\014\n\010FULLSYNC\020\002\022\010\n\004TRUE\020" +
+      "\003\",\n\nRpbAuthReq\022\014\n\004user\030\001 \002(\014\022\020\n\010passwor" +
+      "d\030\002 \002(\014B!\n\027com.basho.riak.protobufB\006Riak" +
+      "PB"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -10291,7 +10402,7 @@ public final class RiakPB {
     internal_static_RpbBucketProps_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_RpbBucketProps_descriptor,
-        new java.lang.String[] { "NVal", "AllowMult", "LastWriteWins", "Precommit", "HasPrecommit", "Postcommit", "HasPostcommit", "ChashKeyfun", "Linkfun", "OldVclock", "YoungVclock", "BigVclock", "SmallVclock", "Pr", "R", "W", "Pw", "Dw", "Rw", "BasicQuorum", "NotfoundOk", "Backend", "Search", "Repl", "SearchIndex", "Datatype", "Consistent", "WriteOnce", });
+        new java.lang.String[] { "NVal", "AllowMult", "LastWriteWins", "Precommit", "HasPrecommit", "Postcommit", "HasPostcommit", "ChashKeyfun", "Linkfun", "OldVclock", "YoungVclock", "BigVclock", "SmallVclock", "Pr", "R", "W", "Pw", "Dw", "Rw", "BasicQuorum", "NotfoundOk", "Backend", "Search", "Repl", "SearchIndex", "Datatype", "Consistent", "WriteOnce", `"HllPrecision", });
     internal_static_RpbAuthReq_descriptor =
       getDescriptor().getMessageTypes().get(12);
     internal_static_RpbAuthReq_fieldAccessorTable = new

--- a/src/test/java/com/basho/riak/client/api/commands/itest/ITestDatatype.java
+++ b/src/test/java/com/basho/riak/client/api/commands/itest/ITestDatatype.java
@@ -171,6 +171,6 @@ public class ITestDatatype extends ITestAutoCleanupBase
         final FetchHll.Response fetchHllResponse = client.execute(hllFetchCmd);
 
         assertNotNull(fetchHllResponse.getDatatype());
-        assertEquals(Long.valueOf(5), fetchHllResponse.getDatatype().view());
+        assertEquals(5l, fetchHllResponse.getDatatype().getCardinality());
     }
 }

--- a/src/test/java/com/basho/riak/client/api/commands/itest/ITestDatatype.java
+++ b/src/test/java/com/basho/riak/client/api/commands/itest/ITestDatatype.java
@@ -168,9 +168,9 @@ public class ITestDatatype extends ITestAutoCleanupBase
         final Location location = new Location(uniqueUsers, hllResponse.getGeneratedKey());
 
         FetchHll hllFetchCmd = new FetchHll.Builder(location).build();
-        final FetchHll.Response fetchHllResponse = client.execute(hllFetchCmd);
+        final RiakHll fetchHll = client.execute(hllFetchCmd);
 
-        assertNotNull(fetchHllResponse.getDatatype());
-        assertEquals(5l, fetchHllResponse.getDatatype().getCardinality());
+        assertNotNull(fetchHll);
+        assertEquals(5l, fetchHll.getCardinality());
     }
 }

--- a/src/test/java/com/basho/riak/client/api/commands/itest/ITestDatatype.java
+++ b/src/test/java/com/basho/riak/client/api/commands/itest/ITestDatatype.java
@@ -1,16 +1,12 @@
 package com.basho.riak.client.api.commands.itest;
 
-import com.basho.riak.client.api.commands.datatypes.*;
-import com.basho.riak.client.core.query.crdt.types.RiakSet;
-import com.basho.riak.client.core.query.crdt.types.RiakMap;
-import com.basho.riak.client.core.query.crdt.types.RiakCounter;
-import com.basho.riak.client.core.query.crdt.types.RiakRegister;
-import com.basho.riak.client.core.query.crdt.types.RiakFlag;
-import com.basho.riak.client.api.commands.datatypes.UpdateDatatype.Option;
 import com.basho.riak.client.api.RiakClient;
+import com.basho.riak.client.api.commands.datatypes.*;
+import com.basho.riak.client.api.commands.datatypes.UpdateDatatype.Option;
 import com.basho.riak.client.core.operations.itest.ITestAutoCleanupBase;
 import com.basho.riak.client.core.query.Location;
 import com.basho.riak.client.core.query.Namespace;
+import com.basho.riak.client.core.query.crdt.types.*;
 import com.basho.riak.client.core.util.BinaryValue;
 import org.junit.Assume;
 import org.junit.Test;
@@ -19,12 +15,9 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
-
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class ITestDatatype extends ITestAutoCleanupBase
 {
@@ -156,6 +149,7 @@ public class ITestDatatype extends ITestAutoCleanupBase
     @Test
     public void testHyperLogLog() throws ExecutionException, InterruptedException
     {
+        Assume.assumeTrue(testHllDataType);
         resetAndEmptyBucket(uniqueUsers);
 
         HllUpdate hllUpdate = new HllUpdate().add("user1").add("user2")

--- a/src/test/java/com/basho/riak/client/core/operations/itest/ITestBase.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/ITestBase.java
@@ -69,6 +69,7 @@ public abstract class ITestBase
     protected static BinaryValue bucketName;
     protected static BinaryValue counterBucketType;
     protected static BinaryValue setBucketType;
+    protected static BinaryValue hllBucketType;
     protected static BinaryValue mapBucketType;
     protected static BinaryValue bucketType;
     protected static BinaryValue yokozunaBucketType;
@@ -143,6 +144,7 @@ public abstract class ITestBase
          */
         counterBucketType = BinaryValue.create("counters");
         setBucketType = BinaryValue.create("sets");
+        hllBucketType = BinaryValue.create("hlls");
         mapBucketType = BinaryValue.create("maps");
 
         mapReduceBucketType = BinaryValue.create("mr");

--- a/src/test/java/com/basho/riak/client/core/operations/itest/ITestBase.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/ITestBase.java
@@ -62,6 +62,7 @@ public abstract class ITestBase
     protected static boolean test2i;
     protected static boolean testBucketType;
     protected static boolean testCrdt;
+    protected static boolean testHllDataType;
     protected static boolean testTimeSeries;
     protected static boolean testCoveragePlan;
     protected static boolean legacyRiakSearch;
@@ -150,6 +151,7 @@ public abstract class ITestBase
         mapReduceBucketType = BinaryValue.create("mr");
 
         testCrdt = Boolean.parseBoolean(System.getProperty("com.basho.riak.crdt", "true"));
+        testHllDataType = Boolean.parseBoolean(System.getProperty("com.basho.riak.hlldt", "true"));
 
         testTimeSeries = Boolean.parseBoolean(System.getProperty("com.basho.riak.timeseries", "false"));
 

--- a/src/test/java/com/basho/riak/client/core/operations/itest/ITestBase.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/ITestBase.java
@@ -151,7 +151,7 @@ public abstract class ITestBase
         mapReduceBucketType = BinaryValue.create("mr");
 
         testCrdt = Boolean.parseBoolean(System.getProperty("com.basho.riak.crdt", "true"));
-        testHllDataType = Boolean.parseBoolean(System.getProperty("com.basho.riak.hlldt", "true"));
+        testHllDataType = Boolean.parseBoolean(System.getProperty("com.basho.riak.hlldt", "false"));
 
         testTimeSeries = Boolean.parseBoolean(System.getProperty("com.basho.riak.timeseries", "false"));
 

--- a/src/test/java/com/basho/riak/client/core/operations/itest/ITestBucketProperties.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/ITestBucketProperties.java
@@ -171,6 +171,17 @@ public class ITestBucketProperties extends ITestAutoCleanupBase
         assertEquals(Integer.valueOf(13), props.getHllPrecision());
     }
 
+    @Test(expected = ExecutionException.class)
+    public void testIncreaseHllPrecisionThrowsError() throws ExecutionException, InterruptedException
+    {
+        Assume.assumeTrue(testHllDataType);
+        Namespace namespace = new Namespace(hllBucketType, BinaryValue.create("hll_" + new Random().nextLong()));
+        StoreBucketPropsOperation.Builder storeOp =
+                new StoreBucketPropsOperation.Builder(namespace).withHllPrecision(15);
+
+        storeBucketProps(storeOp);
+    }
+
     private BucketProperties fetchBucketProps(Namespace namespace) throws InterruptedException, ExecutionException
     {
         FetchBucketPropsOperation.Builder builder = new FetchBucketPropsOperation.Builder(namespace);

--- a/src/test/java/com/basho/riak/client/core/operations/itest/ITestBucketProperties.java
+++ b/src/test/java/com/basho/riak/client/core/operations/itest/ITestBucketProperties.java
@@ -20,8 +20,12 @@ import com.basho.riak.client.core.operations.FetchBucketPropsOperation;
 import com.basho.riak.client.core.operations.StoreBucketPropsOperation;
 import com.basho.riak.client.core.query.BucketProperties;
 import com.basho.riak.client.core.query.Namespace;
+
+import java.util.Random;
 import java.util.concurrent.ExecutionException;
 import static org.junit.Assert.*;
+
+import com.basho.riak.client.core.util.BinaryValue;
 import org.junit.Assume;
 import org.junit.Test;
 
@@ -150,6 +154,21 @@ public class ITestBucketProperties extends ITestAutoCleanupBase
         namespace = new Namespace(Namespace.DEFAULT_BUCKET_TYPE, bucketName.toString());
         props = fetchBucketProps(namespace);
         assertEquals(props.getNVal(), Integer.valueOf(3));
+    }
+
+    @Test
+    public void testSetHllPrecision() throws ExecutionException, InterruptedException
+    {
+        Assume.assumeTrue(testHllDataType);
+        Namespace namespace = new Namespace(hllBucketType, BinaryValue.create("hll_" + new Random().nextLong()));
+        StoreBucketPropsOperation.Builder storeOp =
+                new StoreBucketPropsOperation.Builder(namespace).withHllPrecision(13);
+
+        storeBucketProps(storeOp);
+
+        BucketProperties props = fetchBucketProps(namespace);
+
+        assertEquals(Integer.valueOf(13), props.getHllPrecision());
     }
 
     private BucketProperties fetchBucketProps(Namespace namespace) throws InterruptedException, ExecutionException


### PR DESCRIPTION
Adds HLL data type. 

Test with a devrel of this Riak branch: https://github.com/basho/riak_ee/tree/develop-2.2

Test / sample usage can be found at: https://github.com/basho/riak-java-client/blob/00fc01296fb0226b004754fcf40c1c6c82875032/src/test/java/com/basho/riak/client/api/commands/itest/ITestDatatype.java#L157

When running maven, add the flag `-Dcom.basho.riak.hlldt=true` to enable the new tests.

Docs PR forthcoming.
