### PR TITLE
Feature/clients 1063 equals implementations

### DIFF
--- a/src/main/java/com/basho/riak/client/api/commands/buckets/FetchBucketProperties.java
+++ b/src/main/java/com/basho/riak/client/api/commands/buckets/FetchBucketProperties.java
@@ -19,6 +19,7 @@ package com.basho.riak.client.api.commands.buckets;
 import com.basho.riak.client.api.AsIsRiakCommand;
 import com.basho.riak.client.core.operations.FetchBucketPropsOperation;
 import com.basho.riak.client.core.query.Namespace;
+import java.util.Objects;
 
 /**
  * Command used to fetch the properties of a bucket in Riak.
@@ -49,6 +50,23 @@ public final class FetchBucketProperties extends AsIsRiakCommand<FetchBucketProp
     protected FetchBucketPropsOperation buildCoreOperation()
     {
         return new FetchBucketPropsOperation.Builder(namespace).build();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (!(other instanceof FetchBucketProperties)) {
+            return false;
+        }
+        FetchBucketProperties otherFetchBucketProperties = (FetchBucketProperties) other;
+        return Objects.equals(namespace, otherFetchBucketProperties.namespace);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(namespace);
     }
 
     /**

--- a/src/main/java/com/basho/riak/client/api/commands/buckets/StoreBucketProperties.java
+++ b/src/main/java/com/basho/riak/client/api/commands/buckets/StoreBucketProperties.java
@@ -20,6 +20,7 @@ import com.basho.riak.client.api.AsIsRiakCommand;
 import com.basho.riak.client.core.operations.StoreBucketPropsOperation;
 import com.basho.riak.client.core.query.Namespace;
 import com.basho.riak.client.core.query.functions.Function;
+import java.util.Objects;
 
 /**
  * Command used to store (modify) the properties of a bucket in Riak.
@@ -213,6 +214,48 @@ public final class StoreBucketProperties extends AsIsRiakCommand<Void, Namespace
         }
 
         return builder.build();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (!(other instanceof StoreBucketProperties)) {
+            return false;
+        }
+        StoreBucketProperties otherStoreBucketProperties = (StoreBucketProperties) other;
+        return Objects.equals(namespace, otherStoreBucketProperties.namespace) &&
+                Objects.equals(allowMulti, otherStoreBucketProperties.allowMulti) &&
+                Objects.equals(backend, otherStoreBucketProperties.backend) &&
+                Objects.equals(basicQuorum, otherStoreBucketProperties.basicQuorum) &&
+                Objects.equals(bigVClock, otherStoreBucketProperties.bigVClock) &&
+                Objects.equals(chashkeyFunction, otherStoreBucketProperties.chashkeyFunction) &&
+                Objects.equals(lastWriteWins, otherStoreBucketProperties.lastWriteWins) &&
+                Objects.equals(linkWalkFunction, otherStoreBucketProperties.linkWalkFunction) &&
+                Objects.equals(rw, otherStoreBucketProperties.rw) &&
+                Objects.equals(dw, otherStoreBucketProperties.dw) &&
+                Objects.equals(w, otherStoreBucketProperties.w) &&
+                Objects.equals(r, otherStoreBucketProperties.r) &&
+                Objects.equals(pr, otherStoreBucketProperties.pr) &&
+                Objects.equals(pw, otherStoreBucketProperties.pw) &&
+                Objects.equals(notFoundOk, otherStoreBucketProperties.notFoundOk) &&
+                Objects.equals(preCommitHook, otherStoreBucketProperties.preCommitHook) &&
+                Objects.equals(postCommitHook, otherStoreBucketProperties.postCommitHook) &&
+                Objects.equals(oldVClock, otherStoreBucketProperties.oldVClock) &&
+                Objects.equals(youngVClock, otherStoreBucketProperties.youngVClock) &&
+                Objects.equals(smallVClock, otherStoreBucketProperties.smallVClock) &&
+                Objects.equals(nval, otherStoreBucketProperties.nval) &&
+                Objects.equals(legacySearch, otherStoreBucketProperties.legacySearch) &&
+                Objects.equals(searchIndex, otherStoreBucketProperties.searchIndex) &&
+                Objects.equals(hllPrecision, otherStoreBucketProperties.hllPrecision);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(namespace, allowMulti, backend, basicQuorum, bigVClock, chashkeyFunction, lastWriteWins,
+                linkWalkFunction, rw, dw, w, r, pr, pw, notFoundOk, preCommitHook, postCommitHook, oldVClock,
+                youngVClock, smallVClock, nval, legacySearch, searchIndex, hllPrecision);
     }
 
     public static class Builder

--- a/src/main/java/com/basho/riak/client/api/commands/search/StoreIndex.java
+++ b/src/main/java/com/basho/riak/client/api/commands/search/StoreIndex.java
@@ -3,6 +3,7 @@ package com.basho.riak.client.api.commands.search;
 import com.basho.riak.client.api.AsIsRiakCommand;
 import com.basho.riak.client.core.operations.YzPutIndexOperation;
 import com.basho.riak.client.core.query.search.YokozunaIndex;
+import java.util.Objects;
 
 /**
  * Command used to store a search index in Riak.
@@ -34,6 +35,24 @@ public final class StoreIndex extends AsIsRiakCommand<Void, YokozunaIndex>
         }
 
         return opBuilder.build();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (!(other instanceof StoreIndex)) {
+            return false;
+        }
+        Builder otherStoreIndex = ((StoreIndex) other).cmdBuilder;
+        return Objects.equals(cmdBuilder.index, otherStoreIndex.index)
+                && Objects.equals(cmdBuilder.timeout, otherStoreIndex.timeout);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(cmdBuilder.index, cmdBuilder.timeout);
     }
 
     /**

--- a/src/main/java/com/basho/riak/client/core/query/search/YokozunaIndex.java
+++ b/src/main/java/com/basho/riak/client/core/query/search/YokozunaIndex.java
@@ -15,6 +15,8 @@
  */
 package com.basho.riak.client.core.query.search;
 
