### PR TITLE
Reduce the number of charset lookups performed in BinaryValue under t…

### DIFF
--- a/src/main/java/com/basho/riak/client/core/util/BinaryValue.java
+++ b/src/main/java/com/basho/riak/client/core/util/BinaryValue.java
@@ -41,6 +41,11 @@ import java.util.Arrays;
  */
 public final class BinaryValue
 {
+    /**
+     * It is expected that UTF-8 charset is available.
+     */
+    private static final Charset theUTF8 = Charset.forName("UTF-8");
+
     private final byte[] data;
 
     private BinaryValue(byte[] data)
@@ -87,7 +92,7 @@ public final class BinaryValue
      */
     public static BinaryValue createFromUtf8(String data)
     {
-        return create(data, Charset.forName("UTF-8"));
+        return create(data, theUTF8);
     }
 
     /**
@@ -197,7 +202,7 @@ public final class BinaryValue
      */
     public String toStringUtf8()
     {
-        return toString(Charset.forName("UTF-8"));
+        return toString(theUTF8);
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Getting rid of looking up UTF charset each time when
 BinaryValue.createFromUtf8() and BinaryValue. toStringUtf8() is called
## Motivation and Context
To speed-up corresponding operations

## How Has This Been Tested?
It is expected that this change will be covered by existing tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Inapplicable 

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Javadoc comments for any new public classes, interfaces, etc.
- [ ] A basho_docs PR for new or changed features (basho/basho_docs#???)

Pull requests that are small and limited in scope are most welcome.