### PR TITLE
Adding cleanup() method to RiakCluster & RiakClient for container environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ before_script:
   false
 script:
 - if [ $RIAK_FLAVOR == "riak-kv" ]; then mvn -Pitest,default -Dcom.basho.riak.yokozuna=false
-  verify; else echo "Not riak-kv flavor"; fi
+  verify; for i in {1..10}; do mvn -Ptest-debug-logging surefire:test -Dtest=RiakClusterTest; done; else echo "Not riak-kv flavor"; fi
 - if [ $RIAK_FLAVOR == "riak-ts" ]; then mvn -Pitest,default -Dcom.basho.riak.yokozuna=false
-  -Dcom.basho.riak.timeseries=true verify; else echo "Not riak-ts flavor"; fi
+  -Dcom.basho.riak.timeseries=true verify; for i in {1..10}; do mvn -Ptest-debug-logging surefire:test -Dtest=RiakClusterTest; done; else echo "Not riak-ts flavor"; fi
 after_script:
 - docker rm -f $RIAK_FLAVOR
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,8 @@ before_script:
 - tools/devrel/riak-cluster-config "docker exec $RIAK_FLAVOR riak-admin" 8098 false
   false
 script:
-- if [ $RIAK_FLAVOR == "riak-kv" ]; then mvn -Pitest,default -Dcom.basho.riak.yokozuna=false
-  verify; for i in {1..10}; do mvn -Ptest-debug-logging surefire:test -Dtest=RiakClusterTest; done; else echo "Not riak-kv flavor"; fi
-- if [ $RIAK_FLAVOR == "riak-ts" ]; then mvn -Pitest,default -Dcom.basho.riak.yokozuna=false
-  -Dcom.basho.riak.timeseries=true verify; for i in {1..10}; do mvn -Ptest-debug-logging surefire:test -Dtest=RiakClusterTest; done; else echo "Not riak-ts flavor"; fi
+- if [[ $RIAK_FLAVOR == "riak-kv" ]]; then mvn -Pitest,default -Dcom.basho.riak.yokozuna=false verify; fi
+- if [[ $RIAK_FLAVOR == "riak-ts" ]]; then mvn -Pitest,default -Dcom.basho.riak.yokozuna=false -Dcom.basho.riak.timeseries=true verify; fi
 after_script:
 - docker rm -f $RIAK_FLAVOR
 env:

--- a/src/main/java/com/basho/riak/client/api/RiakClient.java
+++ b/src/main/java/com/basho/riak/client/api/RiakClient.java
@@ -190,7 +190,6 @@ public class RiakClient
         RiakCluster cluster = new RiakCluster.Builder(builder.build()).build();
         cluster.start();
         return new RiakClient(cluster);
-        
     }
 
     /**

--- a/src/main/java/com/basho/riak/client/api/RiakClient.java
+++ b/src/main/java/com/basho/riak/client/api/RiakClient.java
@@ -190,6 +190,7 @@ public class RiakClient
         RiakCluster cluster = new RiakCluster.Builder(builder.build()).build();
         cluster.start();
         return new RiakClient(cluster);
+        
     }
 
     /**
@@ -426,5 +427,18 @@ public class RiakClient
     public RiakCluster getRiakCluster()
     {
         return cluster;
+    }
+
+    /**
+     * Cleans up any Thread-Local variables after shutdown.
+     * This operation is useful when you are in a container environment, and you
+     * do not want to leave the thread local variables in the threads you do not manage.
+     * Call this method when your application is being unloaded from the container, <b>after</b>
+     * all {@link RiakNode}, {@link RiakCluster}, and {@link com.basho.riak.client.api.RiakClient}
+     * objects are in the shutdown state.
+     */
+    public void cleanup()
+    {
+        cluster.cleanup();
     }
 }

--- a/src/main/java/com/basho/riak/client/core/RiakCluster.java
+++ b/src/main/java/com/basho/riak/client/core/RiakCluster.java
@@ -636,6 +636,21 @@ public class  RiakCluster implements OperationRetrier, NodeStateListener
         }
 
     /**
+     * Cleans up any Thread-Local variables after shutdown.
+     * This operation is useful when you are in a container environment, and you
+     * do not want to leave the thread local variables in the threads you do not manage.
+     * Call this method when your application is being unloaded from the container, <b>after</b>
+     * all {@link RiakNode}, {@link RiakCluster}, and {@link com.basho.riak.client.api.RiakClient}
+     * objects are in the shutdown state.
+     */
+    public synchronized void cleanup()
+    {
+        stateCheck(State.SHUTDOWN);
+        io.netty.util.concurrent.FastThreadLocal.removeAll();
+        io.netty.util.concurrent.FastThreadLocal.destroy();
+    }
+
+    /**
      * Builder used to create {@link RiakCluster} instances.
      */
     public static class Builder


### PR DESCRIPTION
Fixes #660 (CLIENTS-962), abstracts away the calls needed to cleanup Netty's thread local variables, so we don't leak classloaders into permgen memory upon container reload. 

cc/ @monday0rsunday