+import java.util.Objects;
+
 /**
  * Represents a Yokozuna Index.
  *
@@ -114,5 +116,24 @@ public class YokozunaIndex
     public Integer getNVal()
     {
         return nVal;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (!(other instanceof YokozunaIndex)) {
+            return false;
+        }
+        YokozunaIndex otherYokozunaIndex = (YokozunaIndex) other;
+        return Objects.equals(name, otherYokozunaIndex.name) &&
+                Objects.equals(schema, otherYokozunaIndex.schema) &&
+                Objects.equals(nVal, otherYokozunaIndex.nVal);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, schema, nVal);
     }
 }

--- a/src/test/java/com/basho/riak/client/api/commands/buckets/FetchBucketPropertiesTest.java
+++ b/src/test/java/com/basho/riak/client/api/commands/buckets/FetchBucketPropertiesTest.java
@@ -1,0 +1,37 @@
+package com.basho.riak.client.api.commands.buckets;
+
+import com.basho.riak.client.core.query.Namespace;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FetchBucketPropertiesTest {
+	@Test
+	public void equalsReturnsTrueForEqualNamespaces() {
+		Namespace namespace1 = new Namespace("namespace");
+		Namespace namespace2 = new Namespace("namespace");
+
+		FetchBucketProperties fetchBucketProperties1 = new FetchBucketProperties.Builder(namespace1).build();
+		FetchBucketProperties fetchBucketProperties2 = new FetchBucketProperties.Builder(namespace2).build();
+
+		assertThat(fetchBucketProperties1, is(equalTo(fetchBucketProperties2)));
+		assertThat(fetchBucketProperties2, is(equalTo(fetchBucketProperties1)));
+	}
+
+	@Test
+	public void equalsReturnsFalseForDifferentNamespaces() {
+		Namespace namespace1 = new Namespace("namespace1");
+		Namespace namespace2 = new Namespace("namespace2");
+
+		FetchBucketProperties fetchBucketProperties1 = new FetchBucketProperties.Builder(namespace1).build();
+		FetchBucketProperties fetchBucketProperties2 = new FetchBucketProperties.Builder(namespace2).build();
+
+		assertThat(fetchBucketProperties1, is(not(equalTo(fetchBucketProperties2))));
+		assertThat(fetchBucketProperties2, is(not(equalTo(fetchBucketProperties1))));
+	}
+}

--- a/src/test/java/com/basho/riak/client/api/commands/buckets/StoreBucketPropertiesTest.java
+++ b/src/test/java/com/basho/riak/client/api/commands/buckets/StoreBucketPropertiesTest.java
@@ -1,0 +1,52 @@
+package com.basho.riak.client.api.commands.buckets;
+
+import com.basho.riak.client.core.query.Namespace;
+import org.junit.Test;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class StoreBucketPropertiesTest {
+	@Test
+	public void equalsReturnsTrueForEqualBucketProperties() {
+		StoreBucketProperties storeBucketProperties1 = new StoreBucketProperties.Builder(new Namespace("namespace"))
+				.withBackend("backend").withNotFoundOk(true).withHllPrecision(15)
+				.withNVal(3).withPr(1).withPw(2).withR(1).withRw(1).withW(1).withDw(3).withBasicQuorum(false)
+				.withAllowMulti(true).withLastWriteWins(true)
+				.withBigVClock(42L).withOldVClock(41L).withSmallVClock(5L).withYoungVClock(19L)
+				.withLegacyRiakSearchEnabled(false).withSearchIndex("index")
+				.build();
+		StoreBucketProperties storeBucketProperties2 = new StoreBucketProperties.Builder(new Namespace("namespace"))
+				.withBackend("backend").withNotFoundOk(true).withHllPrecision(15)
+				.withNVal(3).withPr(1).withPw(2).withR(1).withRw(1).withW(1).withDw(3).withBasicQuorum(false)
+				.withAllowMulti(true).withLastWriteWins(true)
+				.withBigVClock(42L).withOldVClock(41L).withSmallVClock(5L).withYoungVClock(19L)
+				.withLegacyRiakSearchEnabled(false).withSearchIndex("index")
+				.build();
+
+		assertThat(storeBucketProperties1, is(equalTo(storeBucketProperties2)));
+		assertThat(storeBucketProperties2, is(equalTo(storeBucketProperties1)));
+	}
+
+	@Test
+	public void equalsReturnsFalseForDifferentBucketProperties() {
+		StoreBucketProperties storeBucketProperties1 = new StoreBucketProperties.Builder(new Namespace("namespace1"))
+				.withBackend("backend1").withNotFoundOk(true).withHllPrecision(14)
+				.withNVal(3).withPr(1).withPw(2).withR(1).withRw(1).withW(1).withDw(3).withBasicQuorum(false)
+				.withAllowMulti(true).withLastWriteWins(true)
+				.withBigVClock(42L).withOldVClock(41L).withSmallVClock(5L).withYoungVClock(19L)
+				.withLegacyRiakSearchEnabled(false).withSearchIndex("index1")
+				.build();
+		StoreBucketProperties storeBucketProperties2 = new StoreBucketProperties.Builder(new Namespace("namespace2"))
+				.withBackend("backend2").withNotFoundOk(false).withHllPrecision(16)
+				.withNVal(5).withPr(2).withPw(4).withR(2).withRw(2).withW(2).withDw(4).withBasicQuorum(true)
+				.withAllowMulti(false).withLastWriteWins(false)
+				.withBigVClock(43L).withOldVClock(42L).withSmallVClock(4L).withYoungVClock(190L)
+				.withLegacyRiakSearchEnabled(true).withSearchIndex("index2")
+				.build();
+
+		assertThat(storeBucketProperties1, is(not(equalTo(storeBucketProperties2))));
+		assertThat(storeBucketProperties2, is(not(equalTo(storeBucketProperties1))));
+	}
+}

--- a/src/test/java/com/basho/riak/client/api/commands/search/StoreIndexTest.java
+++ b/src/test/java/com/basho/riak/client/api/commands/search/StoreIndexTest.java
@@ -1,0 +1,34 @@
+package com.basho.riak.client.api.commands.search;
+
+import com.basho.riak.client.core.query.search.YokozunaIndex;
+import org.junit.Test;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class StoreIndexTest {
+	@Test
+	public void equalsReturnsTrueForEqualIndexAndTimeout() {
+		YokozunaIndex index1 = new YokozunaIndex("index");
+		YokozunaIndex index2 = new YokozunaIndex("index");
+
+		StoreIndex storeIndex1 = new StoreIndex.Builder(index1).withTimeout(5).build();
+		StoreIndex storeIndex2 = new StoreIndex.Builder(index2).withTimeout(5).build();
+
+		assertThat(storeIndex1, is(equalTo(storeIndex2)));
+		assertThat(storeIndex2, is(equalTo(storeIndex1)));
+	}
+
+	@Test
+	public void equalsReturnsFalseForDifferentIndexAndTimeout() {
+		YokozunaIndex index1 = new YokozunaIndex("index1");
+		YokozunaIndex index2 = new YokozunaIndex("index2");
+
+		StoreIndex storeIndex1 = new StoreIndex.Builder(index1).withTimeout(5).build();
+		StoreIndex storeIndex2 = new StoreIndex.Builder(index2).withTimeout(8).build();
+
+		assertThat(storeIndex1, is(not(equalTo(storeIndex2))));
+		assertThat(storeIndex2, is(not(equalTo(storeIndex1))));
+	}
+}

--- a/src/test/java/com/basho/riak/client/core/query/search/YokozunaIndexTest.java
+++ b/src/test/java/com/basho/riak/client/core/query/search/YokozunaIndexTest.java
@@ -1,0 +1,27 @@
+package com.basho.riak.client.core.query.search;
+
+import org.junit.Test;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class YokozunaIndexTest {
+	@Test
+	public void equalsReturnsTrueForEqualYokozunaIndices() {
+		YokozunaIndex yokozunaIndex1 = new YokozunaIndex("name", "schema").withNVal(3);
+		YokozunaIndex yokozunaIndex2 = new YokozunaIndex("name", "schema").withNVal(3);
+
+		assertThat(yokozunaIndex1, is(equalTo(yokozunaIndex2)));
+		assertThat(yokozunaIndex2, is(equalTo(yokozunaIndex1)));
+	}
+
+	@Test
+	public void equalsReturnsFalseForDifferentYokozunaIndices() {
+		YokozunaIndex yokozunaIndex1 = new YokozunaIndex("name1", "schema1").withNVal(3);
+		YokozunaIndex yokozunaIndex2 = new YokozunaIndex("name2", "schema2").withNVal(5);
+
+		assertThat(yokozunaIndex1, is(not(equalTo(yokozunaIndex2))));
+		assertThat(yokozunaIndex2, is(not(equalTo(yokozunaIndex1))));
+	}
+}


### PR DESCRIPTION
Added `equals()` and `hashCode()` to
- FetchBucketProperties
- StoreBucketProperties
- YokozunaIndex
- StoreIndex

## Related Issue
CLIENTS-1063 (#695)

## Motivation and Context
I need the implementations of `equals()` for mocking in the unit-tests of my client-code.

## How Has This Been Tested?
Added brief unit-tests. Local build passes.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Javadoc comments for any new public classes, interfaces, etc.
- [ ] A basho_docs PR for new or changed features (basho/basho_docs#???)