### PR TITLE
Make RiakObject (and all it's stuff) to be Serializable

### DIFF
--- a/src/main/java/com/basho/riak/client/api/cap/VClock.java
+++ b/src/main/java/com/basho/riak/client/api/cap/VClock.java
@@ -15,13 +15,15 @@
  */
 package com.basho.riak.client.api.cap;
 
+import java.io.Serializable;
+
 /**
  * Access the opaque Riak vector clock as either a String or array of bytes.
  *
  * @author Russel Brown <russelldb at basho dot com>
  * @since 1.0
  */
-public interface VClock
+public interface VClock extends Serializable
 {
     /**
      * Get the bytes that make up this VClock.

--- a/src/main/java/com/basho/riak/client/core/query/RiakObject.java
+++ b/src/main/java/com/basho/riak/client/core/query/RiakObject.java
@@ -23,6 +23,7 @@ import com.basho.riak.client.core.query.links.RiakLinks;
 import com.basho.riak.client.core.util.BinaryValue;
 import com.basho.riak.client.core.util.CharsetUtils;
 
+import java.io.Serializable;
 import java.nio.charset.Charset;
 
 /**
@@ -49,7 +50,7 @@ import java.nio.charset.Charset;
  * @author Brian Roach <roach at basho dot com>
  * @since 2.0
  */
-public final class RiakObject
+public final class RiakObject implements Serializable
 {
     /**
      * The default content type assigned when storing in Riak if one is not
@@ -58,6 +59,7 @@ public final class RiakObject
      * @see RiakObject#setContentType(java.lang.String)
      */
     public final static String DEFAULT_CONTENT_TYPE = "application/octet-stream";
+    private static final long serialVersionUID = 484390882043340231L;
 
     // Mutable types.
     // Worth noting here is that changes to the contents of this

--- a/src/main/java/com/basho/riak/client/core/query/UserMetadata/RiakUserMetadata.java
+++ b/src/main/java/com/basho/riak/client/core/query/UserMetadata/RiakUserMetadata.java
@@ -18,6 +18,7 @@ package com.basho.riak.client.core.query.UserMetadata;
 import com.basho.riak.client.core.util.BinaryValue;
 import com.basho.riak.client.core.util.DefaultCharset;
 
+import java.io.Serializable;
 import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.Map;
@@ -41,8 +42,9 @@ import java.util.concurrent.ConcurrentHashMap;
  * @see com.basho.riak.client.core.query.RiakObject#getUserMeta()
  * @since 2.0
  */
-public class RiakUserMetadata
+public class RiakUserMetadata implements Serializable
 {
+    private static final long serialVersionUID = 9001811266201347973L;
     private final ConcurrentHashMap<BinaryValue, BinaryValue> meta = new ConcurrentHashMap<>();
 
     /**

--- a/src/main/java/com/basho/riak/client/core/query/indexes/BigIntIndex.java
+++ b/src/main/java/com/basho/riak/client/core/query/indexes/BigIntIndex.java
@@ -26,6 +26,7 @@ import java.nio.charset.Charset;
  */
 public class BigIntIndex extends RiakIndex<BigInteger>
 {
+    private static final long serialVersionUID = -1815784710534656508L;
     private BigIntIndex(Name name)
     {
         super(name);

--- a/src/main/java/com/basho/riak/client/core/query/indexes/LongIntIndex.java
+++ b/src/main/java/com/basho/riak/client/core/query/indexes/LongIntIndex.java
@@ -34,6 +34,7 @@ import java.nio.charset.Charset;
  */
 public class LongIntIndex extends RiakIndex<Long>
 {
+    private static final long serialVersionUID = 6311824439922246390L;
     private LongIntIndex(Name name)
     {
         super(name);

--- a/src/main/java/com/basho/riak/client/core/query/indexes/RawIndex.java
+++ b/src/main/java/com/basho/riak/client/core/query/indexes/RawIndex.java
@@ -30,6 +30,7 @@ import com.basho.riak.client.core.util.BinaryValue;
  */
 public class RawIndex extends RiakIndex<BinaryValue>
 {
+    private static final long serialVersionUID = -9062911855629713886L;
     private RawIndex(Name name)
     {
         super(name);

--- a/src/main/java/com/basho/riak/client/core/query/indexes/RiakIndex.java
+++ b/src/main/java/com/basho/riak/client/core/query/indexes/RiakIndex.java
@@ -16,6 +16,8 @@
 package com.basho.riak.client.core.query.indexes;
 
 import com.basho.riak.client.core.util.BinaryValue;
+
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.ConcurrentModificationException;
@@ -50,7 +52,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * href="http://docs.basho.com/riak/latest/dev/using/2i/">Using Secondary
  * Indexes in Riak</a>
  */
-public abstract class RiakIndex<T> implements Iterable<T>
+public abstract class RiakIndex<T> implements Iterable<T>, Serializable
 {
     private final Set<BinaryValue> values;
     private final IndexType type;
@@ -443,4 +445,16 @@ public abstract class RiakIndex<T> implements Iterable<T>
 
         abstract T createIndex();
     }
+
+//    protected final void doWriteObkject(java.io.ObjectOutputStream stream) throws java.io.IOException
+//    {
+//        stream.writeUTF(name);
+//        stream.writeObject(type);
+//        stream.writeObject(values);
+//    }
+//
+//    protected final void doReadObject(java.io.ObjectInputStream stream)
+//            throws java.io.IOException, ClassNotFoundException
+//    {
+//    }
 }

--- a/src/main/java/com/basho/riak/client/core/query/indexes/RiakIndexes.java
+++ b/src/main/java/com/basho/riak/client/core/query/indexes/RiakIndexes.java
@@ -17,6 +17,7 @@ package com.basho.riak.client.core.query.indexes;
 
 import com.basho.riak.client.core.query.RiakObject;
 
+import java.io.Serializable;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
@@ -92,8 +93,9 @@ import java.util.concurrent.ConcurrentHashMap;
  * @since 2.0
  * @see RiakObject#getIndexes()
  */
-public class RiakIndexes implements Iterable<RiakIndex<?>>
+public class RiakIndexes implements Iterable<RiakIndex<?>>, Serializable
 {
+    private static final long serialVersionUID = -2931049191878682591L;
     private final ConcurrentHashMap<String, RiakIndex<?>> indexes = new ConcurrentHashMap<>();
 
     /**

--- a/src/main/java/com/basho/riak/client/core/query/indexes/StringBinIndex.java
+++ b/src/main/java/com/basho/riak/client/core/query/indexes/StringBinIndex.java
@@ -46,7 +46,8 @@ import java.nio.charset.Charset;
  */
 public class StringBinIndex extends RiakIndex<String>
 {
-    private final Charset charset;
+    private static final long serialVersionUID = -5151153157935896563L;
+    private transient Charset charset;
 
     private StringBinIndex(Name name)
     {
@@ -109,5 +110,20 @@ public class StringBinIndex extends RiakIndex<String>
         {
             return new StringBinIndex(this);
         }
+    }
+
+    private void writeObject(java.io.ObjectOutputStream stream)
+            throws java.io.IOException
+    {
+        stream.defaultWriteObject();
+        stream.writeUTF(charset.name());
+    }
+
+    private void readObject(java.io.ObjectInputStream stream)
+            throws java.io.IOException, ClassNotFoundException
+    {
+        stream.defaultReadObject();
+        final String charsetName = stream.readUTF();
+        charset = Charset.forName(charsetName);
     }
 }

--- a/src/main/java/com/basho/riak/client/core/query/links/RiakLink.java
+++ b/src/main/java/com/basho/riak/client/core/query/links/RiakLink.java
@@ -18,6 +18,7 @@ package com.basho.riak.client.core.query.links;
 import com.basho.riak.client.core.util.BinaryValue;
 import com.basho.riak.client.core.util.DefaultCharset;
 
+import java.io.Serializable;
 import java.nio.charset.Charset;
 
 /**
@@ -36,8 +37,9 @@ import java.nio.charset.Charset;
  * @author Brian Roach <roach at basho dot com>
  * @since 1.0
  */
-public class RiakLink
+public class RiakLink implements Serializable
 {
+    private static final long serialVersionUID = -4016542401563611460L;
     private final BinaryValue bucket;
     private final BinaryValue key;
     private final BinaryValue tag;

--- a/src/main/java/com/basho/riak/client/core/query/links/RiakLinks.java
+++ b/src/main/java/com/basho/riak/client/core/query/links/RiakLinks.java
@@ -15,6 +15,7 @@
  */
 package com.basho.riak.client.core.query.links;
 
+import java.io.Serializable;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -27,8 +28,9 @@ import java.util.concurrent.ConcurrentHashMap;
  * @see RiakLink
  * @since 2.0
  */
-public class RiakLinks implements Iterable<RiakLink>
+public class RiakLinks implements Iterable<RiakLink>, Serializable
 {
+    private static final long serialVersionUID = 8826161124877321843L;
     private final Set<RiakLink> links = Collections.newSetFromMap(new ConcurrentHashMap<RiakLink, Boolean>());
 
     /**

--- a/src/main/java/com/basho/riak/client/core/util/BinaryValue.java
+++ b/src/main/java/com/basho/riak/client/core/util/BinaryValue.java
@@ -15,6 +15,10 @@
  */
 package com.basho.riak.client.core.util;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 
@@ -39,12 +43,13 @@ import java.util.Arrays;
  * @author Brian Roach <roach at basho dot com>
  * @since 2.0
  */
-public final class BinaryValue
+public final class BinaryValue implements Serializable
 {
     /**
      * It is expected that UTF-8 charset is available.
      */
     private static final Charset theUTF8 = Charset.forName("UTF-8");
+    private static final long serialVersionUID = 3976425010879879957L;
 
     private final byte[] data;
 

--- a/src/test/java/com/basho/riak/client/api/commands/StoreValueTest.java
+++ b/src/test/java/com/basho/riak/client/api/commands/StoreValueTest.java
@@ -29,11 +29,7 @@ import com.basho.riak.client.core.query.Location;
 import com.basho.riak.client.core.query.Namespace;
 import com.basho.riak.client.core.query.RiakObject;
 import com.basho.riak.client.core.query.RiakObjectTest;
-import com.basho.riak.client.core.query.indexes.StringBinIndex;
-import com.basho.riak.client.core.query.links.RiakLink;
-import com.basho.riak.client.core.util.BinaryValue;
 import com.basho.riak.protobuf.RiakKvPB;
-import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -79,7 +75,7 @@ public class StoreValueTest
         when(mockFuture.isDone()).thenReturn(true);
         when(mockCluster.execute(any(FutureOperation.class))).thenReturn(mockFuture);
         client = new RiakClient(mockCluster);
-        riakObject = RiakObjectTest.CreateFilledObject();
+        riakObject = RiakObjectTest.createFilledObject();
     }
 
     @Test
@@ -114,8 +110,8 @@ public class StoreValueTest
     @Test
     public void testEqualsWithRiakObject()
     {
-        final RiakObject riakObject1 = RiakObjectTest.CreateFilledObject();
-        final RiakObject riakObject2 = RiakObjectTest.CreateFilledObject();
+        final RiakObject riakObject1 = RiakObjectTest.createFilledObject();
+        final RiakObject riakObject2 = RiakObjectTest.createFilledObject();
 
         final StoreValue value1 = filledStoreValue(riakObject1);
         final StoreValue value2 = filledStoreValue(riakObject2);

--- a/src/test/java/com/basho/riak/client/core/query/RiakObjectTest.java
+++ b/src/test/java/com/basho/riak/client/core/query/RiakObjectTest.java
@@ -2,11 +2,13 @@ package com.basho.riak.client.core.query;
 
 import com.basho.riak.client.api.cap.BasicVClock;
 import com.basho.riak.client.api.cap.VClock;
-import com.basho.riak.client.api.commands.kv.StoreValue;
-import com.basho.riak.client.core.query.indexes.StringBinIndex;
+import com.basho.riak.client.core.query.indexes.*;
 import com.basho.riak.client.core.query.links.RiakLink;
 import com.basho.riak.client.core.util.BinaryValue;
 import org.junit.Test;
+
+import java.io.*;
+import java.math.BigInteger;
 
 import static org.junit.Assert.assertEquals;
 
@@ -17,17 +19,37 @@ public class RiakObjectTest
     @Test
     public void testEqualsWithRiakObject()
     {
-        final RiakObject riakObject1 = CreateFilledObject();
-        final RiakObject riakObject2 = CreateFilledObject();
+        final RiakObject riakObject1 = createFilledObject();
+        final RiakObject riakObject2 = createFilledObject();
 
         assertEquals(riakObject1, riakObject2);
     }
 
-    public static RiakObject CreateFilledObject()
+    @Test
+    public void checkSerialization() throws IOException, ClassNotFoundException {
+        final RiakObject ro = createFilledObject();
+
+        final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        final ObjectOutputStream out = new ObjectOutputStream(bos);
+
+        out.writeObject(ro);
+        out.close();
+
+        final ByteArrayInputStream bis = new ByteArrayInputStream(bos.toByteArray());
+        final ObjectInputStream in = new ObjectInputStream(bis);
+
+        final RiakObject ro2 = (RiakObject) in.readObject();
+        assertEquals(ro, ro2);
+    }
+
+    public static RiakObject createFilledObject()
     {
         final RiakObject result = new RiakObject();
         result.setValue(BinaryValue.create(new byte[] {'O', '_', 'o'}));
         result.getIndexes().getIndex(StringBinIndex.named("foo")).add("bar");
+        result.getIndexes().getIndex(LongIntIndex.named("foo-long")).add(2l);
+        result.getIndexes().getIndex(BigIntIndex.named("foo-bint")).add(BigInteger.ONE);
+        result.getIndexes().getIndex(RawIndex.named("foo-raw", IndexType.BUCKET)).add(BinaryValue.create("binary-value"));
         result.getLinks().addLink(new RiakLink("bucket", "linkkey", "linktag"));
         result.getUserMeta().put("foo", "bar");
         result.setVTag("vtag");


### PR DESCRIPTION
## Description
The RiakObject as well as all it's attributes were marked as Serializable and serialVersionUIDs were added accordingly.

## Related Issue
<!--- This project only accepts pull requests related to open github issues or internal JIRA tickets -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue/ticket here: -->

## Motivation and Context
In Spark Connector project there is a need  to use RiakObject as a default mapped type for the Riak KV RDD.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Additional test case has been added in the scope of this PR.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Javadoc comments for any new public classes, interfaces, etc.
- [ ] A basho_docs PR for new or changed features (basho/basho_docs#???)

Pull requests that are small and limited in scope are most welcome.