### PR TITLE
Bump Netty to 4.1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -463,7 +463,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.1.3.Final</version>
+            <version>4.1.4.Final</version>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -463,7 +463,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.1.4.Final</version>
+            <version>4.1.5.Final</version>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
Netty 4.1.3 has a regression where memory can balloon with high-concurrency use cases (us). 

4.1.4 fixes that regression. http://netty.io/news/2016/07/27/4-0-40-Final-4-1-4-Final.html
